### PR TITLE
Remove cidfile annotation from remote

### DIFF
--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -683,10 +683,6 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.Sysctl = sysmap
 	}
 
-	if c.CIDFile != "" {
-		s.Annotations[define.InspectAnnotationCIDFile] = c.CIDFile
-	}
-
 	for _, opt := range c.SecurityOpt {
 		// Docker deprecated the ":" syntax but still supports it,
 		// so we need to as well


### PR DESCRIPTION
Cidfile location should not be passed over on a remote connection. This way you will not mess the host configuraion on container removal.

Resolves: https://github.com/containers/podman/issues/21974

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
