### PR TITLE
test/e2e: on test failures dump server stack strace

### DIFF
--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -103,7 +103,11 @@ func (p *PodmanTestIntegration) StartRemoteService() {
 }
 
 func (p *PodmanTestIntegration) StopRemoteService() {
-	if err := p.RemoteSession.Signal(syscall.SIGTERM); err != nil {
+	p.stopRemoteService(syscall.SIGTERM)
+}
+
+func (p *PodmanTestIntegration) stopRemoteService(signal syscall.Signal) {
+	if err := p.RemoteSession.Signal(signal); err != nil {
 		GinkgoWriter.Printf("unable to clean up service %d, %v\n", p.RemoteSession.Pid, err)
 	}
 	if _, err := p.RemoteSession.Wait(); err != nil {

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -73,6 +74,8 @@ func (p *PodmanTestIntegration) RestoreArtifact(image string) error {
 }
 
 func (p *PodmanTestIntegration) StopRemoteService() {}
+
+func (p *PodmanTestIntegration) stopRemoteService(signal syscall.Signal) {}
 
 // We don't support running API service when local
 func (p *PodmanTestIntegration) StartRemoteService() {


### PR DESCRIPTION
To debug #22246, not sure if this will work. We likely kill the client before which means the connection is likely closed and we do not see the hang or whatever happens.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
