### PR TITLE
machine: Add -all-providers flag to machine list

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -7,15 +7,18 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/containers/common/pkg/completion"
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/report"
 	"github.com/containers/podman/v5/cmd/podman/common"
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/cmd/podman/validate"
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/containers/podman/v5/pkg/machine"
+	provider2 "github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/podman/v5/pkg/machine/shim"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/docker/go-units"
@@ -24,11 +27,12 @@ import (
 
 var (
 	lsCmd = &cobra.Command{
-		Use:               "list [options]",
-		Aliases:           []string{"ls"},
-		Short:             "List machines",
-		Long:              "List managed virtual machines.",
-		PersistentPreRunE: machinePreRunE,
+		Use:     "list [options]",
+		Aliases: []string{"ls"},
+		Short:   "List machines",
+		Long:    "List managed virtual machines.",
+		// do not use machinePreRunE, as that pre-sets the provider
+		PersistentPreRunE: rootlessOnly,
 		RunE:              list,
 		Args:              validate.NoArgs,
 		ValidArgsFunction: completion.AutocompleteNone,
@@ -40,9 +44,10 @@ var (
 )
 
 type listFlagType struct {
-	format    string
-	noHeading bool
-	quiet     bool
+	format       string
+	noHeading    bool
+	quiet        bool
+	allProviders bool
 }
 
 func init() {
@@ -57,6 +62,7 @@ func init() {
 	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.ListReporter{}))
 	flags.BoolVarP(&listFlag.noHeading, "noheading", "n", false, "Do not print headers")
 	flags.BoolVarP(&listFlag.quiet, "quiet", "q", false, "Show only machine names")
+	flags.BoolVar(&listFlag.allProviders, "all-providers", false, "Show machines from all providers")
 }
 
 func list(cmd *cobra.Command, args []string) error {
@@ -64,8 +70,18 @@ func list(cmd *cobra.Command, args []string) error {
 		opts machine.ListOptions
 		err  error
 	)
+	var providers []vmconfigs.VMProvider
+	if listFlag.allProviders {
+		providers = provider2.GetAll()
+	} else {
+		provider, err = provider2.Get()
+		if err != nil {
+			return err
+		}
+		providers = []vmconfigs.VMProvider{provider}
+	}
 
-	listResponse, err := shim.List([]vmconfigs.VMProvider{provider}, opts)
+	listResponse, err := shim.List(providers, opts)
 	if err != nil {
 		return err
 	}
@@ -79,12 +95,8 @@ func list(cmd *cobra.Command, args []string) error {
 		return listResponse[i].Running
 	})
 
-	defaultCon := ""
-	con, err := registry.PodmanConfig().ContainersConfDefaultsRO.GetConnection("", true)
-	if err == nil {
-		// ignore the error here we only want to know if we have a default connection to show it in list
-		defaultCon = con.Name
-	}
+	// ignore the error here we only want to know if we have a default connection to show it in list
+	defaultCon, _ := registry.PodmanConfig().ContainersConfDefaultsRO.GetConnection("", true)
 
 	if report.IsJSON(listFlag.format) {
 		machineReporter := toMachineFormat(listResponse, defaultCon)
@@ -152,11 +164,16 @@ func streamName(imageStream string) string {
 	return imageStream
 }
 
-func toMachineFormat(vms []*machine.ListResponse, defaultCon string) []*entities.ListReporter {
+func toMachineFormat(vms []*machine.ListResponse, defaultCon *config.Connection) []*entities.ListReporter {
 	machineResponses := make([]*entities.ListReporter, 0, len(vms))
 	for _, vm := range vms {
+		isDefault := false
+		// check port, in case we somehow have machines with the same name in different providers
+		if defaultCon != nil {
+			isDefault = vm.Name == defaultCon.Name && strings.Contains(defaultCon.URI, strconv.Itoa((vm.Port)))
+		}
 		response := new(entities.ListReporter)
-		response.Default = vm.Name == defaultCon
+		response.Default = isDefault
 		response.Name = vm.Name
 		response.Running = vm.Running
 		response.LastUp = strTime(vm.LastUp)
@@ -177,11 +194,16 @@ func toMachineFormat(vms []*machine.ListResponse, defaultCon string) []*entities
 	return machineResponses
 }
 
-func toHumanFormat(vms []*machine.ListResponse, defaultCon string) []*entities.ListReporter {
+func toHumanFormat(vms []*machine.ListResponse, defaultCon *config.Connection) []*entities.ListReporter {
 	humanResponses := make([]*entities.ListReporter, 0, len(vms))
 	for _, vm := range vms {
 		response := new(entities.ListReporter)
-		if vm.Name == defaultCon {
+		isDefault := false
+		// check port, in case we somehow have machines with the same name in different providers
+		if defaultCon != nil {
+			isDefault = vm.Name == defaultCon.Name && strings.Contains(defaultCon.URI, strconv.Itoa((vm.Port)))
+		}
+		if isDefault {
 			response.Name = vm.Name + "*"
 			response.Default = true
 		} else {

--- a/docs/source/markdown/podman-machine-list.1.md.in
+++ b/docs/source/markdown/podman-machine-list.1.md.in
@@ -26,6 +26,10 @@ environment variable while the machines are running can lead to unexpected behav
 
 ## OPTIONS
 
+#### **--all-providers**
+
+Show machines from all providers
+
 #### **--format**=*format*
 
 Change the default output format.  This can be of a supported type like 'json'

--- a/pkg/machine/e2e/config_darwin_test.go
+++ b/pkg/machine/e2e/config_darwin_test.go
@@ -1,3 +1,14 @@
 package e2e_test
 
+import "github.com/containers/podman/v5/pkg/machine/define"
+
 const podmanBinary = "../../../bin/darwin/podman"
+
+func getOtherProvider() string {
+	if isVmtype(define.AppleHvVirt) {
+		return "libkrun"
+	} else if isVmtype(define.LibKrun) {
+		return "applehv"
+	}
+	return ""
+}

--- a/pkg/machine/e2e/config_linux_test.go
+++ b/pkg/machine/e2e/config_linux_test.go
@@ -1,3 +1,7 @@
 package e2e_test
 
 const podmanBinary = "../../../bin/podman-remote"
+
+func getOtherProvider() string {
+	return ""
+}

--- a/pkg/machine/e2e/config_list_test.go
+++ b/pkg/machine/e2e/config_list_test.go
@@ -7,9 +7,10 @@ type listMachine struct {
 		-q, --quiet           Show only machine names
 	*/
 
-	format    string
-	noHeading bool
-	quiet     bool
+	format       string
+	noHeading    bool
+	quiet        bool
+	allProviders bool
 
 	cmd []string
 }
@@ -25,6 +26,10 @@ func (i *listMachine) buildCmd(m *machineTestBuilder) []string {
 	if i.quiet {
 		cmd = append(cmd, "--quiet")
 	}
+	if i.allProviders {
+		cmd = append(cmd, "--all-providers")
+	}
+
 	i.cmd = cmd
 	return cmd
 }
@@ -41,5 +46,10 @@ func (i *listMachine) withQuiet() *listMachine {
 
 func (i *listMachine) withFormat(format string) *listMachine {
 	i.format = format
+	return i
+}
+
+func (i *listMachine) withAllProviders() *listMachine {
+	i.allProviders = true
 	return i
 }

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/containers/podman/v5/pkg/machine/define"
 )
 
 const podmanBinary = "../../../bin/windows/podman.exe"
@@ -22,4 +24,13 @@ func pgrep(n string) (string, error) {
 		return "", fmt.Errorf("no task found")
 	}
 	return strOut, nil
+}
+
+func getOtherProvider() string {
+	if isVmtype(define.WSLVirt) {
+		return "hyperv"
+	} else if isVmtype(define.HyperVVirt) {
+		return "wsl"
+	}
+	return ""
 }

--- a/pkg/machine/provider/platform.go
+++ b/pkg/machine/provider/platform.go
@@ -1,71 +1,20 @@
-//go:build !windows && !darwin
-
 package provider
 
 import (
-	"errors"
-	"fmt"
-	"io/fs"
-	"os"
-
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v5/pkg/machine/define"
-	"github.com/containers/podman/v5/pkg/machine/qemu"
-	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
-	"github.com/sirupsen/logrus"
 )
 
-func Get() (vmconfigs.VMProvider, error) {
-	cfg, err := config.Default()
-	if err != nil {
-		return nil, err
-	}
-	provider := cfg.Machine.Provider
-	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
-		provider = providerOverride
-	}
-	resolvedVMType, err := define.ParseVMType(provider, define.QemuVirt)
-	if err != nil {
-		return nil, err
-	}
-
-	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
-	switch resolvedVMType {
-	case define.QemuVirt:
-		return qemu.NewStubber()
-	default:
-		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
-	}
-}
-
-func GetAll(_ bool) ([]vmconfigs.VMProvider, error) {
-	return []vmconfigs.VMProvider{new(qemu.QEMUStubber)}, nil
-}
-
-// SupportedProviders returns the providers that are supported on the host operating system
-func SupportedProviders() []define.VMType {
-	return []define.VMType{define.QemuVirt}
-}
-
-// InstalledProviders returns the supported providers that are installed on the host
 func InstalledProviders() ([]define.VMType, error) {
-	cfg, err := config.Default()
-	if err != nil {
-		return nil, err
+	installedTypes := []define.VMType{}
+	providers := GetAll()
+	for _, p := range providers {
+		installed, err := IsInstalled(p.VMType())
+		if err != nil {
+			return nil, err
+		}
+		if installed {
+			installedTypes = append(installedTypes, p.VMType())
+		}
 	}
-	_, err = cfg.FindHelperBinary(qemu.QemuCommand, true)
-	if errors.Is(err, fs.ErrNotExist) {
-		return []define.VMType{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return []define.VMType{define.QemuVirt}, nil
-}
-
-// HasPermsForProvider returns whether the host operating system has the proper permissions to use the given provider
-func HasPermsForProvider(provider define.VMType) bool {
-	// there are no permissions required for QEMU
-	return provider == define.QemuVirt
+	return installedTypes, nil
 }

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -42,11 +42,11 @@ func Get() (vmconfigs.VMProvider, error) {
 	}
 }
 
-func GetAll(_ bool) ([]vmconfigs.VMProvider, error) {
+func GetAll() []vmconfigs.VMProvider {
 	return []vmconfigs.VMProvider{
 		new(applehv.AppleHVStubber),
 		new(libkrun.LibKrunStubber),
-	}, nil
+	}
 }
 
 // SupportedProviders returns the providers that are supported on the host operating system
@@ -58,27 +58,23 @@ func SupportedProviders() []define.VMType {
 	return supported
 }
 
-// InstalledProviders returns the supported providers that are installed on the host
-func InstalledProviders() ([]define.VMType, error) {
-	installed := []define.VMType{}
-
-	appleHvInstalled, err := appleHvInstalled()
-	if err != nil {
-		return nil, err
+func IsInstalled(provider define.VMType) (bool, error) {
+	switch provider {
+	case define.AppleHvVirt:
+		ahv, err := appleHvInstalled()
+		if err != nil {
+			return false, err
+		}
+		return ahv, nil
+	case define.LibKrun:
+		lkr, err := libKrunInstalled()
+		if err != nil {
+			return false, err
+		}
+		return lkr, nil
+	default:
+		return false, nil
 	}
-	if appleHvInstalled {
-		installed = append(installed, define.AppleHvVirt)
-	}
-
-	libKrunInstalled, err := libKrunInstalled()
-	if err != nil {
-		return nil, err
-	}
-	if libKrunInstalled {
-		installed = append(installed, define.LibKrun)
-	}
-
-	return installed, nil
 }
 
 func appleHvInstalled() (bool, error) {

--- a/pkg/machine/provider/platform_unix.go
+++ b/pkg/machine/provider/platform_unix.go
@@ -1,17 +1,17 @@
+//go:build !windows && !darwin
+
 package provider
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
-
-	"github.com/containers/libhvee/pkg/hypervctl"
-	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
-	"github.com/containers/podman/v5/pkg/machine/wsl"
-	"github.com/containers/podman/v5/pkg/machine/wsl/wutil"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v5/pkg/machine/define"
-	"github.com/containers/podman/v5/pkg/machine/hyperv"
+	"github.com/containers/podman/v5/pkg/machine/qemu"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,50 +24,47 @@ func Get() (vmconfigs.VMProvider, error) {
 	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
 		provider = providerOverride
 	}
-	resolvedVMType, err := define.ParseVMType(provider, define.WSLVirt)
+	resolvedVMType, err := define.ParseVMType(provider, define.QemuVirt)
 	if err != nil {
 		return nil, err
 	}
 
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
-	case define.WSLVirt:
-		return new(wsl.WSLStubber), nil
-	case define.HyperVVirt:
-		if !wsl.HasAdminRights() {
-			return nil, fmt.Errorf("hyperv machines require admin authority")
-		}
-		return new(hyperv.HyperVStubber), nil
+	case define.QemuVirt:
+		return qemu.NewStubber()
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}
 }
 
 func GetAll() []vmconfigs.VMProvider {
-	return []vmconfigs.VMProvider{
-		new(wsl.WSLStubber),
-		new(hyperv.HyperVStubber),
-	}
+	return []vmconfigs.VMProvider{new(qemu.QEMUStubber)}
 }
 
 // SupportedProviders returns the providers that are supported on the host operating system
 func SupportedProviders() []define.VMType {
-	return []define.VMType{define.HyperVVirt, define.WSLVirt}
+	return []define.VMType{define.QemuVirt}
 }
 
 func IsInstalled(provider define.VMType) (bool, error) {
 	switch provider {
-	case define.WSLVirt:
-		return wutil.IsWSLInstalled(), nil
-	case define.HyperVVirt:
-		service, err := hypervctl.NewLocalHyperVService()
-		if err == nil {
-			return true, nil
+	case define.QemuVirt:
+		cfg, err := config.Default()
+		if err != nil {
+			return false, err
 		}
-		if service != nil {
-			defer service.Close()
+		if cfg == nil {
+			return false, fmt.Errorf("error fetching getting default config")
 		}
-		return false, nil
+		_, err = cfg.FindHelperBinary(qemu.QemuCommand, true)
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return true, nil
 	default:
 		return false, nil
 	}
@@ -75,14 +72,6 @@ func IsInstalled(provider define.VMType) (bool, error) {
 
 // HasPermsForProvider returns whether the host operating system has the proper permissions to use the given provider
 func HasPermsForProvider(provider define.VMType) bool {
-	switch provider {
-	case define.QemuVirt:
-		fallthrough
-	case define.AppleHvVirt:
-		return false
-	case define.HyperVVirt:
-		return wsl.HasAdminRights()
-	}
-
-	return true
+	// there are no permissions required for QEMU
+	return provider == define.QemuVirt
 }


### PR DESCRIPTION
Podman machine list now supports a new option, --all-providers, which lists all machines from all providers.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman machine list now supports a new option, --all-providers, which lists all machines from all providers.
```
