### PR TITLE
images/create: handle tag/digest if Tag specified

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -45,6 +45,11 @@ func mergeNameAndTagOrDigest(name, tagOrDigest string) string {
 		// We have a digest, so let's change the separator.
 		separator = "@"
 	}
+	// if both name and tagOrDigest are defined we try to use the tagOrDigest image part and override the tag/digest
+	if len(name) > 0 && strings.Contains(name, separator) {
+		index := strings.LastIndex(name, separator)
+		return fmt.Sprintf("%s%s%s", name[:index], separator, tagOrDigest)
+	}
 	return fmt.Sprintf("%s%s%s", name, separator, tagOrDigest)
 }
 

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -112,6 +112,9 @@ fi
 t POST "/images/create?fromImage=quay.io/idonotexist/idonotexist:dummy" $expect_code \
   .message="$expect_msg"
 
+# compat api pull image with fromImage and Tag
+t GET "/images/create?fromImage=alpine:latest&tag=latest" 200 .error~null .status~".*Download complete.*"
+
 # Export an image on the local
 t GET libpod/images/nonesuch/get 404
 t GET libpod/images/$iid/get?format=foo 500


### PR DESCRIPTION
Podman handles /images/create better when fromImage and Tag are specified. Now the tag/digest value provided in Tag will replace the one in fromImage

Fixes: https://github.com/containers/podman/issues/23938

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
