### PR TITLE
WIP TarCompression

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1780,6 +1780,12 @@ func AutocompleteCompressionFormat(cmd *cobra.Command, args []string, toComplete
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
+// AutocompleteTarCompressionFormat - Autocomplete tar-compression-format type options.
+func AutocompleteTarCompressionFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	types := []string{"gzip", "zstd"}
+	return types, cobra.ShellCompDirectiveNoFileComp
+}
+
 // AutocompleteClone - Autocomplete container and image names
 func AutocompleteClone(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if !validCurrentCmdLine(cmd, args, toComplete) {

--- a/cmd/podman/common/tarcompress.go
+++ b/cmd/podman/common/tarcompress.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v5/cmd/podman/registry"
+	"github.com/spf13/cobra"
+)
+
+func DefineTarCompressFlags(cmd *cobra.Command, tarCompFormat *string) {
+	flags := cmd.Flags()
+
+	tarCompFormatStr := "tar-compression-format"
+	flags.StringVar(tarCompFormat, tarCompFormatStr, tarCompressionFormat(), "compression format to use for archives")
+	_ = cmd.RegisterFlagCompletionFunc(tarCompFormatStr, AutocompleteTarCompressionFormat)
+
+	tarCompLevel := "tar-compression-level"
+	flags.Int(tarCompLevel, tarCompressionLevel(), "compression level to use for archives")
+	_ = cmd.RegisterFlagCompletionFunc(tarCompLevel, completion.AutocompleteNone)
+
+}
+
+func tarCompressionFormat() string {
+	if registry.IsRemote() {
+		return ""
+	}
+
+	return podmanConfig.ContainersConfDefaultsRO.Engine.TarCompressionFormat
+}
+
+func tarCompressionLevel() int {
+	if registry.IsRemote() || podmanConfig.ContainersConfDefaultsRO.Engine.TarCompressionLevel == nil {
+		return 0
+	}
+
+	return *podmanConfig.ContainersConfDefaultsRO.Engine.TarCompressionLevel
+}

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -80,6 +80,8 @@ func init() {
 func pushFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
+	common.DefineTarCompressFlags(cmd, &pushOptions.TarCompressionFormat)
+
 	// For now default All flag to true, for pushing of manifest lists
 	pushOptions.All = true
 	authfileFlagName := "authfile"
@@ -247,6 +249,14 @@ func imagePush(cmd *cobra.Command, args []string) error {
 			// is selected then defaults to `true`.
 			pushOptions.ForceCompressionFormat = true
 		}
+	}
+
+	if cmd.Flags().Changed("tar-compression-level") {
+		val, err := cmd.Flags().GetInt("tar-compression-level")
+		if err != nil {
+			return err
+		}
+		pushOptions.TarCompressionLevel = &val
 	}
 
 	// Let's do all the remaining Yoga in the API to prevent us from scattering

--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -82,6 +82,8 @@ func init() {
 func saveFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
+	common.DefineTarCompressFlags(cmd, &saveOpts.TarCompressionFormat)
+
 	flags.BoolVar(&saveOpts.Compress, "compress", false, "Compress tarball image layers when saving to a directory using the 'dir' transport. (default is same compression type as source)")
 
 	flags.BoolVar(&saveOpts.OciAcceptUncompressedLayers, "uncompressed", false, "Accept uncompressed layers when copying OCI images")
@@ -110,6 +112,13 @@ func save(cmd *cobra.Command, args []string) (finalErr error) {
 	)
 	if cmd.Flag("compress").Changed && saveOpts.Format != define.V2s2ManifestDir {
 		return errors.New("--compress can only be set when --format is 'docker-dir'")
+	}
+	if cmd.Flags().Changed("tar-compression-level") {
+		val, err := cmd.Flags().GetInt("tar-compression-level")
+		if err != nil {
+			return err
+		}
+		saveOpts.TarCompressionLevel = &val
 	}
 	if len(saveOpts.Output) == 0 {
 		saveOpts.Quiet = true

--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/common/pkg/ssh"
 	"github.com/containers/podman/v5/cmd/podman/common"
 	"github.com/containers/podman/v5/cmd/podman/registry"
+	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/spf13/cobra"
 )
 
@@ -73,7 +74,14 @@ func scp(cmd *cobra.Command, args []string) (finalErr error) {
 	}
 
 	sshEngine := ssh.DefineMode(sshType)
-	err = registry.ImageEngine().Scp(registry.Context(), src, dst, parentFlags, quiet, sshEngine)
+	err = registry.ImageEngine().Scp(registry.Context(), src, dst, entities.ImageScpBaseOptions{
+		ImageExecuteTransferOptions: entities.ImageExecuteTransferOptions{
+			ParentFlags:          parentFlags,
+			Quiet:                quiet,
+			SshMode:              sshEngine,
+			TarCompressionFormat: "gzip",
+		},
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -83,6 +83,8 @@ type ExportOptions struct {
 	Format *string
 	// Accept uncompressed layers when copying OCI images.
 	OciAcceptUncompressedLayers *bool
+	TarCompressionFormat        *string
+	TarCompressionLevel         *int
 }
 
 // PruneOptions are optional options for pruning images
@@ -151,7 +153,9 @@ type PushOptions struct {
 	// algorithms are not reused.
 	ForceCompressionFormat *bool
 	// Add existing instances with requested compression algorithms to manifest list
-	AddCompression []string
+	AddCompression       []string
+	TarCompressionFormat *string
+	TarCompressionLevel  *int
 	// Manifest type of the pushed image
 	Format *string
 	// Password for authenticating against the registry.
@@ -245,6 +249,8 @@ type ExistsOptions struct {
 }
 
 type ScpOptions struct {
-	Quiet       *bool
-	Destination *string
+	TarCompressionFormat *string
+	TarCompressionLevel  *int
+	Quiet                *bool
+	Destination          *string
 }

--- a/pkg/bindings/images/types_export_options.go
+++ b/pkg/bindings/images/types_export_options.go
@@ -61,3 +61,33 @@ func (o *ExportOptions) GetOciAcceptUncompressedLayers() bool {
 	}
 	return *o.OciAcceptUncompressedLayers
 }
+
+// WithTarCompressionFormat set field TarCompressionFormat to given value
+func (o *ExportOptions) WithTarCompressionFormat(value string) *ExportOptions {
+	o.TarCompressionFormat = &value
+	return o
+}
+
+// GetTarCompressionFormat returns value of field TarCompressionFormat
+func (o *ExportOptions) GetTarCompressionFormat() string {
+	if o.TarCompressionFormat == nil {
+		var z string
+		return z
+	}
+	return *o.TarCompressionFormat
+}
+
+// WithTarCompressionLevel set field TarCompressionLevel to given value
+func (o *ExportOptions) WithTarCompressionLevel(value int) *ExportOptions {
+	o.TarCompressionLevel = &value
+	return o
+}
+
+// GetTarCompressionLevel returns value of field TarCompressionLevel
+func (o *ExportOptions) GetTarCompressionLevel() int {
+	if o.TarCompressionLevel == nil {
+		var z int
+		return z
+	}
+	return *o.TarCompressionLevel
+}

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -123,6 +123,36 @@ func (o *PushOptions) GetAddCompression() []string {
 	return o.AddCompression
 }
 
+// WithTarCompressionFormat set field TarCompressionFormat to given value
+func (o *PushOptions) WithTarCompressionFormat(value string) *PushOptions {
+	o.TarCompressionFormat = &value
+	return o
+}
+
+// GetTarCompressionFormat returns value of field TarCompressionFormat
+func (o *PushOptions) GetTarCompressionFormat() string {
+	if o.TarCompressionFormat == nil {
+		var z string
+		return z
+	}
+	return *o.TarCompressionFormat
+}
+
+// WithTarCompressionLevel set field TarCompressionLevel to given value
+func (o *PushOptions) WithTarCompressionLevel(value int) *PushOptions {
+	o.TarCompressionLevel = &value
+	return o
+}
+
+// GetTarCompressionLevel returns value of field TarCompressionLevel
+func (o *PushOptions) GetTarCompressionLevel() int {
+	if o.TarCompressionLevel == nil {
+		var z int
+		return z
+	}
+	return *o.TarCompressionLevel
+}
+
 // WithFormat set field Format to given value
 func (o *PushOptions) WithFormat(value string) *PushOptions {
 	o.Format = &value

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/common/libimage/define"
 	"github.com/containers/common/pkg/config"
-	"github.com/containers/common/pkg/ssh"
 	"github.com/containers/podman/v5/pkg/domain/entities/reports"
 )
 
@@ -24,7 +23,7 @@ type ImageEngine interface { //nolint:interfacebloat
 	Push(ctx context.Context, source string, destination string, opts ImagePushOptions) (*ImagePushReport, error)
 	Remove(ctx context.Context, images []string, opts ImageRemoveOptions) (*ImageRemoveReport, []error)
 	Save(ctx context.Context, nameOrID string, tags []string, options ImageSaveOptions) error
-	Scp(ctx context.Context, src, dst string, parentFlags []string, quiet bool, sshMode ssh.EngineMode) error
+	Scp(ctx context.Context, src, dst string, opts ImageScpBaseOptions) error
 	Search(ctx context.Context, term string, opts ImageSearchOptions) ([]ImageSearchReport, error)
 	SetTrust(ctx context.Context, args []string, options SetTrustOptions) error
 	ShowTrust(ctx context.Context, args []string, options ShowTrustOptions) (*ShowTrustReport, error)

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/ssh"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/signature/signer"
 	"github.com/containers/image/v5/types"
@@ -199,6 +200,8 @@ type ImagePushOptions struct {
 	// CompressionFormat is used exclusively, and blobs of other compression
 	// algorithms are not reused.
 	ForceCompressionFormat bool
+	TarCompressionFormat   string
+	TarCompressionLevel    *int
 }
 
 // ImagePushReport is the response from pushing an image.
@@ -301,8 +304,10 @@ type ImageSaveOptions struct {
 	// Output - write image to the specified path.
 	Output string
 	// Quiet - suppress output when copying images
-	Quiet           bool
-	SignaturePolicy string
+	Quiet                bool
+	SignaturePolicy      string
+	TarCompressionFormat string
+	TarCompressionLevel  *int
 }
 
 // ImageScpOptions provide options for securely copying images to and from a remote host
@@ -329,6 +334,25 @@ type ImageScpConnections struct {
 	URI []*url.URL
 	// Identities contains ssh identity keys to be used by the client
 	Identities []string
+}
+
+type ImageScpBaseOptions struct {
+	ImageExecuteTransferOptions
+}
+
+type ImageExecuteTransferOptions struct {
+	ParentFlags          []string
+	Quiet                bool
+	SshMode              ssh.EngineMode
+	TarCompressionFormat string
+	TarCompressionLevel  *int
+}
+
+type ImageExecuteTransferReport struct {
+	LoadReport  *ImageLoadReport
+	Source      *ImageScpOptions
+	Dest        *ImageScpOptions
+	ParentFlags []string
 }
 
 // ImageTreeOptions provides options for ImageEngine.Tree()

--- a/vendor/github.com/containers/common/libimage/save.go
+++ b/vendor/github.com/containers/common/libimage/save.go
@@ -189,7 +189,11 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 		}
 	}
 
-	writer, err := dockerArchiveTransport.NewWriter(r.systemContextCopy(), path)
+	sysContextWithOpts, err := r.newScWithCopyOpts(&options.CopyOptions)
+	if err != nil {
+		return err
+	}
+	writer, err := dockerArchiveTransport.NewWriter(sysContextWithOpts, path)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -542,6 +542,12 @@ type EngineConfig struct {
 	// CompressionLevel is the compression level used to compress image layers.
 	CompressionLevel *int `toml:"compression_level,omitempty"`
 
+	// TarCompressionFormat is the compression format used to compress archives.
+	TarCompressionFormat string `toml:"tar_compression_format,omitempty"`
+
+	// TarCompressionLevel is the compression level used to compress archives.
+	TarCompressionLevel *int `toml:"tar_compression_level,omitempty"`
+
 	// PodmanshTimeout is the number of seconds to wait for podmansh logins.
 	// In other words, the timeout for the `podmansh` container to be in running
 	// state.

--- a/vendor/github.com/containers/image/v5/pkg/compression/compression.go
+++ b/vendor/github.com/containers/image/v5/pkg/compression/compression.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/image/v5/pkg/compression/internal"
 	"github.com/containers/image/v5/pkg/compression/types"
+	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chunked/compressor"
 	"github.com/klauspost/pgzip"
 	"github.com/sirupsen/logrus"
@@ -162,4 +163,25 @@ func AutoDecompress(stream io.Reader) (io.ReadCloser, bool, error) {
 		res = io.NopCloser(stream)
 	}
 	return res, decompressor != nil, nil
+}
+
+// ToArchiveCompression takes an Algorithm
+// and returns the corresponding archive.Compression from c/storage.
+// Returns error if no match is found.
+func ToArchiveCompression(algo *Algorithm) (archive.Compression, error) {
+	if algo == nil {
+		return archive.Uncompressed, nil
+	}
+	switch n := algo.Name(); n {
+	case types.GzipAlgorithmName:
+		return archive.Gzip, nil
+	case types.Bzip2AlgorithmName:
+		return archive.Bzip2, nil
+	case types.XzAlgorithmName:
+		return archive.Xz, nil
+	case types.ZstdAlgorithmName:
+		return archive.Zstd, nil
+	default:
+		return 0, fmt.Errorf("no c/storage compression found for algorithm %q", n)
+	}
 }

--- a/vendor/github.com/containers/image/v5/types/types.go
+++ b/vendor/github.com/containers/image/v5/types/types.go
@@ -674,7 +674,9 @@ type SystemContext struct {
 	// CompressionFormat is the format to use for the compression of the blobs
 	CompressionFormat *compression.Algorithm
 	// CompressionLevel specifies what compression level is used
-	CompressionLevel *int
+	CompressionLevel     *int
+	TarCompressionFormat *compression.Algorithm
+	TarCompressionLevel  *int
 }
 
 // ProgressEvent is the type of events a progress reader can produce


### PR DESCRIPTION
This is a WIP commit to add tar compression options to containers lib. Will need to be split into several commits across multiple repos.

This is a proposed feature for #23192

I wanted to share this current WIP though to get some feedback, before I went about the process of splitting this into different PRs and making / fixing tests.

The overall idea is to add two new options, `TarCompressionFormat / --tar-compression-format` and `TarCompressionLevel / --tar-compression-level` to be used throughout podman's `push`, `save`, and `scp` subcommands. For `push` and `save`, the options are passed to specific transport implementations, in this case the oci-archive and docker-archive transports. They both have different implementation details for enabling compression of the resulting tar file.

For the `scp` subcommand, it is already using `save` under the hood, so to enable compression we would just pass the new options to the `save` subcommand. This would only work with remote transfers, but this is fine because I don't think(?) there should be a need for compression on local transfers. 

I took care to ensure that everything is backwards compatible, however the only one place that couldn't be backwards compatible would be the [change to the `ImageEngine` interface's `Scp` function.](https://github.com/zackattackz/podman/blob/76c21e8159978c73e9e2466820bf1d4abc211184/pkg/domain/entities/engine_image.go#L26)

This change would be needed to allow for specifying compression options to `Scp`. But, more broadly, adding an options type here would be great for any future changes to SCP options to allow backwards compatibility.

Other than that, I would think everything else is compatible (could be wrong though).

Another change worth noting is in [common/libimage/save.go](https://github.com/zackattackz/podman/blob/76c21e8159978c73e9e2466820bf1d4abc211184/vendor/github.com/containers/common/libimage/save.go) and [common/libimage/copier.go](https://github.com/zackattackz/podman/blob/76c21e8159978c73e9e2466820bf1d4abc211184/vendor/github.com/containers/common/libimage/copier.go).

In `save.go`, it was necessary to use the system context AFTER the copy options are set into it. This would normally happen if you used `NewCopier().systemContext`, but in this case a writer is created before the copier is created, and it doesn't get any of the copy options passed into it. So to solve this I just made new functions in copier.go `Runtime.newScWithCopyOpts` and `ScWithCopyOpts`. These methods just abstract away the part of overwriting system context opts with copy opts when `NewCopier` is called

Also worth noting is the potential confusion between these new options and the existing `Compression` related options. The existing options were designed explicitly for compression layers in docker dir transport, not with any other kind of compression, so I thought it made more sense and was safer to create new options than to repurpose the exiting ones.

As far as what needs to be done: Of course tests will need to be done. Also, the `scp` command right now just has a forced compression of gzip, but I need to make the command line options for it (they already are working for `save` and `push` though). There probably should be checks added to ensure the options are used correctly. For instance, the `--compress` flag should probably never be allowed to be used with `--tar-compression-format`. Finally, a `--tar-compress` bool flag could be added to just enable gzip format by default. 

I appreciate any feedback! I will move forward with trying to separate this into multiple PRs soon.