### PR TITLE
WIP: podman exec: correctly support detaching (part 2)

### DIFF
--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -172,7 +171,7 @@ func exec(cmd *cobra.Command, args []string) error {
 		streams.OutputStream = os.Stdout
 		streams.ErrorStream = os.Stderr
 		if execOpts.Interactive {
-			streams.InputStream = bufio.NewReader(os.Stdin)
+			streams.InputStream = os.Stdin
 			streams.AttachInput = true
 		}
 		streams.AttachOutput = true

--- a/go.mod
+++ b/go.mod
@@ -231,3 +231,5 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
+
+replace github.com/containers/common => github.com/Luap99/common v0.20.3-0.20250123195450-f0fd031b07f8

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/Luap99/common v0.20.3-0.20250123195450-f0fd031b07f8 h1:Uh/dSC6OGikcFGsvbzy0a3ma9NISRLGL2KW8XwRknuY=
+github.com/Luap99/common v0.20.3-0.20250123195450-f0fd031b07f8/go.mod h1:mWhwkYaWR5bXeOwq3ruzdmH9gaT2pex00C6pd4VXuvM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=
@@ -78,8 +80,6 @@ github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
 github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33 h1:Ih6KuyByK7ZGGzkS0M5rVBPLWIyeDvdL5klhsKBo8vA=
 github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33/go.mod h1:RxIuKhwTpRl3ma4d4BF6QzSSeg9zNNvo/xhYJOKeDQs=
-github.com/containers/common v0.61.1-0.20250120135258-06628cb958e9 h1:aiup0MIiAi2Xnv15vApAPqgy4/49ZGkYOpevDgGHfxg=
-github.com/containers/common v0.61.1-0.20250120135258-06628cb958e9/go.mod h1:1S+/XhAEOwMGePCUqoYYh1iZo9fU1IpuIwVzCCIdBVU=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.8.2 h1:uQMBCCHlIIj62fPjbvgm6AL5EzsP6TP5eviByOJEsOg=

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -284,11 +284,7 @@ func (c *Container) ExecStart(sessionID string) error {
 	return c.save()
 }
 
-func (c *Container) ExecStartAndAttach(sessionID string, streams *define.AttachStreams, newSize *resize.TerminalSize) error {
-	return c.execStartAndAttach(sessionID, streams, newSize, false)
-}
-
-// ExecStartAndAttach starts and attaches to an exec session in a container.
+// execStartAndAttach starts and attaches to an exec session in a container.
 // newSize resizes the tty to this size before the process is started, must be nil if the exec session has no tty
 func (c *Container) execStartAndAttach(sessionID string, streams *define.AttachStreams, newSize *resize.TerminalSize, isHealthcheck bool) error {
 	if !c.batched {

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -1,7 +1,6 @@
 package define
 
 import (
-	"bufio"
 	"io"
 
 	"github.com/containers/common/libnetwork/types"
@@ -55,7 +54,7 @@ type AttachStreams struct {
 	// ErrorStream will be attached to container's STDERR
 	ErrorStream io.Writer
 	// InputStream will be attached to container's STDIN
-	InputStream *bufio.Reader
+	InputStream io.Reader
 	// AttachOutput is whether to attach to STDOUT
 	// If false, stdout will not be attached
 	AttachOutput bool

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -3,7 +3,6 @@
 package libpod
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -85,7 +84,7 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	streams := new(define.AttachStreams)
 	output := &bytes.Buffer{}
 
-	streams.InputStream = bufio.NewReader(os.Stdin)
+	streams.InputStream = os.Stdin
 	streams.OutputStream = output
 	streams.ErrorStream = output
 	streams.AttachOutput = true

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -149,7 +149,7 @@ func checkDependencyContainer(depCtr, ctr *Container) error {
 
 // hijackWriteError writes an error to a hijacked HTTP session.
 func hijackWriteError(toWrite error, cid string, terminal bool, httpBuf *bufio.ReadWriter) {
-	if toWrite != nil {
+	if toWrite != nil && !errors.Is(toWrite, define.ErrDetach) {
 		errString := []byte(fmt.Sprintf("Error: %v\n", toWrite))
 		if !terminal {
 			// We need a header.

--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -200,7 +200,7 @@ func ExecStartHandler(w http.ResponseWriter, r *http.Request) {
 		t := r.Context().Value(api.IdleTrackerKey).(*idle.Tracker)
 		defer t.Close()
 
-		if err != nil {
+		if err != nil && !errors.Is(err, define.ErrDetach) {
 			// Cannot report error to client as a 500 as the Upgrade set status to 101
 			logErr(err)
 		}

--- a/pkg/domain/infra/abi/terminal/terminal_common.go
+++ b/pkg/domain/infra/abi/terminal/terminal_common.go
@@ -3,7 +3,6 @@
 package terminal
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -65,7 +64,7 @@ func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, 
 	streams := new(define.AttachStreams)
 	streams.OutputStream = stdout
 	streams.ErrorStream = stderr
-	streams.InputStream = bufio.NewReader(stdin)
+	streams.InputStream = stdin
 	streams.AttachOutput = true
 	streams.AttachError = true
 	streams.AttachInput = true

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -1,6 +1,7 @@
 package tunnel
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -610,7 +611,7 @@ func (ic *ContainerEngine) ContainerExec(ctx context.Context, nameOrID string, o
 	startAndAttachOptions := new(containers.ExecStartAndAttachOptions)
 	startAndAttachOptions.WithOutputStream(streams.OutputStream).WithErrorStream(streams.ErrorStream)
 	if streams.InputStream != nil {
-		startAndAttachOptions.WithInputStream(*streams.InputStream)
+		startAndAttachOptions.WithInputStream(*bufio.NewReader(streams.InputStream))
 	}
 	startAndAttachOptions.WithAttachError(streams.AttachError).WithAttachOutput(streams.AttachOutput).WithAttachInput(streams.AttachInput)
 	if err := containers.ExecStartAndAttach(ic.ClientCtx, sessionID, startAndAttachOptions); err != nil {

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -84,7 +84,9 @@ load helpers
     dd if=/dev/urandom of=$bigfile bs=1024 count=1500
     expect=$(sha512sum $bigfile | awk '{print $1}')
     # Transfer it to container, via exec, make sure correct #bytes are sent
-    run_podman exec -i $cid dd of=/tmp/bigfile bs=512 <$bigfile
+    # Note using --detach-keys "" to disable the detach sequence, otherwise
+    # the byte sequence may randomly appear in the stream and could cause flakes.
+    run_podman exec -i --detach-keys "" $cid dd of=/tmp/bigfile bs=512 <$bigfile
     is "${lines[0]}" "3000+0 records in"  "dd: number of records in"
     is "${lines[1]}" "3000+0 records out" "dd: number of records out"
     # Verify sha. '% *' strips off the path, keeping only the SHA

--- a/vendor/github.com/containers/common/pkg/detach/copy.go
+++ b/vendor/github.com/containers/common/pkg/detach/copy.go
@@ -1,6 +1,7 @@
 package detach
 
 import (
+	"bytes"
 	"errors"
 	"io"
 )
@@ -11,47 +12,84 @@ var ErrDetach = errors.New("detached from container")
 
 // Copy is similar to io.Copy but support a detach key sequence to break out.
 func Copy(dst io.Writer, src io.Reader, keys []byte) (written int64, err error) {
+	// if no key sequence we can use the fast std lib implementation
+	if len(keys) == 0 {
+		return io.Copy(dst, src)
+	}
 	buf := make([]byte, 32*1024)
+
+	// When key 1 is on one read and the key2 on the second read we cannot do a normal full match in the buffer.
+	// Thus we use this index to store where in keys we matched on the end of the previous buffer.
+	keySequenceIndex := 0
+outer:
 	for {
 		nr, er := src.Read(buf)
-		if nr > 0 {
-			preservBuf := []byte{}
-			for i, key := range keys {
-				preservBuf = append(preservBuf, buf[0:nr]...)
-				if nr != 1 || buf[0] != key {
-					break
+		// Do not check error right away, i.e. if we have EOF this code still must flush the last partial key sequence first.
+		// Previous key index, if the last buffer ended with the start of the key sequence
+		// then we must continue looking here.
+		if keySequenceIndex > 0 {
+			bytesToCheck := min(nr, len(keys)-keySequenceIndex)
+			if bytes.Equal(buf[:bytesToCheck], keys[keySequenceIndex:keySequenceIndex+bytesToCheck]) {
+				if keySequenceIndex+bytesToCheck == len(keys) {
+					// we are done
+					return written, ErrDetach
 				}
-				if i == len(keys)-1 {
-					return 0, ErrDetach
-				}
-				nr, er = src.Read(buf)
+				// still not at the end of the sequence, must continue to read
+				keySequenceIndex += bytesToCheck
+				continue outer
 			}
-			var nw int
-			var ew error
-			if len(preservBuf) > 0 {
-				nw, ew = dst.Write(preservBuf)
-				nr = len(preservBuf)
-			} else {
-				nw, ew = dst.Write(buf[0:nr])
-			}
-			if nw > 0 {
-				written += int64(nw)
-			}
+			// No match, write buffered keys now
+			nw, ew := dst.Write(keys[:keySequenceIndex])
 			if ew != nil {
-				err = ew
-				break
+				return written, ew
 			}
-			if nr != nw {
-				err = io.ErrShortWrite
-				break
-			}
+			written += int64(nw)
+			keySequenceIndex = 0
 		}
+
+		// Now we can handle and return the error.
 		if er != nil {
-			if er != io.EOF {
-				err = er
+			if er == io.EOF {
+				return written, nil
 			}
-			break
+			return written, err
 		}
+
+		// Check buffer from 0 to end - sequence length (after that there cannot be a full match),
+		// then walk the entire buffer and try to perform a full sequence match.
+		readMinusKeys := nr - len(keys)
+		for i := range readMinusKeys {
+			if bytes.Equal(buf[i:i+len(keys)], keys) {
+				if i > 0 {
+					nw, ew := dst.Write(buf[:i])
+					if ew != nil {
+						return written, ew
+					}
+					written += int64(nw)
+				}
+				return written, ErrDetach
+			}
+		}
+
+		// Now read the rest of the buffer to the end and perform a partial match on the sequence.
+		// Note that readMinusKeys can be < 0 on reads smaller than sequence length. Thus we must
+		// ensure it is at least 0 otherwise the index access will cause a panic.
+		for i := max(readMinusKeys, 0); i < nr; i++ {
+			if bytes.Equal(buf[i:nr], keys[:nr-i]) {
+				nw, ew := dst.Write(buf[:i])
+				if ew != nil {
+					return written, ew
+				}
+				written += int64(nw)
+				keySequenceIndex = nr - i
+				continue outer
+			}
+		}
+
+		nw, ew := dst.Write(buf[:nr])
+		if ew != nil {
+			return written, ew
+		}
+		written += int64(nw)
 	}
-	return written, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,8 +178,8 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.61.1-0.20250120135258-06628cb958e9
-## explicit; go 1.22.6
+# github.com/containers/common v0.61.1-0.20250120135258-06628cb958e9 => github.com/Luap99/common v0.20.3-0.20250123195450-f0fd031b07f8
+## explicit; go 1.22.8
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring
 github.com/containers/common/libimage
@@ -1406,3 +1406,4 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.8.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
+# github.com/containers/common => github.com/Luap99/common v0.20.3-0.20250123195450-f0fd031b07f8


### PR DESCRIPTION
podman exec support detaching early via the detach key sequence. In that
case the podman process should exit successfully but the container exec
process keeps running.

Given that I could not find any existing test for the detach key
functionality not even for exec I added some. This seems to reveal more
issues with on podman-remote, podman-remote run detach was broken which
I fixed here as well but for podman-remote exec something bigger is
needed. While I thought I fixed most problems there there was a strange
race condition which caused the process to just hang.

Thus I skipped the remote exec test for now and filled https://github.com/containers/podman/issues/25089 to track
that.

Fixes #24895

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix the detach sequence for podman exec so it cannot correctly detach without errors.
```
