### PR TITLE
document `--service-container` on podman-kube-play

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -283,6 +283,12 @@ Tears down the pods created by a previous run of `kube play` and recreates the p
 
 Directory path for seccomp profiles (default: "/var/lib/kubelet/seccomp"). (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
+#### **--service-container**
+
+Sets the default log-driver to `passthrough`.
+
+*This flags is used for systemd integration and is not meant to be used directly.*
+
 #### **--start**
 
 Start the pod after creating it, set to false to only create it.


### PR DESCRIPTION
This flag was added on Podman v4.4.0 but was not documented.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Document `--service-container` on podman-kube-play
```
