### PR TITLE
GHA: Pin Go to 1.24.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: stable
+        go-version: '1.24.2'
     - name: Set up pandoc
       run: |
           sudo apt-get install -y pandoc
@@ -109,7 +109,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: stable
+        go-version: '1.24.2'
     - name: Create Keychain
       run: |
         echo $APPLICATION_CERTIFICATE | base64 --decode -o appcert.p12
@@ -167,7 +167,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: stable
+        go-version: '1.24.2'
     - name: Set up WiX
       run: dotnet tool install --global wix
     - name: Setup Signature Tooling


### PR DESCRIPTION
There is a bug that makes building with the latest go to fail. Pin to 1.24.2 for now.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
