### PR TITLE
Trigger podman.io version bump from release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,3 +345,12 @@ jobs:
           to: Podman List <podman@lists.podman.io>
           from: ${{secrets.ACTION_MAIL_SENDER}}
           body: file://./email_body.txt
+
+  updatepodmanio:
+    name: Update podman.io
+    uses: ./.github/workflows/update-podmanio.yml
+    needs: [check, release]
+    if: needs.check.outputs.buildonly == 'false'
+    secrets: inherit
+    with:
+      version: ${{ needs.check.outputs.version }}

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -212,7 +212,7 @@ spelled with complete minutiae.
          * shasums
       1. An email should have been sent to the [podman](mailto:podman@lists.podman.io) mailing list.
          Keep an eye on it make sure the email went through to the list.
-   1. After the release action is run, an action to bump the Podman version on podman.io will run. This action will open a PR if a non-rc latest version is released. Go to the podman.io repo and merge the PR opened by this action, if needed.
+   1. The release action will also bump the Podman version on podman.io. It will open a PR if a non-rc latest version is released. Go to the [podman.io](https://github.com/containers/podman.io) repo and merge the PR opened by this action, if needed.
    1. After the tag is pushed, an action to bump to -dev will run. A PR will be opened for this bump. Merge this PR if needed.
 
 


### PR DESCRIPTION
Our release is created by a GitHub action, and GitHub prevents workflows from running on events that were caused by other workflows to prevent unlimited recursion. To get around this, use a reusable workflow to trigger the podman.io version bump from the release action.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
