### PR TITLE
libpod: Implement --log-opt label=LABEL=Value

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1169,7 +1169,7 @@ func AutocompleteLogDriver(_ *cobra.Command, _ []string, _ string) ([]string, co
 // AutocompleteLogOpt - Autocomplete log-opt options.
 // -> "path=", "tag="
 func AutocompleteLogOpt(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	logOptions := []string{"path=", "tag=", "max-size="}
+	logOptions := []string{"path=", "tag=", "max-size=", "label="}
 	if strings.HasPrefix(toComplete, "path=") {
 		return nil, cobra.ShellCompDirectiveDefault
 	}

--- a/docs/source/markdown/options/log-opt.md
+++ b/docs/source/markdown/options/log-opt.md
@@ -18,3 +18,9 @@ Set custom logging configuration. The following *name*s are supported:
     (e.g. **--log-opt tag="{{.ImageName}}"**.
 It supports the same keys as **podman inspect --format**.
 This option is currently supported only by the **journald** log driver.
+
+**label**: specify a custom log label for the container
+    (e.g. **--log-opt label="CONTAINER_IMAGE={{.ImageName}}"**.
+It supports the same keys as **podman inspect --format**.
+This option can be repeated multiple times.
+This option is currently supported only by the **journald** log driver.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -676,6 +676,11 @@ func (c *Container) LogSizeMax() int64 {
 	return c.runtime.config.Containers.LogSizeMax
 }
 
+// LogLabels returns the labels added to the container's log file
+func (c *Container) LogLabels() map[string]string {
+	return c.config.LogLabels
+}
+
 // RestartPolicy returns the container's restart policy.
 func (c *Container) RestartPolicy() string {
 	return c.config.RestartPolicy

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -369,6 +369,8 @@ type ContainerMiscConfig struct {
 	LogPath string `json:"logPath"`
 	// LogTag is the tag used for logging
 	LogTag string `json:"logTag"`
+	// LogLabels is a set of key-value pairs used to label log messages
+	LogLabels map[string]string `json:"logLabels,omitempty"`
 	// LogSize is the maximum size of the container's log file
 	LogSize int64 `json:"logSize"`
 	// LogDriver driver for logs

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -399,7 +399,7 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 	}
 	defer processFile.Close()
 
-	args, err := r.sharedConmonArgs(c, sessionID, c.execBundlePath(sessionID), c.execPidPath(sessionID), c.execLogPath(sessionID), c.execExitFileDir(sessionID), c.execPersistDir(sessionID), ociLog, define.NoLogging, c.config.LogTag)
+	args, err := r.sharedConmonArgs(c, sessionID, c.execBundlePath(sessionID), c.execPidPath(sessionID), c.execLogPath(sessionID), c.execExitFileDir(sessionID), c.execPersistDir(sessionID), ociLog, define.NoLogging, c.config.LogTag, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1046,6 +1046,19 @@ func WithLogTag(tag string) CtrCreateOption {
 	}
 }
 
+// WithLogLabels sets the labels to the log file.
+func WithLogLabels(logLabels map[string]string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.LogLabels = logLabels
+
+		return nil
+	}
+}
+
 // WithCgroupsMode disables the creation of Cgroups for the conmon process.
 func WithCgroupsMode(mode string) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -565,7 +565,9 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 		if len(s.LogConfiguration.Options) > 0 && s.LogConfiguration.Options["tag"] != "" {
 			options = append(options, libpod.WithLogTag(s.LogConfiguration.Options["tag"]))
 		}
-
+		if len(s.LogConfiguration.Labels) > 0 {
+			options = append(options, libpod.WithLogLabels(s.LogConfiguration.Labels))
+		}
 		if len(s.LogConfiguration.Driver) > 0 {
 			options = append(options, libpod.WithLogDriver(s.LogConfiguration.Driver))
 		}

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -247,6 +247,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	}
 
 	s.LogConfiguration.Options = make(map[string]string)
+	s.LogConfiguration.Labels = make(map[string]string)
 	for _, o := range opts.LogOptions {
 		opt, val, hasVal := strings.Cut(o, "=")
 		if !hasVal {
@@ -263,6 +264,12 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 				return nil, err
 			}
 			s.LogConfiguration.Size = logSize
+		case "label":
+			labelKey, labelVal, hasVal := strings.Cut(val, "=")
+			if !hasVal {
+				return nil, fmt.Errorf("invalid log label %q", o)
+			}
+			s.LogConfiguration.Labels[labelKey] = labelVal
 		default:
 			if len(val) == 0 {
 				return nil, fmt.Errorf("invalid log option: %w", define.ErrInvalidArg)

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -26,6 +26,10 @@ type LogConfig struct {
 	// Size is the maximum size of the log file
 	// Optional.
 	Size int64 `json:"size,omitempty"`
+	// A set of log labels to apply
+	// Only available if LogDriver is set to "journald".
+	// Optional
+	Labels map[string]string `json:"labels,omitempty"`
 	// A set of options to accompany the log driver.
 	// Optional.
 	Options map[string]string `json:"options,omitempty"`

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -849,6 +849,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	}
 
 	logOpts := make(map[string]string)
+	logLabels := make(map[string]string)
 	for _, o := range c.LogOptions {
 		key, val, hasVal := strings.Cut(o, "=")
 		if !hasVal {
@@ -865,6 +866,12 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 				return err
 			}
 			s.LogConfiguration.Size = logSize
+		case "label":
+			labelKey, labelVal, hasVal := strings.Cut(val, "=")
+			if !hasVal {
+				return fmt.Errorf("invalid log label %q", o)
+			}
+			logLabels[labelKey] = labelVal
 		default:
 			logOpts[key] = val
 		}
@@ -872,6 +879,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 
 	if len(s.LogConfiguration.Options) == 0 || len(c.LogOptions) != 0 {
 		s.LogConfiguration.Options = logOpts
+	}
+	if len(s.LogConfiguration.Labels) == 0 || len(c.LogOptions) != 0 {
+		s.LogConfiguration.Labels = logLabels
 	}
 	if len(s.Name) == 0 || len(c.Name) != 0 {
 		s.Name = c.Name

--- a/test/e2e/quadlet/logopt.container
+++ b/test/e2e/quadlet/logopt.container
@@ -1,9 +1,11 @@
 ## assert-podman-args "--log-opt" "path=/var/log/some-logs.json"
 ## assert-podman-args "--log-opt" "size=10mb"
 ## assert-podman-args "--log-opt" "tag="{{.ImageName}}""
+## assert-podman-args "--log-opt" "label=CONTAINER_LABEL=LabelValue"
 
 [Container]
 Image=localhost/imagename
 LogOpt=path=/var/log/some-logs.json
 LogOpt=size=10mb
 LogOpt=tag="{{.ImageName}}"
+LogOpt=label=CONTAINER_LABEL=LabelValue

--- a/test/e2e/quadlet/logopt.kube
+++ b/test/e2e/quadlet/logopt.kube
@@ -1,9 +1,11 @@
 ## assert-podman-args "--log-opt" "path=/var/log/some-logs.json"
 ## assert-podman-args "--log-opt" "size=10mb"
 ## assert-podman-args "--log-opt" "tag="{{.ImageName}}""
+## assert-podman-args "--log-opt" "label=CONTAINER_LABEL=LabelValue"
 
 [Kube]
 Yaml=deployment.yml
 LogOpt=path=/var/log/some-logs.json
 LogOpt=size=10mb
 LogOpt=tag="{{.ImageName}}"
+LogOpt=label=CONTAINER_LABEL=LabelValue


### PR DESCRIPTION
Currently, Compose on Podman has a significant limitation compared to Compose on Docker: there's no way to include container labels such as the Compose project name in the logs. This issue exists regardless of the underlying Compose provider.

This PR implements support for passing container labels to conmon via new `--log-label` option. The container labels are supported only on journald log driver and are exposed via `--log-opt label=KEY=VALUE` syntax. The option can be repeated multiple times to set multiple labels.

#### Does this PR introduce a user-facing change?

```release-note
The `--log-opt` option for `podman create` and `podman run` now supports the `label` option to set additional labels that are attached to the log messages when using journald driver
```
