### PR TITLE
podman search: add --show-hash to show image digest in output

### DIFF
--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -110,7 +110,7 @@ func searchFlags(cmd *cobra.Command) {
 	flags.BoolVar(&searchOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 	flags.BoolVar(&searchOptions.ListTags, "list-tags", false, "List the tags of the input registry")
 
-	//Implementation of show-hash flag
+	// Implementation of show-hash flag
 	flags.BoolVar(&searchOptions.ShowHash, "show-hash", false, "Prints the hash digest for each tag")
 
 	if !registry.IsRemote() {

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -197,6 +197,8 @@ type ImageSearchOptions struct {
 	SkipTLSVerify types.OptionalBool
 	// ListTags search the available tags of the repository
 	ListTags bool
+	// Whether the engine should fetch and include manifest digests
+	ShowHash bool
 }
 
 // ImageSearchReport is the response from searching images.

--- a/pkg/domain/entities/types/images.go
+++ b/pkg/domain/entities/types/images.go
@@ -78,6 +78,8 @@ type ImageSearchReport struct {
 	Automated string
 	// Tag is the repository tag
 	Tag string
+	//Hash
+	Hash string
 }
 
 // ShowTrustReport describes the results of show trust

--- a/pkg/domain/entities/types/images.go
+++ b/pkg/domain/entities/types/images.go
@@ -78,7 +78,7 @@ type ImageSearchReport struct {
 	Automated string
 	// Tag is the repository tag
 	Tag string
-	//Hash
+	// Hash
 	Hash string
 }
 


### PR DESCRIPTION
Adds an additional feature allowing users to optionally check hashes of the tagged images, used along with --list-tags.

Signed-off-by: Aakarsh Maurya <mauryaaakarsh11@gmail.com> 

#### Which issues does the PR fixes?
Fixes #26054 

#### What type of PR is this?
/kind feature

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

```release-note
podman search: Added `--show-hash` flag to display image manifest digests alongside tags.

When enabled, it displays the manifest digest (hash) alongside each image tag. This helps users gain better visibility into what tags point to which content, especially in cases where multiple tags reference the same image hash, a common scenario in container registries.

This feature improves clarity when comparing image tags and was suggested in the related issue.

```

#### Usage 
``` 
podman search --list-tags --show-hash <registry>

```
<img width="1010" height="109" alt="image" src="https://github.com/user-attachments/assets/036a0829-38ab-4201-9f57-05a67a83da6f" />


#### Additional notes
* Currently focusing on the use case, the flag is compatible only when used with --list-tags.
* JSON formatting is currently unimplemented as i wish to discuss more with the maintainers on how JSON-structs must be implemented.
* I have done common benchmark tests.
* I am currently interested in further working over the features along with the related documentation of the added feature.
