### PR TITLE
feat: Pass through debug logging level to vfkit 

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -208,6 +208,8 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 		}
 		cmd.Args = append(cmd.Args, debugDevArgs...)
 		cmd.Args = append(cmd.Args, "--gui") // add command line switch to pop the gui open
+
+		cmd.Args = append(cmd.Args, "--log-level", "debug") // Pass through debug logging if enabled
 	}
 
 	endpointArgs, err := GetVfKitEndpointCMDArgs(endpoint)

--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -141,9 +141,7 @@ func GenerateSystemDFilesForVirtiofsMounts(mounts []machine.VirtIoFs) ([]ignitio
 
 // StartGenericAppleVM is wrapped by apple provider methods and starts the vm
 func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootloader vfConfig.Bootloader, endpoint string) (func() error, func() error, error) {
-	var (
-		ignitionSocket *define.VMFile
-	)
+	var ignitionSocket *define.VMFile
 
 	// Add networking
 	netDevice, err := vfConfig.VirtioNetNew(applehvMACAddress)
@@ -199,9 +197,17 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 	if err != nil {
 		return nil, nil, err
 	}
+
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+
+		debugDevArgs, err := GetDebugDevicesCMDArgs()
+		if err != nil {
+			return nil, nil, err
+		}
+		cmd.Args = append(cmd.Args, debugDevArgs...)
+		cmd.Args = append(cmd.Args, "--gui") // add command line switch to pop the gui open
 	}
 
 	endpointArgs, err := GetVfKitEndpointCMDArgs(endpoint)
@@ -209,20 +215,11 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 		return nil, nil, err
 	}
 
+	cmd.Args = append(cmd.Args, endpointArgs...)
+
 	machineDataDir, err := mc.DataDir()
 	if err != nil {
 		return nil, nil, err
-	}
-
-	cmd.Args = append(cmd.Args, endpointArgs...)
-
-	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		debugDevArgs, err := GetDebugDevicesCMDArgs()
-		if err != nil {
-			return nil, nil, err
-		}
-		cmd.Args = append(cmd.Args, debugDevArgs...)
-		cmd.Args = append(cmd.Args, "--gui") // add command line switch to pop the gui open
 	}
 
 	if mc.LibKrunHypervisor != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When starting the Podman machine with `--log-level=debug` the underlying call to vfkit will also inherit the debug log level 
```
