### PR TITLE
healthcheck for non-systemd podman

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -164,6 +164,8 @@ type ContainerState struct {
 	PID int `json:"pid,omitempty"`
 	// ConmonPID is the PID of the container's conmon
 	ConmonPID int `json:"conmonPid,omitempty"`
+	// HealthCheckStopFile is the path to a file that signals the healthcheck timer to stop (nosystemd only)
+	HealthCheckStopFile string `json:"healthCheckStopFile,omitempty"`
 	// ExecSessions contains all exec sessions that are associated with this
 	// container.
 	ExecSessions map[string]*ExecSession `json:"newExecSessions,omitempty"`

--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -18,6 +18,14 @@ import (
 	systemdCommon "go.podman.io/common/pkg/systemd"
 )
 
+// ReattachHealthCheckTimers reattaches healthcheck timers for running containers after podman restart
+// This is a no-op for systemd builds since systemd manages healthcheck timers independently
+func ReattachHealthCheckTimers(containers []*Container) {
+	// Systemd healthchecks are managed by systemd and don't need reattachment
+	// The timers persist across podman restarts because they're systemd units
+	logrus.Debugf("Skipping healthcheck reattachment for systemd build - timers are managed by systemd")
+}
+
 // createTimer systemd timers for healthchecks of a container
 func (c *Container) createTimer(interval string, isStartup bool) error {
 	if c.disableHealthCheckSystemd(isStartup) {

--- a/libpod/healthcheck_nosystemd_linux.go
+++ b/libpod/healthcheck_nosystemd_linux.go
@@ -4,20 +4,172 @@ package libpod
 
 import (
 	"context"
+	"fmt"
+	"time"
+
+	"github.com/containers/podman/v5/libpod/define"
+	"github.com/sirupsen/logrus"
 )
 
-// createTimer systemd timers for healthchecks of a container
+// healthcheckTimer manages the background goroutine for healthchecks
+type healthcheckTimer struct {
+	container *Container
+	interval  time.Duration
+	ctx       context.Context
+	cancel    context.CancelFunc
+	done      chan struct{}
+}
+
+// Global map to track active timers (in a real implementation, this would be part of the runtime)
+var activeTimers = make(map[string]*healthcheckTimer)
+
+// disableHealthCheckSystemd returns true if healthcheck should be disabled
+// For non-systemd builds, we only disable if interval is 0
+func (c *Container) disableHealthCheckSystemd(isStartup bool) bool {
+	if isStartup {
+		if c.config.StartupHealthCheckConfig != nil && c.config.StartupHealthCheckConfig.Interval == 0 {
+			return true
+		}
+	}
+	if c.config.HealthCheckConfig != nil && c.config.HealthCheckConfig.Interval == 0 {
+		return true
+	}
+	return false
+}
+
+// createTimer creates a goroutine-based timer for healthchecks of a container
 func (c *Container) createTimer(interval string, isStartup bool) error {
+	if c.disableHealthCheckSystemd(isStartup) {
+		return nil
+	}
+
+	// Parse the interval duration
+	duration, err := time.ParseDuration(interval)
+	if err != nil {
+		return err
+	}
+
+	// Stop any existing timer
+	if c.state.HCUnitName != "" {
+		c.stopHealthCheckTimer()
+	}
+
+	// Create context for cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Create timer struct
+	timer := &healthcheckTimer{
+		container: c,
+		interval:  duration,
+		ctx:       ctx,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+	}
+
+	// Store timer reference globally and in container state
+	activeTimers[c.ID()] = timer
+	c.state.HCUnitName = "goroutine-timer"
+
+	if err := c.save(); err != nil {
+		cancel()
+		delete(activeTimers, c.ID())
+		return fmt.Errorf("saving container %s healthcheck timer: %w", c.ID(), err)
+	}
+
+	// Start the background goroutine
+	go timer.run()
+
+	logrus.Debugf("Created goroutine-based healthcheck timer for container %s with interval %s", c.ID(), interval)
 	return nil
 }
 
-// startTimer starts a systemd timer for the healthchecks
+// startTimer starts the goroutine-based timer for healthchecks
 func (c *Container) startTimer(isStartup bool) error {
+	// Timer is already started in createTimer, nothing to do
 	return nil
 }
 
-// removeTransientFiles removes the systemd timer and unit files
-// for the container
+// removeTransientFiles stops the goroutine-based timer
 func (c *Container) removeTransientFiles(ctx context.Context, isStartup bool, unitName string) error {
-	return nil
+	return c.stopHealthCheckTimer()
+}
+
+// stopHealthCheckTimer stops the background healthcheck goroutine
+func (c *Container) stopHealthCheckTimer() error {
+	timer, exists := activeTimers[c.ID()]
+	if !exists {
+		logrus.Debugf("No active healthcheck timer found for container %s", c.ID())
+		return nil
+	}
+
+	logrus.Debugf("Stopping healthcheck timer for container %s", c.ID())
+
+	// Cancel the context to stop the goroutine
+	timer.cancel()
+
+	// Wait for the goroutine to finish (with timeout)
+	select {
+	case <-timer.done:
+		logrus.Debugf("Healthcheck timer for container %s stopped gracefully", c.ID())
+	case <-time.After(5 * time.Second):
+		logrus.Warnf("Healthcheck timer for container %s did not stop within timeout", c.ID())
+	}
+
+	// Remove from active timers
+	delete(activeTimers, c.ID())
+
+	// Clear the unit name
+	c.state.HCUnitName = ""
+	return c.save()
+}
+
+// run executes the healthcheck in a loop with the specified interval
+func (t *healthcheckTimer) run() {
+	defer close(t.done)
+
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	logrus.Debugf("Starting healthcheck timer for container %s with interval %s", t.container.ID(), t.interval)
+
+	for {
+		select {
+		case <-t.ctx.Done():
+			logrus.Debugf("Healthcheck timer for container %s stopped", t.container.ID())
+			return
+		case <-ticker.C:
+			// Run the healthcheck
+			if err := t.runHealthCheck(); err != nil {
+				logrus.Errorf("Healthcheck failed for container %s: %v", t.container.ID(), err)
+			}
+		}
+	}
+}
+
+// runHealthCheck executes a single healthcheck
+func (t *healthcheckTimer) runHealthCheck() error {
+	// Check if container is still running (without holding lock to avoid deadlock)
+	state, err := t.container.State()
+	if err != nil {
+		return err
+	}
+
+	if state != define.ContainerStateRunning {
+		logrus.Debugf("Container %s is not running (state: %v), skipping healthcheck", t.container.ID(), state)
+		return nil
+	}
+
+	// Get healthcheck config (without holding lock)
+	healthConfig := t.container.HealthCheckConfig()
+	if healthConfig == nil {
+		logrus.Debugf("No healthcheck config found for container %s, skipping healthcheck", t.container.ID())
+		return nil
+	}
+
+	// Run the healthcheck - let runHealthCheck handle its own locking internally
+	ctx, cancel := context.WithTimeout(context.Background(), healthConfig.Timeout)
+	defer cancel()
+
+	_, _, err = t.container.runHealthCheck(ctx, false)
+	return err
 }

--- a/libpod/healthcheck_unsupported.go
+++ b/libpod/healthcheck_unsupported.go
@@ -6,6 +6,12 @@ import (
 	"context"
 )
 
+// ReattachHealthCheckTimers reattaches healthcheck timers for running containers after podman restart
+// This is a no-op for unsupported platforms since healthchecks are not supported
+func ReattachHealthCheckTimers(containers []*Container) {
+	// Healthchecks are not supported on this platform
+}
+
 // createTimer systemd timers for healthchecks of a container
 func (c *Container) createTimer(interval string, isStartup bool) error {
 	return nil

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -647,6 +647,16 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 
 	runtime.startWorker()
 
+	// Reattach healthcheck timers for running containers after podman restart
+	// This is only needed for the nosystemd build where healthchecks are managed by goroutines
+	// Systemd healthchecks are managed by systemd and don't need reattachment
+	ctrs, err := runtime.state.AllContainers(true)
+	if err != nil {
+		logrus.Errorf("Failed to get containers for healthcheck reattachment: %v", err)
+	} else {
+		ReattachHealthCheckTimers(ctrs)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
On a non-systemd host, healthchecks are not processed. This is about the implementation for the non-systemd. Instead of using timers with systemd, it starts a pure goroutine that do the healthchecks.

Why this is needed: when running podman with exposing the unix socket like `podman system service  unix:///tmp/podman.sock`, and then using docker compose, the healthchecks are not run, so if there are dependencies in the docker compose (like depends_on), it will hang forever

#### Does this PR introduce a user-facing change?

```release-note
Added healthcheck for non-systemd hosts

```
