### PR TITLE
Support spec.replicas > 1 in podman play kube — allow multiple Deployment replicas

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -190,6 +190,9 @@ func playFlags(cmd *cobra.Command) {
 	noPodPrefix := "no-pod-prefix"
 	flags.BoolVar(&playOptions.NoPodPrefix, noPodPrefix, false, "Do not prefix container name with pod name")
 
+	multiplePods := "multiple-pods"
+	flags.BoolVar(&playOptions.MultiplePods, multiplePods, false, "Allow creation of multiple pod replicas from a Deployment")
+
 	if !registry.IsRemote() {
 		certDirFlagName := "cert-dir"
 		flags.StringVar(&playOptions.CertDir, certDirFlagName, "", "`Pathname` of a directory containing TLS certificates and keys")

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -245,6 +245,10 @@ Set logging driver for all created containers.
 Assign a static mac address to the pod. This option can be specified several times when kube play creates more than one pod.
 Note: When joining multiple networks use the **--network name:mac=\<mac\>** syntax.
 
+#### **--multiple-pods**
+
+Only one Pod replica is created by default, despite the desired number of Pods in the Kubernetes Deployment resource. This setting overrides the default behavior, allowing the desired number of Pods to be created.
+
 @@option network
 
 When no network option is specified and *host* network mode is not configured in the YAML file, a new network stack is created and pods are attached to it making possible pod to pod communication.
@@ -265,6 +269,8 @@ Define or override a port definition in the YAML file.
 
 The lists of ports in the YAML file and the command line are merged. Matching is done by using the **containerPort** field.
 If **containerPort** exists in both the YAML file and the option, the latter takes precedence.
+
+In case this options is used with **--multiple-pods** option then number of published ports should be equal to the number of replicas in container spec, e.g. Deployment.spec.replicas is 3, then **--publish** is set to "8080:80,8081:80,8082:80"
 
 #### **--publish-all**
 

--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -124,6 +124,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		Wait             bool              `schema:"wait"`
 		Build            bool              `schema:"build"`
 		NoPodPrefix      bool              `schema:"noPodPrefix"`
+		MultiplePods     bool              `schema:"multiplePods"`
 	}{
 		TLSVerify: true,
 		Start:     true,
@@ -208,6 +209,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		Wait:               query.Wait,
 		ContextDir:         contextDirectory,
 		NoPodPrefix:        query.NoPodPrefix,
+		MultiplePods:       query.MultiplePods,
 	}
 	if _, found := r.URL.Query()["build"]; found {
 		options.Build = types.NewOptionalBool(query.Build)

--- a/pkg/api/server/register_kube.go
+++ b/pkg/api/server/register_kube.go
@@ -73,6 +73,10 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    items:
 	//         type: string
 	//  - in: query
+	//    name: multiplepods
+	//    type: boolean
+	//    description: Allow creation of multiple pod replicas from a Deployment
+	//  - in: query
 	//    name: network
 	//    type: array
 	//    description: USe the network mode or specify an array of networks.

--- a/pkg/bindings/kube/types.go
+++ b/pkg/bindings/kube/types.go
@@ -67,6 +67,8 @@ type PlayOptions struct {
 	Wait             *bool
 	ServiceContainer *bool
 	NoPodPrefix      *bool
+	// MultiplePods allows creating of multiple Pods
+	MultiplePods *bool
 }
 
 // ApplyOptions are optional options for applying kube YAML files to a k8s cluster

--- a/pkg/bindings/kube/types_play_options.go
+++ b/pkg/bindings/kube/types_play_options.go
@@ -437,3 +437,18 @@ func (o *PlayOptions) GetNoPodPrefix() bool {
 	}
 	return *o.NoPodPrefix
 }
+
+// WithMultiplePods set field MultiplePods to given value
+func (o *PlayOptions) WithMultiplePods(value bool) *PlayOptions {
+	o.MultiplePods = &value
+	return o
+}
+
+// GetMultiplePods returns value of field MultiplePods
+func (o *PlayOptions) GetMultiplePods() bool {
+	if o.MultiplePods == nil {
+		var z bool
+		return z
+	}
+	return *o.MultiplePods
+}

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -120,6 +120,8 @@ type PlayKubeOptions struct {
 	NoPodPrefix bool
 	// Validate controls how unrecognized YAML fields and kinds are handled.
 	Validate KubeValidateMode
+	// MultiplePods allows creating of multiple Pods
+	MultiplePods bool
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -277,6 +277,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 	ipIndex := 0
 
 	var configMaps []v1.ConfigMap
+	var numReplicas int32
 
 	ranContainers := false
 	// set the ranContainers bool to true if at least one container was successfully started.
@@ -413,16 +414,48 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 			}
 			report.ValidationWarnings = append(report.ValidationWarnings, warnings...)
 
-			r, proxies, err := ic.playKubeDeployment(ctx, &deploymentYAML, options, &ipIndex, configMaps, serviceContainer)
-			if err != nil {
-				return nil, err
+			numReplicas = 1
+			if deploymentYAML.Spec.Replicas != nil {
+				numReplicas = *deploymentYAML.Spec.Replicas
 			}
-			notifyProxies = append(notifyProxies, proxies...)
 
-			report.Pods = append(report.Pods, r.Pods...)
-			report.ValidationWarnings = append(report.ValidationWarnings, r.ValidationWarnings...)
+			if numReplicas > 1 && options.MultiplePods {
+				if len(options.PublishPorts) > 0 && len(options.PublishPorts) != int(numReplicas) {
+					return nil, fmt.Errorf("number of Pod replicas aren't equal to the number of published ports: %d replicas, %d published ports", numReplicas, len(options.PublishPorts))
+				}
+
+				for i := range numReplicas {
+					replicaOpts := options
+					if len(replicaOpts.PublishPorts) != 0 {
+						replicaOpts.PublishPorts = options.PublishPorts[i : i+1]
+					}
+					podName := fmt.Sprintf("%s-pod-%d", deploymentYAML.ObjectMeta.Name, i)
+					r, proxies, err := ic.playKubeDeployment(ctx, &deploymentYAML, replicaOpts, &ipIndex, configMaps, serviceContainer, podName)
+					if err != nil {
+						return nil, err
+					}
+					notifyProxies = append(notifyProxies, proxies...)
+
+					report.Pods = append(report.Pods, r.Pods...)
+					report.ValidationWarnings = append(report.ValidationWarnings, r.ValidationWarnings...)
+					setRanContainers(r)
+				}
+			} else {
+				if numReplicas > 1 {
+					logrus.Warnf("Limiting replica count to 1, use `--multiple-pods` to enable more than one replica")
+				}
+				podName := fmt.Sprintf("%s-pod", deploymentYAML.ObjectMeta.Name)
+				r, proxies, err := ic.playKubeDeployment(ctx, &deploymentYAML, options, &ipIndex, configMaps, serviceContainer, podName)
+				if err != nil {
+					return nil, err
+				}
+				notifyProxies = append(notifyProxies, proxies...)
+
+				report.Pods = append(report.Pods, r.Pods...)
+				report.ValidationWarnings = append(report.ValidationWarnings, r.ValidationWarnings...)
+				setRanContainers(r)
+			}
 			validKinds++
-			setRanContainers(r)
 		case "Job":
 			var jobYAML v1.Job
 
@@ -625,11 +658,10 @@ func (ic *ContainerEngine) playKubeDaemonSet(ctx context.Context, daemonSetYAML 
 	return &report, proxies, nil
 }
 
-func (ic *ContainerEngine) playKubeDeployment(ctx context.Context, deploymentYAML *v1apps.Deployment, options entities.PlayKubeOptions, ipIndex *int, configMaps []v1.ConfigMap, serviceContainer *libpod.Container) (*entities.PlayKubeReport, []*notifyproxy.NotifyProxy, error) {
+func (ic *ContainerEngine) playKubeDeployment(ctx context.Context, deploymentYAML *v1apps.Deployment, options entities.PlayKubeOptions, ipIndex *int, configMaps []v1.ConfigMap, serviceContainer *libpod.Container, podName string) (*entities.PlayKubeReport, []*notifyproxy.NotifyProxy, error) {
 	var (
 		deploymentName string
 		podSpec        v1.PodTemplateSpec
-		numReplicas    int32
 		report         entities.PlayKubeReport
 	)
 
@@ -637,16 +669,9 @@ func (ic *ContainerEngine) playKubeDeployment(ctx context.Context, deploymentYAM
 	if deploymentName == "" {
 		return nil, nil, errors.New("deployment does not have a name")
 	}
-	numReplicas = 1
-	if deploymentYAML.Spec.Replicas != nil {
-		numReplicas = *deploymentYAML.Spec.Replicas
-	}
-	if numReplicas > 1 {
-		logrus.Warnf("Limiting replica count to 1, more than one replica is not supported by Podman")
-	}
+
 	podSpec = deploymentYAML.Spec.Template
 
-	podName := fmt.Sprintf("%s-pod", deploymentName)
 	podReport, proxies, err := ic.playKubePod(ctx, podName, &podSpec, options, ipIndex, deploymentYAML.Annotations, configMaps, serviceContainer)
 	if err != nil {
 		return nil, nil, fmt.Errorf("encountered while bringing up pod %s: %w", podName, err)
@@ -1826,8 +1851,17 @@ func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, opt
 			if deploymentYAML.Spec.Replicas != nil {
 				numReplicas = *deploymentYAML.Spec.Replicas
 			}
+			// Remove multiple Pod replicas from a Deployment resource
 			if numReplicas > 1 {
-				logrus.Warnf("Limiting replica count to 1, more than one replica is not supported by Podman")
+				for n := range numReplicas {
+					podName := fmt.Sprintf("%s-pod-%d", deploymentName, n)
+					podNames = append(podNames, podName)
+				}
+				// add a single Pod name in case a user wants to remove a single pod
+				// by applying Deployment resource file with the field "replicas" value > 1
+				podName := fmt.Sprintf("%s-pod", deploymentName)
+				podNames = append(podNames, podName)
+				break
 			}
 			podName := fmt.Sprintf("%s-pod", deploymentName)
 			podNames = append(podNames, podName)

--- a/pkg/domain/infra/tunnel/kube.go
+++ b/pkg/domain/infra/tunnel/kube.go
@@ -76,6 +76,7 @@ func (ic *ContainerEngine) PlayKube(_ context.Context, body io.Reader, opts enti
 	options.WithPublishAllPorts(opts.PublishAllPorts)
 	options.WithNoTrunc(opts.UseLongAnnotations)
 	options.WithNoPodPrefix(opts.NoPodPrefix)
+	options.WithMultiplePods(opts.MultiplePods)
 	return play.KubeWithBody(ic.ClientCtx, body, options)
 }
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -525,6 +525,28 @@ spec:
           periodSeconds: 1
 `
 
+var replicasPodYaml = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: replicas-pods-test
+  labels:
+    app: testimage
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: testimage
+  template:
+    metadata:
+      labels:
+        app: testimage
+    spec:
+      containers:
+      - name: testimage
+        image: ` + NGINX_IMAGE + `
+`
+
 var selinuxLabelPodYaml = `
 apiVersion: v1
 kind: Pod
@@ -3961,7 +3983,7 @@ spec:
 		if IsRemote() {
 			Expect(kube.ErrorToString()).To(BeEmpty())
 		} else {
-			Expect(kube.ErrorToString()).To(ContainSubstring("Limiting replica count to 1, more than one replica is not supported by Podman"))
+			Expect(kube.ErrorToString()).To(ContainSubstring("Limiting replica count to 1, use `--multiple-pods` to enable more than one replica"))
 		}
 
 		podName := getPodNameInDeployment(deployment)
@@ -4018,7 +4040,7 @@ spec:
 		if IsRemote() {
 			Expect(kube.ErrorToString()).To(BeEmpty())
 		} else {
-			Expect(kube.ErrorToString()).To(ContainSubstring("Limiting replica count to 1, more than one replica is not supported by Podman"))
+			Expect(kube.ErrorToString()).To(ContainSubstring("Limiting replica count to 1, use `--multiple-pods` to enable more than one replica"))
 		}
 
 		podName := getPodNameInDeployment(deployment)
@@ -4523,7 +4545,7 @@ spec:
 		if IsRemote() {
 			Expect(kube.ErrorToString()).To(BeEmpty())
 		} else {
-			Expect(kube.ErrorToString()).To(ContainSubstring("Limiting replica count to 1, more than one replica is not supported by Podman"))
+			Expect(kube.ErrorToString()).To(ContainSubstring("Limiting replica count to 1, use `--multiple-pods` to enable more than one replica"))
 		}
 
 		correctLabels := expectedLabelKey + ":" + expectedLabelValue
@@ -4564,7 +4586,7 @@ spec:
 		if IsRemote() {
 			Expect(kube.ErrorToString()).To(BeEmpty())
 		} else {
-			Expect(kube.ErrorToString()).To(ContainSubstring("Limiting replica count to 1, more than one replica is not supported by Podman"))
+			Expect(kube.ErrorToString()).To(ContainSubstring("Limiting replica count to 1, use `--multiple-pods` to enable more than one replica"))
 		}
 
 		pod := getPodNameInDeployment(deployment)
@@ -6184,7 +6206,7 @@ spec:
 
 		// warnings are only propagated to local clients
 		if !IsRemote() {
-			Expect(kube.ErrorToString()).Should(ContainSubstring("Limiting replica count to 1, more than one replica is not supported by Podman"))
+			Expect(kube.ErrorToString()).Should(ContainSubstring("Limiting replica count to 1, use `--multiple-pods` to enable more than one replica"))
 		}
 
 		Expect(strings.Count(kube.OutputToString(), "Pod:")).To(Equal(1))
@@ -6891,5 +6913,67 @@ spec:
 		podmanTest.PodmanExitCleanly("kube", "play", "--no-pod-prefix", kubeYaml)
 		inspect := podmanTest.PodmanExitCleanly("inspect", "simpleWithoutPodPrefix")
 		Expect(inspect.InspectContainerToJSON()[0].Name).Should(Equal("simpleWithoutPodPrefix"))
+	})
+
+	It("multiple Pod replicas", func() {
+		err := writeYaml(replicasPodYaml, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		podmanTest.PodmanExitCleanly("kube", "play", "-q", "--multiple-pods", "--publish", fmt.Sprintf("%d:%d,%d:%d", GetPort(), 80, GetPort(), 80), kubeYaml)
+
+		podsCount := podmanTest.PodmanExitCleanly("pod", "ps", "-n")
+		Expect(podsCount.OutputToStringArray()).To(HaveLen(2))
+	})
+
+	It("multiple Pod replicas down", func() {
+		err := writeYaml(replicasPodYaml, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		podmanTest.PodmanExitCleanly("kube", "play", "-q", "--multiple-pods", "--publish", fmt.Sprintf("%d:%d,%d:%d", GetPort(), 80, GetPort(), 80), kubeYaml)
+
+		podsCount := podmanTest.PodmanExitCleanly("pod", "ps", "-n")
+		Expect(podsCount.OutputToStringArray()).To(HaveLen(2))
+
+		podmanTest.PodmanExitCleanly("kube", "down", kubeYaml)
+
+		podsCount = podmanTest.PodmanExitCleanly("pod", "ps", "-n")
+		Expect(podsCount.OutputToStringArray()).To(BeEmpty())
+	})
+
+	It("single Pod down for multiple replicas in YAML", func() {
+		err := writeYaml(replicasPodYaml, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		podmanTest.PodmanExitCleanly("kube", "--log-level=error", "play", "-q", kubeYaml)
+
+		podsCount := podmanTest.PodmanExitCleanly("pod", "ps", "-n")
+		Expect(podsCount.OutputToStringArray()).To(HaveLen(1))
+
+		podmanTest.PodmanExitCleanly("kube", "down", kubeYaml)
+
+		podsCount = podmanTest.PodmanExitCleanly("pod", "ps", "-n")
+		Expect(podsCount.OutputToStringArray()).To(BeEmpty())
+	})
+
+	It("multiple Pods without publish ports", func() {
+		err := writeYaml(replicasPodYaml, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		podmanTest.PodmanExitCleanly("kube", "play", "-q", "--multiple-pods", kubeYaml)
+
+		podsCount := podmanTest.PodmanExitCleanly("pod", "ps", "-n")
+		Expect(podsCount.OutputToStringArray()).To(HaveLen(2))
+
+		portsCount := podmanTest.PodmanExitCleanly("port", "-a")
+		Expect(portsCount.OutputToStringArray()).To(BeEmpty())
+	})
+
+	It("Pods count is unequal to publish ports", func() {
+		err := writeYaml(replicasPodYaml, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		session := podmanTest.Podman([]string{"kube", "play", "--multiple-pods", "--publish", fmt.Sprintf("%d:%d", GetPort(), 80), kubeYaml})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError(125, `number of Pod replicas aren't equal to the number of published ports: 2 replicas, 1 published ports`))
 	})
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
Hello,
I decided to introduce this PR as **draft one**, because the issue doesn't have solid decision on publish port behavior.
The code introduces a new option  `--multiple-pods`, which allows users to create multiple Pods (Deployment.spec.replicas > 1) and it changes `--publish` option behavior as user has to set

So, the idea is to use as many publishing ports as many Replicas is created, therefore it is user's responsibility on which ports are used on host side; no need to take random ports as those port might be blocked on firewalls, etc.
For example, if Replicas = 2 then it is necessary to use option`--publish` with  `8080:80,8081:80` value.


Once final decision on this solution is approved then I will update Docs and crate tests
#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a new `--multiple-pods` option to allow creating multiple Pods.
```
Fixes: #26769 