### PR TITLE
[Artifacts] Podman artifacts should support emitting events

### DIFF
--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -83,6 +83,13 @@ The *secret* type reports the following statuses:
  * create
  * remove
 
+ The *artifact* type reports the following statuses:
+ * add
+ * extract
+ * pull
+ * push
+ * remove
+
 #### Verbose Create Events
 
 Setting `events_container_create_inspect_data=true` in containers.conf(5) instructs Podman to create more verbose container-create events which include a JSON payload with detailed information about the containers.  The JSON payload is identical to the one of podman-container-inspect(1).  The associated field in journald is named `PODMAN_CONTAINER_INSPECT_DATA`.

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -202,7 +202,7 @@ func (r *Runtime) NewSecretEvent(status events.Status, secretID string) {
 }
 
 // NewArtifactEvent creates a new event for a libpod artifact
-func (r *Runtime) NewArtifactEvent(status events.Status, name, digest string, attr map[string]string){
+func (r *Runtime) NewArtifactEvent(status events.Status, name, digest string, attr map[string]string) {
 	e := events.NewEvent(status)
 	e.Type = events.Artifact
 	e.Name = name

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -201,6 +201,18 @@ func (r *Runtime) NewSecretEvent(status events.Status, secretID string) {
 	}
 }
 
+// NewArtifactEvent creates a new event for a libpod artifact
+func (r *Runtime) NewArtifactEvent(status events.Status, name, digest string, attr map[string]string){
+	e := events.NewEvent(status)
+	e.Type = events.Artifact
+	e.Name = name
+	e.ID = digest
+	e.Attributes = attr
+	if err := r.eventer.Write(e); err != nil {
+		logrus.Errorf("Unable to write artifact event: %q", err)
+	}
+}
+
 // Events is a wrapper function for everyone to begin tailing the events log
 // with options
 func (r *Runtime) Events(ctx context.Context, options events.ReadOptions) error {

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -133,7 +133,11 @@ const (
 	Machine Type = "machine"
 	// Secret - event is related to secrets
 	Secret Type = "secret"
+	// Artifact - event is related to artifacts
+	Artifact Type = "artifact"
 
+	// Add ...
+	Add Status = "add"
 	// Attach ...
 	Attach Status = "attach"
 	// AutoUpdate ...
@@ -156,6 +160,8 @@ const (
 	ExecDied Status = "exec_died"
 	// Exited indicates that a container's process died
 	Exited Status = "died"
+	// Extract ...
+	Extract Status = "extract"
 	// Export ...
 	Export Status = "export"
 	// HealthStatus ...

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -94,6 +94,14 @@ func (e *Event) ToHumanReadable(truncate bool) string {
 		humanFormat = fmt.Sprintf("%s %s %s %s", e.Time, e.Type, e.Status, e.Name)
 	case Secret:
 		humanFormat = fmt.Sprintf("%s %s %s %s", e.Time, e.Type, e.Status, id)
+	case Artifact:
+		humanFormat = fmt.Sprintf("%s %s %s %s (name=%s", e.Time, e.Type, e.Status, id, e.Name)
+		if len(e.Attributes) > 0 {
+			for k, v := range e.Attributes {
+				humanFormat += fmt.Sprintf(", %s=%s", k, v)
+			}
+		}
+		humanFormat += ")"
 	}
 	return humanFormat
 }
@@ -127,6 +135,8 @@ func StringToType(name string) (Type, error) {
 		return Volume, nil
 	case Secret.String():
 		return Secret, nil
+	case Artifact.String():
+		return Artifact, nil
 	case "":
 		return "", ErrEventTypeBlank
 	}
@@ -136,6 +146,8 @@ func StringToType(name string) (Type, error) {
 // StringToStatus converts a string to an Event Status
 func StringToStatus(name string) (Status, error) {
 	switch name {
+	case Add.String():
+		return Add, nil
 	case Attach.String():
 		return Attach, nil
 	case AutoUpdate.String():
@@ -156,6 +168,8 @@ func StringToStatus(name string) (Status, error) {
 		return ExecDied, nil
 	case Exited.String():
 		return Exited, nil
+	case Extract.String():
+		return Extract, nil
 	case Export.String():
 		return Export, nil
 	case HealthStatus.String():

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -74,6 +74,12 @@ func (e EventJournalD) Write(ee Event) error {
 		}
 	case Volume:
 		m["PODMAN_NAME"] = ee.Name
+	case Artifact:
+		m["PODMAN_NAME"] = ee.Name
+		m["PODMAN_ID"] = ee.ID
+		if err := addLabelsToJournal(m, ee.Details.Attributes); err != nil {
+			return err
+		}
 	}
 
 	// starting with commit 7e6e267329 we set LogLevel=notice for the systemd healthcheck unit
@@ -274,6 +280,11 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) {
 		newEvent.ID = entry.Fields["PODMAN_ID"]
 		if val, ok := entry.Fields["ERROR"]; ok {
 			newEvent.Error = val
+		}
+	case Artifact:
+		newEvent.ID = entry.Fields["PODMAN_ID"]
+		if err := getLabelsFromJournal(entry, &newEvent); err != nil {
+			return nil, err
 		}
 	}
 	return &newEvent, nil

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -174,7 +174,7 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 				continue
 			}
 			switch event.Type {
-			case Image, Volume, Pod, Container, Network, Secret:
+			case Image, Volume, Pod, Container, Network, Secret, Artifact:
 				//	no-op
 			case System:
 				begin, end, err := e.readRotateEvent(event)

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -531,7 +531,15 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 
 		// Using sync once value to only init the store exactly once and only when it will be actually be used.
 		runtime.ArtifactStore = sync.OnceValues(func() (*artStore.ArtifactStore, error) {
-			return artStore.NewArtifactStore(filepath.Join(runtime.storageConfig.GraphRoot, "artifacts"), runtime.SystemContext())
+			artifactEventCallBack := func(status, name, digest string, attributes map[string]string) {
+				eventStatus, err := events.StringToStatus(status)
+				if err != nil {
+					logrus.Errorf("Unknown artifact event status %q: %v", status, err)
+					return
+				}
+				runtime.NewArtifactEvent(eventStatus, name, digest, attributes)
+			}
+			return artStore.NewArtifactStoreWithEventCallback(filepath.Join(runtime.storageConfig.GraphRoot, "artifacts"), runtime.SystemContext(), artifactEventCallBack)
 		})
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Fixed #27260 

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Added support for artifact events in podman events. 
- Users can now monitor artifact operations (pull, push, add, remove, extract) using podman events --filter type=artifact. 
- This feature works with both journald and file event backends and displays artifact names, digests, and operation details.
```

https://github.com/containers/container-libs/pull/418 should be merget at first and reflected in this PR.