### PR TITLE
Allow RC Windows Installer to be built

### DIFF
--- a/contrib/win-installer/wix/podman.wixproj
+++ b/contrib/win-installer/wix/podman.wixproj
@@ -1,6 +1,7 @@
 <Project Sdk="WixToolset.Sdk/5.0.2">
 	<PropertyGroup>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+		<SuppressIces>ICE24</SuppressIces>
 	</PropertyGroup>
 	<ItemGroup>
 		<HarvestDirectory Include="..\docs">


### PR DESCRIPTION
The windows installer doesn't like -rc's because it's not strictly semver, but this error can be suppressed.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
