### PR TITLE
Fixes #27121. quadlet: add Pod field to quadlet list output

### DIFF
--- a/docs/source/markdown/podman-quadlet-list.1.md
+++ b/docs/source/markdown/podman-quadlet-list.1.md
@@ -35,6 +35,7 @@ Print results with a Go template.
 | .App            | Name of application if Quadlet is part of an app |
 | .Name           | Name of the Quadlet file                         |
 | .Path           | Quadlet file path on disk                        |
+| .Pod            | Pod name (if the quadlet is part of a pod - only applicable to .container files)|
 | .Status         | Quadlet status corresponding to systemd unit     |
 | .UnitName       | Systemd unit name corresponding to quadlet       |
 

--- a/pkg/domain/entities/quadlet.go
+++ b/pkg/domain/entities/quadlet.go
@@ -41,6 +41,8 @@ type ListQuadlet struct {
 	// If multiple quadlets were installed together they will belong
 	// to common App.
 	App string
+	// Pod is the name of the pod this quadlet belongs to
+	Pod string
 }
 
 // QuadletRemoveOptions contains parameters for removing Quadlets

--- a/pkg/domain/infra/abi/quadlet.go
+++ b/pkg/domain/infra/abi/quadlet.go
@@ -465,10 +465,21 @@ func (ic *ContainerEngine) QuadletList(ctx context.Context, options entities.Qua
 		if ok {
 			appName = value
 		}
+
+		// Parse the unit file to extract Pod= from the [Container] section
+		podName := ""
+		unitFile, err := parser.ParseUnitFile(path)
+		if err == nil {
+			// LookupLast returns the last value if Pod= is specified multiple times
+			value, _ := unitFile.LookupLast("Container", "Pod")
+			podName = value
+		}
+
 		report := entities.ListQuadlet{
 			Name: filepath.Base(path),
 			Path: path,
 			App:  appName,
+			Pod:  podName,
 		}
 
 		serviceName, err := getQuadletServiceName(path)

--- a/test/system/253-podman-quadlet.bats
+++ b/test/system/253-podman-quadlet.bats
@@ -504,4 +504,43 @@ EOF
     run_podman quadlet rm alpine-quadlet.container
 }
 
+@test "quadlet verb - list shows Pod field" {
+    # Create a pod quadlet
+    local pod_file=$PODMAN_TMPDIR/test-pod.pod
+    cat > $pod_file <<EOF
+[Pod]
+EOF
+    # Create a container quadlet that joins the pod
+    local container_file=$PODMAN_TMPDIR/pod-member.container
+    cat > $container_file <<EOF
+[Container]
+Image=$IMAGE
+Pod=test-pod
+Exec=sh -c "echo STARTED CONTAINER IN POD; trap 'exit' SIGTERM; while :; do sleep 0.1; done"
+EOF
+    # Create a standalone container (no pod)
+    local standalone_file=$PODMAN_TMPDIR/standalone.container
+    cat > $standalone_file <<EOF
+[Container]
+Image=$IMAGE
+Exec=sh -c "echo STARTED STANDALONE; trap 'exit' SIGTERM; while :; do sleep 0.1; done"
+EOF
+    # Install all quadlets
+    run_podman quadlet install $pod_file $container_file $standalone_file
+
+    # Test that Pod field appears in custom format
+    run_podman quadlet list --format '{{.Name}} {{.Pod}}'
+    assert "$output" =~ "pod-member.container test-pod" "container in pod should show pod name"
+    assert "$output" =~ $'standalone.container[[:space:]]*($|\n)' "standalone container should have empty pod field"
+    assert "$output" =~ $'test-pod.pod[[:space:]]*($|\n)' "pod itself should have empty pod field"
+
+    # Test that Pod field works in JSON output
+    run_podman quadlet list --format json
+    assert "$output" =~ '"Name".*"pod-member.container"' "JSON should contain pod-member"
+    assert "$output" =~ '"Pod".*"test-pod"' "JSON should show Pod field with value"
+
+    # Clean up
+    run_podman quadlet rm test-pod.pod pod-member.container standalone.container
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
quadlet: `podman quadlet list` now supports a `.Pod` field in `--format` to display which pod a container quadlet belongs to
```
