### PR TITLE
[WIP] Fix race condition in concurrent artifact additions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -195,3 +195,5 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.0.0 // indirect
 )
+
+replace go.podman.io/common => github.com/rhatdan/container-libs b801c9d727f587ca2c9d50ca3a3278fd6c4c979d

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -741,6 +741,62 @@ var _ = Describe("Podman artifact", func() {
 		session = podmanTest.PodmanExitCleanly("artifact", "inspect", artifactDigest[:12], "-f", "{{.Name}}")
 		Expect(session.OutputToString()).To(Equal(artifact1Name))
 	})
+
+	// Regression test for https://github.com/containers/podman/issues/27569
+	It("podman artifact add concurrent - no race condition", func() {
+		const numArtifacts = 5
+
+		// Create temporary files for artifacts
+		artifactFiles := make([]string, numArtifacts)
+		artifactNames := make([]string, numArtifacts)
+		for i := 0; i < numArtifacts; i++ {
+			file, err := createArtifactFile(int64(1024 * (i + 1))) // Different sizes
+			Expect(err).ToNot(HaveOccurred())
+			artifactFiles[i] = file
+			artifactNames[i] = fmt.Sprintf("localhost/concurrent/artifact%d", i)
+		}
+
+		// Run all artifact add commands concurrently
+		sessions := make([]*PodmanSessionIntegration, numArtifacts)
+		for i := 0; i < numArtifacts; i++ {
+			// Start all commands without waiting
+			sessions[i] = podmanTest.Podman([]string{"artifact", "add", artifactNames[i], artifactFiles[i]})
+		}
+
+		// Wait for all to complete and collect results
+		digests := make([]string, numArtifacts)
+		for i := 0; i < numArtifacts; i++ {
+			sessions[i].WaitWithDefaultTimeout()
+			Expect(sessions[i]).Should(ExitCleanly())
+			digests[i] = sessions[i].OutputToString()
+			Expect(digests[i]).To(HaveLen(64)) // SHA256 digest length
+		}
+
+		// Verify all artifacts were created successfully
+		listSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.Repository}}")
+		output := listSession.OutputToStringArray()
+
+		// Check that all artifact names are in the list
+		for i := 0; i < numArtifacts; i++ {
+			Expect(output).To(ContainElement(artifactNames[i]),
+				fmt.Sprintf("Artifact %s should be in the list", artifactNames[i]))
+		}
+
+		// Verify each artifact can be inspected
+		for i := 0; i < numArtifacts; i++ {
+			inspectSession := podmanTest.PodmanExitCleanly("artifact", "inspect", artifactNames[i])
+			Expect(inspectSession.OutputToString()).To(ContainSubstring(artifactNames[i]))
+		}
+
+		// Verify each artifact has the correct size
+		for i := 0; i < numArtifacts; i++ {
+			expectedSize := 1024 * (i + 1)
+			sizeSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.VirtualSize}}", "--noheading")
+			sizes := sizeSession.OutputToStringArray()
+			Expect(sizes).To(ContainElement(fmt.Sprintf("%d", expectedSize)),
+				fmt.Sprintf("Artifact %d should have size %d", i, expectedSize))
+		}
+	})
 })
 
 func digestToFilename(digest string) string {


### PR DESCRIPTION
This fixes a race condition where concurrent 'podman artifact add' commands for different artifacts would result in only one artifact being created, without any error messages.

The root cause was in the artifact store's Add() method, which would:
1. Acquire lock
2. Read OCI layout index
3. Create ImageDestination (which snapshots the index)
4. RELEASE lock (optimization for blob copying)
5. Copy blobs (while unlocked)
6. Reacquire lock
7. Commit changes (write new index)

When two concurrent additions happened:
- Process A: Lock → Read index → Create dest A → Unlock → Copy blobs
- Process B: Lock → Read index (no artifact A!) → Create dest B → Unlock
- Process A: Lock → Commit (write index with A)
- Process B: Lock → Commit (write index with B, OVERWRITING A)

The fix keeps the lock held for the entire operation. While this reduces concurrency for blob copying, it prevents the index file corruption that caused artifacts to be lost.

Changes:
- Remove lock release/reacquire around blob copying in store.Add()
- Simplify lock management (no more conditional unlock)
- Add e2e test for concurrent artifact additions
- Add standalone test script to verify the fix

Fixes: https://github.com/containers/podman/issues/27569

Generated-with: Cursor AI

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
podman artifact add can now run without race conditions on adds.
```
