### PR TITLE
test/system: Fix the IPv6 address mismatch error

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -307,10 +307,10 @@ function pasta_test_do() {
     run_podman run --rm --net=pasta $IMAGE ip -j -6 address show
 
     local container_address="$(ipv6_get_addr_global "${output}")"
-    local host_address="$(default_addr 6)"
+    local host_addresses="$(all_addr 6)"
 
-    assert "${container_address}" = "${host_address}" \
-           "Container address not matching host"
+    echo "${host_addresses}" | grep -qw "${container_address}"
+    assert $? -eq 0 "Container address not matching host"
 }
 
 @test "IPv6 address assignment" {

--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -449,3 +449,11 @@ function default_addr() {
     local expr='[.[0].addr_info[] | select(.deprecated != true)][0].local'
     ip -j -"${ip_ver}" addr show "${ifname}" | jq -rM "${expr}"
 }
+
+function all_addr() {
+    local ip_ver="${1}"
+    local ifname="${2:-$(default_ifname "${ip_ver}")}"
+
+    local expr='[.[0].addr_info[] | select(.deprecated != true)]'
+    ip -j -"${ip_ver}" addr show "${ifname}" | jq -rM "${expr}" | grep local | cut -d'"' -f4 | tr '\n' ' '
+}


### PR DESCRIPTION
For IPv6 addresses within the same scope group, Linux kernel preserves insertion order, where the first inserted address appears last. As a result, the ordering inside pasta differs from the host, causing a test to fail when they compare only the first address on each side. Fix this by checking that the container’s first address matches any of the host’s addresses.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
None
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
NONE
```
