### PR TITLE
fix: Container with Notify=healthy respect `HealthStartPeriod` larger than `TimeoutStartSec`.

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1344,6 +1344,51 @@ func (c *Container) waitForHealthy(ctx context.Context) error {
 		c.lock.Unlock()
 		defer c.lock.Lock()
 	}
+	if c.config.SdNotifySocket != "" {
+		// While waiting for the container to turn healthy, keep
+		// extending the start timeout of the systemd unit so that a
+		// time-to-healthy larger than systemd's TimeoutStartSec is
+		// respected, whether it is dominated by a large
+		// HealthStartPeriod or by a long-running startup healthcheck.
+		// The health status remains "starting" during that entire
+		// window, so extensions stop as soon as the container turns
+		// healthy (the wait below returns), unhealthy or stopped,
+		// letting systemd's own timeout kick back in.
+		const (
+			extendInterval = 25 * time.Second
+			extendAmount   = 30 * time.Second
+		)
+
+		extendCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		ticker := time.NewTicker(extendInterval)
+		defer ticker.Stop()
+
+		msg := fmt.Sprintf("EXTEND_TIMEOUT_USEC=%d", extendAmount.Microseconds())
+
+		// Send the first extension immediately.
+		// systemd.service(5): "The first receipt of this message must occur before TimeoutStartSec= is exceeded."
+		if err := notifyproxy.SendMessage(c.config.SdNotifySocket, msg); err != nil {
+			logrus.Errorf("Sending EXTEND_TIMEOUT_USEC failed: %v", err)
+		}
+		go func() {
+			for {
+				select {
+				case <-extendCtx.Done():
+					return
+				case <-ticker.C:
+					status, err := c.HealthCheckStatus()
+					if err != nil || status != define.HealthCheckStarting {
+						return
+					}
+					if err := notifyproxy.SendMessage(c.config.SdNotifySocket, msg); err != nil {
+						logrus.Errorf("Sending EXTEND_TIMEOUT_USEC failed: %v", err)
+					}
+				}
+			}
+		}()
+	}
 
 	if _, err := c.WaitForConditionWithInterval(ctx, DefaultWaitInterval, define.HealthCheckHealthy); err != nil {
 		if errors.Is(err, define.ErrNoSuchCtr) {

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -403,6 +403,76 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     service_cleanup
 }
 
+# Helper for the --sdnotify=healthy timeout-extension tests below.
+# Writes a Type=notify unit with a TimeoutStartSec shorter than the
+# container's time-to-healthy, starts it, and asserts that it turns active.
+#
+#  $1 - container name
+#  $2 - extra podman-run healthcheck arguments
+function _test_sdnotify_healthy_extends_timeout() {
+    local cname="$1"
+    local hc_args="$2"
+
+    local runtime=$(podman_runtime)
+    if [[ "$runtime" != "crun" ]]; then
+        skip "this test only works with crun, not $runtime"
+    fi
+
+    # The container turns healthy after ~15 seconds, past the 10-second
+    # TimeoutStartSec.
+    cat > $UNIT_FILE <<EOF
+[Unit]
+Description=Podman sdnotify=healthy test
+
+[Service]
+Type=notify
+NotifyAccess=all
+TimeoutStartSec=10
+ExecStart=$PODMAN run -d --name $cname --rm --sdnotify=healthy $hc_args \
+    $IMAGE sh -c "sleep 15; touch /ready; sleep infinity"
+ExecStop=$PODMAN stop -t0 $cname
+TimeoutStopSec=30
+EOF
+    systemctl daemon-reload
+
+    # Start must survive past TimeoutStartSec=10 and succeed once healthy.
+    systemctl_start "$SERVICE_NAME"
+
+    run systemctl show --value --property=ActiveState "$SERVICE_NAME"
+    assert "$output" = "active" "service active after container turned healthy"
+
+    run_podman healthcheck run $cname
+
+    service_cleanup
+}
+
+# https://github.com/containers/podman/issues/27290
+@test "podman --sdnotify=healthy - HealthStartPeriod larger than TimeoutStartSec" {
+    # With --sdnotify=healthy, the READY message is only sent once the
+    # container turns healthy.  Podman must extend the systemd start timeout
+    # (EXTEND_TIMEOUT_USEC) while waiting, otherwise a health-start-period
+    # larger than the unit's TimeoutStartSec= makes systemd kill the service
+    # before the container can turn healthy.
+    _test_sdnotify_healthy_extends_timeout c-$(safename) \
+        "--health-cmd \"test -f /ready\" \
+         --health-interval 2s \
+         --health-retries 1 \
+         --health-start-period 2m"
+}
+
+# https://github.com/containers/podman/issues/27290
+@test "podman --sdnotify=healthy - startup healthcheck longer than TimeoutStartSec" {
+    # Same as above, but here the time-to-healthy is dominated by a startup
+    # healthcheck while the health-start-period is short: the start timeout
+    # must keep being extended for as long as the container is "starting".
+    _test_sdnotify_healthy_extends_timeout c-$(safename) \
+        "--health-cmd \"test -f /ready\" \
+         --health-interval 2s \
+         --health-start-period 1s \
+         --health-startup-cmd \"test -f /ready\" \
+         --health-startup-interval 2s"
+}
+
 @test "podman-kube@.service template" {
     install_kube_template
     # Create the YAMl file


### PR DESCRIPTION
- This logic only run when `HealthStartPeriod > 0`
- The system now respects the containers `HealthStartPeriod` by sending periodic `EXTEND_TIMEOUT_USEC` messages 
- The code dynamically calculates how much time to extend, only asking for the remaining duration of the `HealthStartPeriod`.
- The extension logic run in separate goroutine. This implementation adapted the pattern of `copyInternal` function https://github.com/containers/container-libs/blob/a3b0f19c3ea12cb02f0b11788489c52d4fb02e96/common/libimage/copier.go#L392-L421 
suggested by maintainers.
- Would be happy to chat with maintainers if any further improvement is needed!


closes #27290
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Containers started with `--sdnotify=healthy` (Quadlet `Notify=healthy`) now extend the systemd startup timeout while waiting to become healthy, so a health start period (`HealthStartPeriod`) larger than the unit's `TimeoutStartSec` no longer causes systemd to kill the service before the container can turn healthy.
```
