### PR TITLE
Add automatic DCO signing support with Git hooks

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This script automatically adds a Signed-off-by trailer to each commit message, so that your commits
+# will adhere to the DCO (Developer Certificate of Origin) requirements.
+#
+# To enable this hook, run `make init-git-hooks`, or run the following from the
+# root of the repo:
+#
+# $ ln -sf ../../.githooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+
+COMMIT_MESSAGE_FILE="$1"
+AUTHOR=$(git var GIT_AUTHOR_IDENT)
+SIGNOFF=$(echo "$AUTHOR" | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+
+# Check for DCO signoff message. If one doesn't exist, append one.
+if ! grep -qs "^$SIGNOFF" "$COMMIT_MESSAGE_FILE"; then
+  echo "" >> "$COMMIT_MESSAGE_FILE"
+  echo "$SIGNOFF" >> "$COMMIT_MESSAGE_FILE"
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,6 +330,16 @@ Use your real name (sorry, no pseudonyms or anonymous contributions).
 
 If you set your `user.name` and `user.email` git configs, you can sign your commit automatically with `git commit -s`.
 
+#### Automatic DCO Signing (Recommended)
+
+To automatically sign all your commits and avoid DCO check failures, configure Git to use the repository's hooks:
+
+```shell
+$ make init-git-hooks
+```
+
+This will configure Git to automatically add the `Signed-off-by` trailer to all your commit messages.
+
 ### Reviewing PRs
 
 If you are a maintainer of Podman project, please following the [guidelines](https://github.com/containers/podman/blob/main/REVIEWING.md) on how to review a PR.

--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,17 @@ help: ## (Default) Print listing of key targets with their descriptions
 		awk 'BEGIN {FS = ":(.*)?## "}; \
 			{printf $(_HLPFMT), $$1, $$2}'
 
+.PHONY: init-git-hooks
+init-git-hooks: ## Install prepare-commit-msg hook for automatic DCO signing
+	@if [ -e .git/hooks/prepare-commit-msg ] && [ ! -L .git/hooks/prepare-commit-msg ]; then \
+		echo "Warning: .git/hooks/prepare-commit-msg already exists and is not a symlink."; \
+		echo "Backup your existing hook before running this command."; \
+		exit 1; \
+	fi
+	@mkdir -p .git/hooks
+	ln -sf ../../.githooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+	@echo "DCO sign-off hook installed. Commits will now be automatically signed."
+
 ###
 ### Linting/Formatting/Code Validation targets
 ###


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

This pull request introduces an automated process to ensure all commits are properly signed with a DCO (Developer Certificate of Origin) signature, helping contributors avoid DCO-related CI failures. The changes add a git hook script for automatic signing, update the documentation to recommend this workflow, and provide a convenient Makefile target for setup.

**Automatic DCO signing improvements:**

* Added a `prepare-commit-msg` git hook script in `.githooks/` that automatically appends a `Signed-off-by` trailer to commit messages using the committer's configured name and email. This enforces DCO compliance for every commit.
* Introduced a new `init-git-hooks` target in the `Makefile` to configure the repository to use the custom hooks directory, making it easy for contributors to enable automatic DCO signing.
* Updated `CONTRIBUTING.md` to recommend using `make init-git-hooks` for automatic DCO signing, explaining the benefits and providing setup instructions.
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.


```release-note
None
```

Fixes #27698 