### PR TITLE
Improve OOMKilled Visibility

### DIFF
--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -54,6 +54,8 @@ type Event struct {
 	// containerExitCode is for storing the exit code of a container which can
 	// be used for "internal" event notification
 	ContainerExitCode *int `json:",omitempty"`
+	// OOMKilled indicates whether the container was killed by an OOM condition
+	OOMKilled *bool `json:",omitempty"`
 	// ID can be for the container, image, volume, etc
 	ID string `json:",omitempty"`
 	// Image used where applicable
@@ -81,6 +83,7 @@ type Event struct {
 func newEventFromLibpodEvent(e *events.Event) Event {
 	return Event{
 		ContainerExitCode: e.ContainerExitCode,
+		OOMKilled:         e.OOMKilled,
 		ID:                e.ID,
 		Image:             e.Image,
 		Name:              e.Name,

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -127,6 +127,7 @@ Format the output to JSON Lines or using the given Go template.
 | .Image                | Name of image being run (string)                                     |
 | .Name                 | Container name (string)                                              |
 | .Network              | Name of network being used (string)                                  |
+| .OOMKilled            | Whether container was killed due to OOM (bool)                       |
 | .PodID                | ID of pod associated with container, if any                          |
 | .Status               | Event status (e.g., create, start, died, ...)                        |
 | .Time                 | Event timestamp (string)                                             |

--- a/docs/source/markdown/podman-inspect.1.md.in
+++ b/docs/source/markdown/podman-inspect.1.md.in
@@ -147,6 +147,12 @@ podman container inspect --latest --format {{.EffectiveCaps}}
 [CAP_CHOWN CAP_DAC_OVERRIDE CAP_FSETID CAP_FOWNER CAP_SETGID CAP_SETUID CAP_SETFCAP CAP_SETPCAP CAP_NET_BIND_SERVICE CAP_KILL]
 ```
 
+Inspect the specified container for the `OOMKilled` format specifier
+```
+podman container inspect myContainer --format {{.State.OOMKilled}}
+false
+```
+
 Inspect the specified pod for the `Name` format specifier:
 ```
 # podman inspect myPod --type pod --format "{{.Name}}"

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -105,9 +105,11 @@ func (c *Container) newContainerExitedEvent(exitCode int32) {
 	intExitCode := int(exitCode)
 	e.ContainerExitCode = &intExitCode
 
-	e.Details = events.Details{
-		Attributes: c.Labels(),
+	attrs := c.Labels()
+	if c.state.OOMKilled {
+		e.OOMKilled = &c.state.OOMKilled
 	}
+	e.Details = events.Details{Attributes: attrs}
 
 	if err := c.runtime.eventer.Write(e); err != nil {
 		logrus.Errorf("Unable to write container exited event: %q", err)

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -24,6 +24,8 @@ type Event struct {
 	// ContainerExitCode is for storing the exit code of a container which can
 	// be used for "internal" event notification
 	ContainerExitCode *int `json:",omitempty"`
+	// OOMKilled indicates whether the container was killed by an OOM condition
+	OOMKilled *bool `json:",omitempty"`
 	// ID can be for the container, image, volume, etc
 	ID string `json:",omitempty"`
 	// Image used where applicable

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -50,6 +50,9 @@ func (e EventJournalD) Write(ee Event) error {
 		if ee.ContainerExitCode != nil {
 			m["PODMAN_EXIT_CODE"] = strconv.Itoa(*ee.ContainerExitCode)
 		}
+		if ee.OOMKilled != nil {
+			m["PODMAN_OOM_KILLED"] = strconv.FormatBool(*ee.OOMKilled)
+		}
 		if ee.PodID != "" {
 			m["PODMAN_POD_ID"] = ee.PodID
 		}
@@ -248,6 +251,14 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) {
 				logrus.Errorf("Parsing event exit code %s", code)
 			} else {
 				newEvent.ContainerExitCode = &intCode
+			}
+		}
+		if val, ok := entry.Fields["PODMAN_OOM_KILLED"]; ok {
+			oomKilled, err := strconv.ParseBool(val)
+			if err != nil {
+				logrus.Errorf("Parsing event oom killed value %s", val)
+			} else {
+				newEvent.OOMKilled = &oomKilled
 			}
 		}
 		if err := getLabelsFromJournal(entry, &newEvent); err != nil {

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -338,6 +338,24 @@ EOF
     assert "$output" = "$lvalue" "podman-events output includes container label"
 }
 
+@test "events - died event contains OOMKilled attribute" {
+    local cname=c-$(safename)
+
+    run_podman run -d --rm \
+                --name $cname \
+                --memory 20m \
+                --cgroup-conf=memory.oom.group=1 \
+                $IMAGE sh -c "x=a; while :; do x=\$x\$x\$x\$x; done"
+    run_podman wait $cname
+    run_podman events \
+               --filter container=$cname \
+               --filter event=died \
+               --stream=false \
+               --format "{{.OOMKilled}}"
+
+    assert "$output" = "true" "OOMKilled attribute should be present and set to true"
+}
+
 # bats test_tags=ci:parallel
 @test "events - backend none should error" {
     skip_if_remote "remote does not support --events-backend"


### PR DESCRIPTION
As seen in issues #26701 and #25990, discovering whether a container has been OOMKilled doesn't seem to be very well known to users.

To address this, this PR adds an example of inspecting a container for the OOMKilled attribute to the podman inspect docs.

However, in scenarios where a container is automatically restarted, the podman inspect data will get wiped. In these cases, an OOMKilled attribute has been added to the container died event. This way, podman events can be a more persistent source of this information.

In short, this PR:
 - Adds an OOMKilled attribute to the container died event
 - Adds a system test for the above
 - Updates documentation of `podman inspect` to include an example of inspecting a container for the OOMKilled label.

Fixes: #26701

#### Checklist

- [X] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [X] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [X] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [X] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [X] All commits pass `make validatepr` (format/lint checks)
- [X] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Add OOMKilled attribute to container died event
```
