### PR TITLE
Fix ancestor filter to resolve image names to IDs

### DIFF
--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -92,27 +92,31 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 	case "ancestor":
 		// This needs to refine to match docker
 		// - ancestor=(<image-name>[:tag]|<image-id>| ⟨image@digest⟩) - containers created from an image or a descendant.
+		imgRuntime := r.LibimageRuntime()
+		var resolvedIDs []string
+		var passthrough []string
+		for _, filterValue := range filterValues {
+			img, _, err := imgRuntime.LookupImage(filterValue, nil)
+			if err == nil && img != nil {
+				// filterValue is a resolvable image name[:tag] 
+				// Store the image's ID
+				resolvedIDs = append(resolvedIDs, img.ID())
+				continue
+			}
+			// Not resolvable as a name (possibly ID)
+			passthrough = append(passthrough, filterValue)
+		}
 		return func(c *libpod.Container) bool {
-			for _, filterValue := range filterValues {
-				rootfsImageID, rootfsImageName := c.Image()
-				var imageTag string
-				var imageNameWithoutTag string
-				// Compare with ImageID, ImageName
-				// Will match ImageName if running image has tag latest for other tags exact complete filter must be given
-				name, tag, hasColon := strings.Cut(rootfsImageName, ":")
-				if hasColon {
-					imageNameWithoutTag = name
-					imageTag = tag
-				}
-
-				// Check for substring match on image ID (Docker compatibility)
-				if strings.Contains(rootfsImageID, filterValue) {
+			rootfsImageID, _ := c.Image()
+			// Check ID match for resolved names
+			for _, id := range resolvedIDs {
+				if strings.Contains(rootfsImageID, id) {
 					return true
 				}
-
-				// Check for regex match (advanced use cases)
-				if util.StringMatchRegexSlice(rootfsImageName, filterValues) ||
-					(util.StringMatchRegexSlice(imageNameWithoutTag, filterValues) && imageTag == "latest") {
+			}
+			// Check if given ID matches ancestor ID
+			for _, id := range passthrough {
+				if strings.Contains(rootfsImageID, id) {
 					return true
 				}
 			}
@@ -361,26 +365,30 @@ func GenerateExternalContainerFilterFuncs(filter string, filterValues []string, 
 	case "ancestor":
 		// This needs to refine to match docker
 		// - ancestor=(<image-name>[:tag]|<image-id>| ⟨image@digest⟩) - containers created from an image or a descendant.
-		return func(listContainer *types.ListContainer) bool {
-			for _, filterValue := range filterValues {
-				var imageTag string
-				var imageNameWithoutTag string
-				// Compare with ImageID, ImageName
-				// Will match ImageName if running image has tag latest for other tags exact complete filter must be given
-				name, tag, hasColon := strings.Cut(listContainer.Image, ":")
-				if hasColon {
-					imageNameWithoutTag = name
-					imageTag = tag
-				}
+		imgRuntime := r.LibimageRuntime()
+		var resolvedIDs []string
+		var passthrough []string
+		for _, filterValue := range filterValues {
+			img, _, err := imgRuntime.LookupImage(filterValue, nil)
+			if err == nil && img != nil {
+				// filterValue is a resolvable image name[:tag]
+				// Store the image's ID
+				resolvedIDs = append(resolvedIDs, img.ID())
+				continue
+			}
+			// Not resolvable as a name (possibly ID)
+			passthrough = append(passthrough, filterValue)
+		}
 
-				// Check for substring match on image ID (Docker compatibility)
-				if strings.Contains(listContainer.ImageID, filterValue) {
+		return func(listContainer *types.ListContainer) bool {
+			for _, id := range resolvedIDs {
+				if strings.Contains(listContainer.ImageID, id) {
 					return true
 				}
-
-				// Check for regex match (advanced use cases)
-				if util.StringMatchRegexSlice(listContainer.Image, filterValues) ||
-					(util.StringMatchRegexSlice(imageNameWithoutTag, filterValues) && imageTag == "latest") {
+			}
+			for _, id := range passthrough {
+				id = strings.TrimPrefix(id, "sha256:")
+				if strings.Contains(listContainer.ImageID, id) {
 					return true
 				}
 			}


### PR DESCRIPTION
Fix ancestor filter to resolve image names to IDs. This is necessary since image names are mutable and can thus point to different image IDs as time goes by. The image ID, on the other hand, stays immutable and thus is the best approach in finding a container's ancestor.

Fixes: #27743

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

Fixed `podman ps --filter ancestor=...` to resolve image names and tags to immutable image IDs at container creation time.

Previously, filtering by an image name or tag (e.g., `ancestor=alpine:latest`) could incorrectly match containers if the tag was later retagged to a different image. Podman now matches containers based on the original image ID they were created from, ensuring correct and Docker-compatible behavior when image tags are mutable.

```
