### PR TITLE
set up default IDMappings when none are set and userns=auto

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -217,6 +217,22 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		}
 	}
 
+	// if userns is auto, set up annotation, and default IDMappings if none are set
+	if s.UserNS.IsAuto() {
+		if s.Annotations == nil {
+			s.Annotations = make(map[string]string)
+		}
+		s.Annotations[define.UserNsAnnotation] = string(s.UserNS.NSMode)
+
+		if s.IDMappings == nil {
+			mappings, err := util.ParseIDMapping(namespaces.UsernsMode(s.UserNS.NSMode), nil, nil, "", "")
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			s.IDMappings = mappings
+		}
+	}
+
 	if err := s.Validate(); err != nil {
 		return nil, nil, nil, fmt.Errorf("invalid config provided: %w", err)
 	}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -948,6 +948,31 @@ for runtime in "${oci_runtimes[@]}"; do
     t DELETE containers/$cid 204
 done
 
+# 27988: make sure creation with "userns": {"nsmode": "auto"} works even without
+# explicit idmappings. check for the same behaviour the cmd line shows: when the
+# container is created, UsernsMode is ""; after the container is started,
+# UsernsMode becomes "private"
+
+t POST libpod/containers/create \
+  Image=$IMAGE \
+  UserNS='{"NSMode":"auto"}' \
+  201
+cid=$(jq -r '.Id' <<<"$output")
+
+t GET libpod/containers/$cid/json \
+  200 \
+  .HostConfig.UsernsMode=''
+
+t POST   libpod/containers/$cid/start 204
+
+t GET libpod/containers/$cid/json \
+  200 \
+  .HostConfig.UsernsMode=private
+
+t DELETE libpod/containers/$cid 200 .[0].Id=$cid
+
+
+# clean up
 podman rmi -f $IMAGE
 
 # Test health status in /containers/json (GH #27786)

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -968,17 +968,24 @@ done
 
 # 27998: make sure a created (and not started) container with userns=auto shows
 # UsernsMode = private before being started
+# 27988: make sure creation with "userns": {"nsmode": "auto"} works even without
+# explicit idmappings
 
 t POST libpod/containers/create \
-  image=$IMAGE \
+  Image=$IMAGE \
   UserNS='{"NSMode":"auto"}' \
-  IDMappings='{"AutoUserNs":true,"AutoUserNsOpts":{"AdditionalUIDMappings":[],"AdditionalGIDMappings":[],"PasswdFile":"","GroupFile":"","InitialSize":0,"Size":0}}' \
   201
 cid=$(jq -r '.Id' <<<"$output")
 
 t GET libpod/containers/$cid/json \
   200 \
   .HostConfig.UsernsMode='private'
+
+t POST   libpod/containers/$cid/start 204
+
+t GET libpod/containers/$cid/json \
+  200 \
+  .HostConfig.UsernsMode=private
 
 t DELETE libpod/containers/$cid 200 .[0].Id=$cid
 


### PR DESCRIPTION
This PR originates from [podman-py#499](https://github.com/containers/podman-py/pull/499).

The rationale is to make the behavior of userns=auto a bit more consistent, by setting up default IDMappings when none are provided. Before this patch, Podman would just ignore the userns parameter silently, resulting in a container with non-private userns. This is not ideal from the point of view of security, and it can also be confusing (it was to me at least).

After this patch, e.g. API call `POST libpod/containers/create UserNS='{"NSMode":"auto"}'` results in a container with private userns, as imo one could reasonably expect.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
libpod API sets up default IDMappings during container creation when userns is set to 'auto'
```
