### PR TITLE
Return usernsmode=private for autons from inspect

### DIFF
--- a/libpod/container_inspect_linux.go
+++ b/libpod/container_inspect_linux.go
@@ -292,6 +292,13 @@ func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostC
 				}
 			}
 		}
+
+		// If userns=auto, setting up the namespace is deferred until the container
+		// is created. If the container is configured, check if it is going to have a
+		// private userns and return accordingly
+		if c.state.State == define.ContainerStateConfigured && c.config.IDMappings.AutoUserNs {
+			usernsMode = "private"
+		}
 	}
 	hostConfig.UsernsMode = usernsMode
 	if c.config.IDMappings.UIDMap != nil && c.config.IDMappings.GIDMap != nil {

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -683,7 +683,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		}
 	}
 
-	// Add shared namespaces from other containers
+	// Add shared namespaces from other containers. Also handles userns=auto
 	if err := c.addSharedNamespaces(&g); err != nil {
 		return nil, nil, err
 	}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -966,6 +966,24 @@ for runtime in "${oci_runtimes[@]}"; do
     t DELETE containers/$cid 204
 done
 
+# 27998: make sure a created (and not started) container with userns=auto shows
+# UsernsMode = private before being started
+
+t POST libpod/containers/create \
+  image=$IMAGE \
+  UserNS='{"NSMode":"auto"}' \
+  IDMappings='{"AutoUserNs":true,"AutoUserNsOpts":{"AdditionalUIDMappings":[],"AdditionalGIDMappings":[],"PasswdFile":"","GroupFile":"","InitialSize":0,"Size":0}}' \
+  201
+cid=$(jq -r '.Id' <<<"$output")
+
+t GET libpod/containers/$cid/json \
+  200 \
+  .HostConfig.UsernsMode='private'
+
+t DELETE libpod/containers/$cid 200 .[0].Id=$cid
+
+
+# clean up
 podman rmi -f $IMAGE
 
 # Test health status in /containers/json (GH #27786)


### PR DESCRIPTION
When a container is created (internal state configured) using `podman create` or the `/create` API endpoint, and the container is configured with userns=auto, the `Spec` structure is not populated with the future user namespace, as the auto case is not handled in [`specgen.SetupUserNS`](https://github.com/containers/podman/blob/b8a758c859f9ecebdef3fd24193cd743b527d82f/pkg/specgen/namespaces.go#L484).

Instead, auto user ns is [handled](https://github.com/containers/podman/blob/b8a758c859f9ecebdef3fd24193cd743b527d82f/libpod/container_internal_linux.go#L495) while adding shared namespaces when actual OCI initialization happens. 

This patch introduces an additional check in the inspect operation, which will return the value 'private' for 'usernsmode' in this situation, to reflect that when the container is started it will have a private user namespace.

Please let me know if this change makes sense to you. Needs some additional thoughts for testing & documentation.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
return usernsmode=private when inspecting configured (podman create) containers with userns=auto
```
