### PR TITLE
Rework devices from path

### DIFF
--- a/pkg/specgen/generate/cdi_freebsd.go
+++ b/pkg/specgen/generate/cdi_freebsd.go
@@ -1,0 +1,15 @@
+//go:build !remote
+
+package generate
+
+import "github.com/containers/podman/v6/pkg/specgen"
+
+// allowAdditionalCDIDevices returns whether additional CDI devices should be
+// processed.
+// In addition to the --device or --gpus flags, devices can be specified in
+// container.conf or as default host devices.
+func allowAdditionalCDIDevices(s *specgen.SpecGenerator) bool {
+	// On freebsd systems, additional devices are only supported on
+	// non-privileged containers.
+	return !s.IsPrivileged()
+}

--- a/pkg/specgen/generate/cdi_linux.go
+++ b/pkg/specgen/generate/cdi_linux.go
@@ -1,0 +1,9 @@
+//go:build !remote
+
+package generate
+
+import "github.com/containers/podman/v6/pkg/specgen"
+
+func allowAdditionalCDIDevices(_ *specgen.SpecGenerator) bool {
+	return true
+}

--- a/pkg/specgen/generate/config_freebsd.go
+++ b/pkg/specgen/generate/config_freebsd.go
@@ -10,28 +10,13 @@ import (
 	"strings"
 
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/sirupsen/logrus"
-	"go.podman.io/common/pkg/config"
 	"golang.org/x/sys/unix"
-	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 // DevicesFromPath computes a list of devices
-func DevicesFromPath(g *generate.Generator, devicePath string, config *config.Config) error {
+func DevicesFromPath(g *generate.Generator, devicePath string) error {
 	if isCDIDevice(devicePath) {
-		registry, err := cdi.NewCache(
-			cdi.WithSpecDirs(config.Engine.CdiSpecDirs.Get()...),
-			cdi.WithAutoRefresh(false),
-		)
-		if err != nil {
-			return fmt.Errorf("creating CDI registry: %w", err)
-		}
-		if err := registry.Refresh(); err != nil {
-			logrus.Debugf("The following error was triggered when refreshing the CDI registry: %v", err)
-		}
-		if _, err = registry.InjectDevices(g.Config, devicePath); err != nil {
-			return fmt.Errorf("setting up CDI devices: %w", err)
-		}
+		// CDI devices are processed separately. Ignoring device.
 		return nil
 	}
 	devs := strings.Split(devicePath, ":")

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -20,25 +20,12 @@ import (
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
-	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 // DevicesFromPath computes a list of devices
-func DevicesFromPath(g *generate.Generator, devicePath string, config *config.Config) error {
+func DevicesFromPath(g *generate.Generator, devicePath string) error {
 	if isCDIDevice(devicePath) {
-		registry, err := cdi.NewCache(
-			cdi.WithSpecDirs(config.Engine.CdiSpecDirs.Get()...),
-			cdi.WithAutoRefresh(false),
-		)
-		if err != nil {
-			return fmt.Errorf("creating CDI registry: %w", err)
-		}
-		if err := registry.Refresh(); err != nil {
-			logrus.Debugf("The following error was triggered when refreshing the CDI registry: %v", err)
-		}
-		if _, err := registry.InjectDevices(g.Config, devicePath); err != nil {
-			return fmt.Errorf("setting up CDI devices: %w", err)
-		}
+		// CDI devices are processed separately. Ignoring device.
 		return nil
 	}
 	devs := strings.Split(devicePath, ":")

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -246,13 +246,9 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		logrus.Debugf("setting container name %s", s.Name)
 		options = append(options, libpod.WithName(s.Name))
 	}
-	if len(s.GPUs) > 0 {
-		options = append(options, libpod.WithGPUs(s.GPUs))
-	}
-	if len(s.Devices) > 0 {
-		opts = ExtractCDIDevices(s)
-		options = append(options, opts...)
-	}
+
+	options = append(options, ExtractCDIDevices(s, rtc.Containers.Devices.Get(), compatibleOptions.HostDeviceList)...)
+
 	runtimeSpec, err := SpecGenToOCI(ctx, s, rt, rtc, newImage, finalMounts, pod, command, compatibleOptions)
 	if err != nil {
 		return nil, nil, nil, err
@@ -326,23 +322,59 @@ func ExecuteCreate(ctx context.Context, rt *libpod.Runtime, runtimeSpec *specs.S
 }
 
 // ExtractCDIDevices process the list of Devices in the spec and determines if any of these are CDI devices.
-// The CDI devices are added to the list of CtrCreateOptions.
+// The CDI devices are added to the list of CtrCreateOptions and include CDI
+// devices that are directly requested as well as those inferred from the --gpus
+// flag, the container.conf, or default host devices if supported on the target
+// platform.
 // Note that this may modify the device list associated with the spec, which should then only contain non-CDI devices.
-func ExtractCDIDevices(s *specgen.SpecGenerator) []libpod.CtrCreateOption {
-	devs := make([]specs.LinuxDevice, 0, len(s.Devices))
-	var cdiDevs []string
+func ExtractCDIDevices(s *specgen.SpecGenerator, containerConfDevices []string, defaultHostDevices []specs.LinuxDevice) []libpod.CtrCreateOption {
 	var options []libpod.CtrCreateOption
 
+	// We track the devices requested as part of the --gpus flag separately.
+	if len(s.GPUs) > 0 {
+		options = append(options, libpod.WithGPUs(s.GPUs))
+	}
+
+	cdiDevs := make([]string, 0, len(s.Devices))
+	nonCDIDevices := make([]specs.LinuxDevice, 0, len(s.Devices))
 	for _, device := range s.Devices {
 		if isCDIDevice(device.Path) {
-			logrus.Debugf("Identified CDI device %v", device.Path)
+			logrus.Debugf("Identified CDI device from device flag %v", device.Path)
 			cdiDevs = append(cdiDevs, device.Path)
 			continue
 		}
 		logrus.Debugf("Non-CDI device %v; assuming standard device", device.Path)
-		devs = append(devs, device)
+		nonCDIDevices = append(nonCDIDevices, device)
 	}
-	s.Devices = devs
+
+	if len(cdiDevs) > 0 {
+		if len(nonCDIDevices) != 0 {
+			s.Devices = nonCDIDevices
+		} else {
+			var noDevices []specs.LinuxDevice
+			s.Devices = noDevices
+		}
+	}
+
+	if allowAdditionalCDIDevices(s) {
+		// CDI devices can also be specified in the containers.conf file:
+		for _, containerConfDevice := range containerConfDevices {
+			if isCDIDevice(containerConfDevice) {
+				logrus.Debugf("Identified CDI device from container.conf %v", containerConfDevice)
+				cdiDevs = append(cdiDevs, containerConfDevice)
+				continue
+			}
+		}
+
+		if len(s.Devices) == 0 {
+			for _, device := range defaultHostDevices {
+				if isCDIDevice(device.Path) {
+					logrus.Debugf("Identified CDI device from host_device_list flag %v", device.Path)
+					cdiDevs = append(cdiDevs, device.Path)
+				}
+			}
+		}
+	}
 	if len(cdiDevs) > 0 {
 		options = append(options, libpod.WithCDI(cdiDevs))
 	}

--- a/pkg/specgen/generate/container_create_test.go
+++ b/pkg/specgen/generate/container_create_test.go
@@ -1,0 +1,84 @@
+//go:build !remote && (linux || freebsd)
+
+package generate
+
+import (
+	"testing"
+
+	"github.com/containers/podman/v6/libpod"
+	"github.com/containers/podman/v6/pkg/specgen"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractCDIDevices(t *testing.T) {
+	testCases := []struct {
+		description          string
+		generator            specgen.SpecGenerator
+		containerConfDevices []string
+		defaultHostDevices   []specs.LinuxDevice
+		expectedOptions      []libpod.CtrCreateOption
+		expectedGenerator    specgen.SpecGenerator
+	}{
+		{
+			description: "no cdi devices does not update specgen",
+			generator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					Devices: []specs.LinuxDevice{
+						{Path: "/dev/foo"},
+					},
+				},
+			},
+			expectedGenerator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					Devices: []specs.LinuxDevice{
+						{Path: "/dev/foo"},
+					},
+				},
+			},
+		},
+		{
+			description: "cdi device is removed from generator",
+			generator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					Devices: []specs.LinuxDevice{
+						{Path: "example.com/class=device"},
+					},
+				},
+			},
+			expectedOptions: []libpod.CtrCreateOption{libpod.WithCDI([]string{"example.com/class=device"})},
+			expectedGenerator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					Devices: []specs.LinuxDevice{},
+				},
+			},
+		},
+		{
+			description: "cdi device is removed from generator with existing device",
+			generator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					Devices: []specs.LinuxDevice{
+						{Path: "example.com/class=device"},
+						{Path: "/dev/foo"},
+					},
+				},
+			},
+			expectedOptions: []libpod.CtrCreateOption{libpod.WithCDI([]string{"example.com/class=device"})},
+			expectedGenerator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					Devices: []specs.LinuxDevice{
+						{Path: "/dev/foo"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			options := ExtractCDIDevices(&tc.generator)
+			require.EqualValues(t, len(tc.expectedOptions), len(options))
+			require.EqualValues(t, tc.expectedGenerator, tc.generator)
+		})
+	}
+}

--- a/pkg/specgen/generate/container_create_test.go
+++ b/pkg/specgen/generate/container_create_test.go
@@ -48,9 +48,7 @@ func TestExtractCDIDevices(t *testing.T) {
 			},
 			expectedOptions: []libpod.CtrCreateOption{libpod.WithCDI([]string{"example.com/class=device"})},
 			expectedGenerator: specgen.SpecGenerator{
-				ContainerStorageConfig: specgen.ContainerStorageConfig{
-					Devices: []specs.LinuxDevice{},
-				},
+				ContainerStorageConfig: specgen.ContainerStorageConfig{},
 			},
 		},
 		{
@@ -72,11 +70,42 @@ func TestExtractCDIDevices(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "gpus flag adds options",
+			generator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					GPUs: []string{"all"},
+				},
+			},
+			expectedOptions: []libpod.CtrCreateOption{libpod.WithGPUs([]string{"all"})},
+			expectedGenerator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					GPUs: []string{"all"},
+				},
+			},
+		},
+		{
+			description: "gpus flag works with CDI devices",
+			generator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					GPUs: []string{"all"},
+					Devices: []specs.LinuxDevice{
+						{Path: "example.com/class=device"},
+					},
+				},
+			},
+			expectedOptions: []libpod.CtrCreateOption{libpod.WithGPUs([]string{"all"}), libpod.WithCDI([]string{"example.com/class=device"})},
+			expectedGenerator: specgen.SpecGenerator{
+				ContainerStorageConfig: specgen.ContainerStorageConfig{
+					GPUs: []string{"all"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			options := ExtractCDIDevices(&tc.generator)
+			options := ExtractCDIDevices(&tc.generator, tc.containerConfDevices, tc.defaultHostDevices)
 			require.EqualValues(t, len(tc.expectedOptions), len(options))
 			require.EqualValues(t, tc.expectedGenerator, tc.generator)
 		})

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -117,7 +117,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	if !s.IsPrivileged() {
 		// add default devices from containers.conf
 		for _, device := range rtc.Containers.Devices.Get() {
-			if err = DevicesFromPath(&g, device, rtc); err != nil {
+			if err = DevicesFromPath(&g, device); err != nil {
 				return nil, err
 			}
 		}
@@ -128,7 +128,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		}
 		// add default devices specified by caller
 		for _, device := range userDevices {
-			if err = DevicesFromPath(&g, device.Path, rtc); err != nil {
+			if err = DevicesFromPath(&g, device.Path); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -248,7 +248,7 @@ func SpecGenToOCI(_ context.Context, s *specgen.SpecGenerator, rt *libpod.Runtim
 	var userDevices []spec.LinuxDevice
 	// add default devices from containers.conf
 	for _, device := range rtc.Containers.Devices.Get() {
-		if err = DevicesFromPath(&g, device, rtc); err != nil {
+		if err = DevicesFromPath(&g, device); err != nil {
 			return nil, err
 		}
 	}
@@ -259,7 +259,7 @@ func SpecGenToOCI(_ context.Context, s *specgen.SpecGenerator, rt *libpod.Runtim
 	}
 	// add default devices specified by caller
 	for _, device := range userDevices {
-		if err = DevicesFromPath(&g, device.Path, rtc); err != nil {
+		if err = DevicesFromPath(&g, device.Path); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This PR is a response to https://github.com/containers/podman/pull/28008/changes#r2787912757

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

This changes how container.conf and host_device_list CDI devices
are handled. Instead of injecting these separately (requiring)
separate instatiations of a CDI cache, these are pre-processed to
extract the list of CDI device names. These CDI devices are then
added to the list of CDI devices names from explicit --device requests
and implicit requests from the --gpus flag.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
