### PR TITLE
fix: compat API image push err meg propagation

### DIFF
--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -189,15 +189,18 @@ loop: // break out of for/select infinite loop
 			flush()
 		case err := <-pushErrChan:
 			if err != nil {
-				var msg string
+				code := http.StatusInternalServerError
 				if errors.Is(err, storage.ErrImageUnknown) {
 					// Image may have been removed in the meantime.
-					writeStatusCode(http.StatusNotFound)
-					msg = "An image does not exist locally with the tag: " + imageName
-				} else {
-					writeStatusCode(http.StatusInternalServerError)
-					msg = err.Error()
+					code = http.StatusNotFound
+					err = errors.New("An image does not exist locally with the tag: " + imageName)
 				}
+				if !statusWritten {
+					utils.Error(w, code, err)
+					flush()
+					break loop
+				}
+				var msg = err.Error()
 				report.Error = &jsonstream.Error{
 					Message: msg,
 				}

--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -200,7 +200,7 @@ loop: // break out of for/select infinite loop
 					flush()
 					break loop
 				}
-				var msg = err.Error()
+				msg := err.Error()
 				report.Error = &jsonstream.Error{
 					Message: msg,
 				}

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -26,7 +26,7 @@ t GET libpod/images/$IMAGE/json 200 \
 
 # Push to local registry...
 t POST "/v1.40/images/localhost:$REGISTRY_PORT/myrepo/push?tag=mytag" 500 \
-  .error~".*x509: certificate signed by unknown authority"
+  .message~".*x509: certificate signed by unknown authority"
 t POST "images/localhost:$REGISTRY_PORT/myrepo/push?tlsVerify=false&tag=mytag" 200 \
   .error~null
 

--- a/test/python/docker/compat/test_images.py
+++ b/test/python/docker/compat/test_images.py
@@ -5,8 +5,10 @@ import io
 import os
 import unittest
 import json
+from typing import Iterator
 
 from docker import errors
+from docker.errors import APIError
 
 # pylint: disable=no-name-in-module,import-error,wrong-import-order
 from test.python.docker.compat import common, constant
@@ -134,6 +136,33 @@ class TestImages(common.DockerTestCase):
             except json.JSONDecodeError as e:
                 raise IOError(f"Line '{line}' was not JSON parsable")
             assert "errorDetail" not in parsed
+
+    def test_push_error(self):
+        """Validates that push error is correctly propagated"""
+        alpine = self.docker.images.get(constant.ALPINE)
+        if not alpine.tag("non-existent.lan:5000/alpine", "latest"):
+            self.fail("not tagged")
+        try:
+            resp: str = self.docker.images.push("non-existent.lan:5000/alpine", "latest")
+            for obj in json_stream(resp):
+                if 'no such host' in obj.get('errorDetail', {}).get('message', ''):
+                    return
+            self.fail('expected error not found in the response')
+        except APIError as e:
+            if 'no such host' not in e.explanation:
+                self.fail('expected error not found in the response')
+
+def json_stream(data: str) -> Iterator[dict]:
+    decoder = json.JSONDecoder()
+    pos = 0
+    length = len(data)
+    while pos < length:
+        if data[pos].isspace():
+            pos += 1
+            continue
+        obj, pos_end = decoder.raw_decode(data, pos)
+        yield obj
+        pos = pos_end
 
 if __name__ == "__main__":
     # Setup temporary space


### PR DESCRIPTION
When returning error http code (e.g. 4xx, 5xx) the body needs to contain a JSON that has a key `message` in it,
we must not use `jsonmessage.JSONMessage`.

The JSON of shape `jsonmessage.JSONMessage` is used only when client already received 200.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
