### PR TITLE
RFC: podman: Add support for blackhole routes

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -73,7 +73,7 @@ func networkCreateFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(subnetFlagName, completion.AutocompleteNone)
 
 	routeFlagName := "route"
-	flags.StringArrayVar(&networkCreateOptions.Routes, routeFlagName, nil, "static routes")
+	flags.StringArrayVar(&networkCreateOptions.Routes, routeFlagName, nil, "Static routes for this network. Format: <destination>,<gateway>[,<metric>] or <destination>,<type>[,<metric>] where type is blackhole, unreachable, or prohibit")
 	_ = cmd.RegisterFlagCompletionFunc(routeFlagName, completion.AutocompleteNone)
 
 	interfaceFlagName := "interface-name"
@@ -192,41 +192,57 @@ func networkCreate(cmd *cobra.Command, args []string) error {
 
 func parseRoute(routeStr string) (*types.Route, error) {
 	s := strings.Split(routeStr, ",")
-	var metric *uint32
 
-	if len(s) == 2 || len(s) == 3 {
-		dstStr := s[0]
-		gwStr := s[1]
+	if len(s) < 2 || len(s) > 3 {
+		return nil, fmt.Errorf("invalid route: %s\nFormat: --route <destination>,<gateway>[,<metric>] or --route <destination>,<type>[,<metric>] where type is blackhole, unreachable, or prohibit", routeStr)
+	}
 
-		destination, err := types.ParseCIDR(dstStr)
-		gateway := net.ParseIP(gwStr)
+	destination, err := types.ParseCIDR(s[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid route destination %s: %w", s[0], err)
+	}
 
-		if err != nil {
-			return nil, fmt.Errorf("invalid route destination %s", dstStr)
-		}
+	route := &types.Route{
+		Destination: destination,
+	}
 
-		if gateway == nil {
-			return nil, fmt.Errorf("invalid route gateway %s", gwStr)
-		}
-
-		if len(s) == 3 {
+	// Check if second field is a route type (blackhole, unreachable, prohibit)
+	secondField := strings.ToLower(s[1])
+	switch types.RouteType(secondField) {
+	case types.RouteTypeBlackhole, types.RouteTypeUnreachable, types.RouteTypeProhibit:
+		route.RouteType = types.RouteType(secondField)
+		// Parse optional metric from position 2
+		if len(s) >= 3 {
 			mtr, err := strconv.ParseUint(s[2], 10, 32)
 			if err != nil {
 				return nil, fmt.Errorf("invalid route metric %s", s[2])
 			}
 			x := uint32(mtr)
-			metric = &x
+			route.Metric = &x
 		}
-
-		r := types.Route{
-			Destination: destination,
-			Gateway:     gateway,
-			Metric:      metric,
-		}
-
-		return &r, nil
+		return route, nil
+	case types.RouteTypeUnicast:
+		return nil, fmt.Errorf("unicast route requires a gateway, format: --route <destination>,<gateway>[,<metric>]")
 	}
-	return nil, fmt.Errorf("invalid route: %s\nFormat: --route <destination in CIDR>,<gateway>,<metric (optional)>", routeStr)
+
+	// Regular unicast route with gateway
+	gateway := net.ParseIP(s[1])
+	if gateway == nil {
+		return nil, fmt.Errorf("invalid route gateway %s", s[1])
+	}
+	route.Gateway = gateway
+	route.RouteType = types.RouteTypeUnicast // Default
+
+	// Parse optional metric
+	if len(s) >= 3 {
+		mtr, err := strconv.ParseUint(s[2], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid route metric %s", s[2])
+		}
+		x := uint32(mtr)
+		route.Metric = &x
+	}
+	return route, nil
 }
 
 func parseRange(iprange string) (*types.LeaseRange, error) {

--- a/cmd/podman/networks/create_test.go
+++ b/cmd/podman/networks/create_test.go
@@ -1,0 +1,222 @@
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/common/libnetwork/types"
+)
+
+func TestParseRoute(t *testing.T) {
+	tests := []struct {
+		name        string
+		routeStr    string
+		want        *types.Route
+		wantErr     bool
+		errContains string
+	}{
+		// Valid unicast routes (2 fields)
+		{
+			name:     "unicast route with destination and gateway",
+			routeStr: "10.21.0.0/24,10.19.12.250",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Gateway:     net.ParseIP("10.19.12.250"),
+				RouteType:   types.RouteTypeUnicast,
+			},
+		},
+		// Valid unicast routes (3 fields with metric)
+		{
+			name:     "unicast route with destination, gateway and metric",
+			routeStr: "10.21.0.0/24,10.19.12.250,100",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Gateway:     net.ParseIP("10.19.12.250"),
+				Metric:      uint32Ptr(100),
+				RouteType:   types.RouteTypeUnicast,
+			},
+		},
+		// Valid blackhole routes (2 fields)
+		{
+			name:     "blackhole route with destination only",
+			routeStr: "10.21.0.0/24,blackhole",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				RouteType:   types.RouteTypeBlackhole,
+			},
+		},
+		// Valid blackhole routes (3 fields with metric)
+		{
+			name:     "blackhole route with destination and metric",
+			routeStr: "10.21.0.0/24,blackhole,200",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Metric:      uint32Ptr(200),
+				RouteType:   types.RouteTypeBlackhole,
+			},
+		},
+		// Valid unreachable routes
+		{
+			name:     "unreachable route with destination only",
+			routeStr: "192.168.100.0/24,unreachable",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "192.168.100.0/24"),
+				RouteType:   types.RouteTypeUnreachable,
+			},
+		},
+		{
+			name:     "unreachable route with destination and metric",
+			routeStr: "192.168.100.0/24,unreachable,150",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "192.168.100.0/24"),
+				Metric:      uint32Ptr(150),
+				RouteType:   types.RouteTypeUnreachable,
+			},
+		},
+		// Valid prohibit routes
+		{
+			name:     "prohibit route with destination only",
+			routeStr: "172.16.0.0/16,prohibit",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "172.16.0.0/16"),
+				RouteType:   types.RouteTypeProhibit,
+			},
+		},
+		{
+			name:     "prohibit route with destination and metric",
+			routeStr: "172.16.0.0/16,prohibit,50",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "172.16.0.0/16"),
+				Metric:      uint32Ptr(50),
+				RouteType:   types.RouteTypeProhibit,
+			},
+		},
+		// Case insensitivity for route types
+		{
+			name:     "blackhole route type uppercase",
+			routeStr: "10.21.0.0/24,BLACKHOLE",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				RouteType:   types.RouteTypeBlackhole,
+			},
+		},
+		{
+			name:     "unreachable route type mixed case",
+			routeStr: "10.21.0.0/24,Unreachable",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				RouteType:   types.RouteTypeUnreachable,
+			},
+		},
+		{
+			name:     "prohibit route type mixed case",
+			routeStr: "10.21.0.0/24,ProHiBit",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				RouteType:   types.RouteTypeProhibit,
+			},
+		},
+		// IPv6 routes
+		{
+			name:     "unicast IPv6 route",
+			routeStr: "fd00:1::/64,fd00::1",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "fd00:1::/64"),
+				Gateway:     net.ParseIP("fd00::1"),
+				RouteType:   types.RouteTypeUnicast,
+			},
+		},
+		{
+			name:     "blackhole IPv6 route",
+			routeStr: "fd00:2::/64,blackhole",
+			want: &types.Route{
+				Destination: mustParseCIDR(t, "fd00:2::/64"),
+				RouteType:   types.RouteTypeBlackhole,
+			},
+		},
+		// Invalid routes - too few fields
+		{
+			name:        "route with only destination",
+			routeStr:    "10.21.0.0/24",
+			wantErr:     true,
+			errContains: "invalid route",
+		},
+		// Invalid routes - too many fields
+		{
+			name:        "route with too many fields",
+			routeStr:    "10.21.0.0/24,10.19.12.250,100,extra",
+			wantErr:     true,
+			errContains: "invalid route",
+		},
+		// Invalid routes - unicast without gateway
+		{
+			name:        "unicast route type without gateway",
+			routeStr:    "10.21.0.0/24,unicast",
+			wantErr:     true,
+			errContains: "unicast route requires a gateway",
+		},
+		// Invalid routes - bad destination
+		{
+			name:        "invalid destination CIDR",
+			routeStr:    "invalid-cidr,10.19.12.250",
+			wantErr:     true,
+			errContains: "invalid route destination",
+		},
+		// Invalid routes - bad gateway
+		{
+			name:        "invalid gateway IP",
+			routeStr:    "10.21.0.0/24,invalid-gateway",
+			wantErr:     true,
+			errContains: "invalid route gateway",
+		},
+		// Invalid routes - bad metric
+		{
+			name:        "invalid metric for unicast route",
+			routeStr:    "10.21.0.0/24,10.19.12.250,invalid-metric",
+			wantErr:     true,
+			errContains: "invalid route metric",
+		},
+		{
+			name:        "invalid metric for blackhole route",
+			routeStr:    "10.21.0.0/24,blackhole,invalid-metric",
+			wantErr:     true,
+			errContains: "invalid route metric",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRoute(tt.routeStr)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.Destination.String(), got.Destination.String())
+			assert.Equal(t, tt.want.Gateway, got.Gateway)
+			assert.Equal(t, tt.want.RouteType, got.RouteType)
+			if tt.want.Metric != nil {
+				require.NotNil(t, got.Metric)
+				assert.Equal(t, *tt.want.Metric, *got.Metric)
+			} else {
+				assert.Nil(t, got.Metric)
+			}
+		})
+	}
+}
+
+func mustParseCIDR(t *testing.T, cidr string) types.IPNet {
+	t.Helper()
+	ipnet, err := types.ParseCIDR(cidr)
+	require.NoError(t, err)
+	return ipnet
+}
+
+func uint32Ptr(v uint32) *uint32 {
+	return &v
+}

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1221,6 +1221,31 @@ func SkipIfConmonVersionLessThan(minVersion string) {
 	}
 }
 
+// SkipIfNetavarkVersionLessThan skips a test if the netavark version is less than
+// the specified minimum version (e.g., "2.0.0").
+func SkipIfNetavarkVersionLessThan(minVersion string) {
+	out, err := exec.Command("netavark", "--version").Output()
+	if err != nil {
+		Fail(fmt.Sprintf("[netavark]: failed to get netavark version: %v", err))
+	}
+	// Output format: "netavark 1.14.0" or "netavark 2.0.0"
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) < 2 {
+		Fail(fmt.Sprintf("[netavark]: unexpected netavark --version output: %s", out))
+	}
+	current, err := semver.Parse(fields[1])
+	if err != nil {
+		Fail(fmt.Sprintf("[netavark]: failed to parse netavark version %q: %v", fields[1], err))
+	}
+	minVer, err := semver.Parse(minVersion)
+	if err != nil {
+		Fail(fmt.Sprintf("[netavark]: failed to parse minimum version %q: %v", minVersion, err))
+	}
+	if current.Compare(minVer) < 0 {
+		Skip(fmt.Sprintf("[netavark]: need netavark >= %s; have %s", minVersion, fields[1]))
+	}
+}
+
 // SkipIfNotActive skips a test if the given systemd unit is not active
 func SkipIfNotActive(unit string, reason string) {
 	checkReason(reason)

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -20,6 +20,10 @@ func removeNetworkDevice(name string) {
 	session.WaitWithDefaultTimeout()
 }
 
+func uintPtr(u uint32) *uint32 {
+	return &u
+}
+
 var _ = Describe("Podman network create", func() {
 	It("podman network create with name and subnet", func() {
 		netName := "subnet-" + stringid.GenerateRandomID()
@@ -711,4 +715,51 @@ var _ = Describe("Podman network create", func() {
 		// All we care about is the ip is from the range which allows for both.
 		Expect(containerIP.String()).To(Or(Equal("10.11.16.11"), Equal("10.11.16.12")), "ip address must be in --ip-range")
 	})
+
+	DescribeTable("podman network create with special route types",
+		func(subnet string, route string, expectedDest string, expectedRouteType types.RouteType, expectedMetric *uint32) {
+			SkipIfNetavarkVersionLessThan("2.0.0")
+			netName := "subnet-" + stringid.GenerateRandomID()
+			nc := podmanTest.Podman([]string{
+				"network",
+				"create",
+				"--subnet",
+				subnet,
+				"--route",
+				route,
+				netName,
+			})
+			nc.WaitWithDefaultTimeout()
+			defer podmanTest.removeNetwork(netName)
+			Expect(nc).Should(ExitCleanly())
+
+			inspect := podmanTest.Podman([]string{"network", "inspect", netName})
+			inspect.WaitWithDefaultTimeout()
+			Expect(inspect).Should(ExitCleanly())
+
+			var results []entities.NetworkInspectReport
+			err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			result := results[0]
+			Expect(result).To(HaveField("Name", netName))
+			Expect(result.Subnets).To(HaveLen(1))
+			Expect(result.Subnets[0].Subnet.String()).To(Equal(subnet))
+			Expect(result.Routes).To(HaveLen(1))
+			Expect(result.Routes[0].Destination.String()).To(Equal(expectedDest))
+			Expect(result.Routes[0].Gateway).To(BeNil())
+			Expect(result.Routes[0].RouteType).To(Equal(expectedRouteType))
+			if expectedMetric != nil {
+				Expect(*result.Routes[0].Metric).To(Equal(*expectedMetric))
+			} else {
+				Expect(result.Routes[0].Metric).To(BeNil())
+			}
+
+			defer removeNetworkDevice(result.NetworkInterface)
+		},
+		Entry("blackhole route", "10.19.20.0/24", "10.21.10.0/24,blackhole", "10.21.10.0/24", types.RouteTypeBlackhole, nil),
+		Entry("unreachable route", "10.19.21.0/24", "10.21.11.0/24,unreachable", "10.21.11.0/24", types.RouteTypeUnreachable, nil),
+		Entry("prohibit route", "10.19.22.0/24", "10.21.12.0/24,prohibit", "10.21.12.0/24", types.RouteTypeProhibit, nil),
+		Entry("blackhole route with metric", "10.19.23.0/24", "10.21.13.0/24,blackhole,250", "10.21.13.0/24", types.RouteTypeBlackhole, uintPtr(250)),
+	)
 })

--- a/vendor/go.podman.io/common/libnetwork/internal/util/validate.go
+++ b/vendor/go.podman.io/common/libnetwork/internal/util/validate.go
@@ -102,8 +102,20 @@ func ValidateRoute(route types.Route) error {
 		return errors.New("route destination mask nil")
 	}
 
-	if route.Gateway == nil {
-		return errors.New("route gateway nil")
+	// Validate route type and gateway requirements
+	switch route.RouteType {
+	case "", types.RouteTypeUnicast:
+		// Unicast routes require gateway
+		if route.Gateway == nil {
+			return errors.New("unicast route requires gateway")
+		}
+	case types.RouteTypeBlackhole, types.RouteTypeUnreachable, types.RouteTypeProhibit:
+		// Blackhole routes must NOT have gateway
+		if route.Gateway != nil {
+			return fmt.Errorf("%s route must not have a gateway", route.RouteType)
+		}
+	default:
+		return fmt.Errorf("invalid route type: %s", route.RouteType)
 	}
 
 	// Reparse to ensure destination is valid.

--- a/vendor/go.podman.io/common/libnetwork/internal/util/validate_test.go
+++ b/vendor/go.podman.io/common/libnetwork/internal/util/validate_test.go
@@ -1,0 +1,231 @@
+package util
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/common/libnetwork/types"
+)
+
+func TestValidateRoute(t *testing.T) {
+	tests := []struct {
+		name        string
+		route       types.Route
+		wantErr     bool
+		errContains string
+	}{
+		// Valid unicast routes with gateway
+		{
+			name: "valid unicast route with gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Gateway:     net.ParseIP("10.19.12.250"),
+				RouteType:   types.RouteTypeUnicast,
+			},
+		},
+		{
+			name: "valid unicast route with empty route type and gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Gateway:     net.ParseIP("10.19.12.250"),
+				RouteType:   "",
+			},
+		},
+		{
+			name: "valid unicast route with metric",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Gateway:     net.ParseIP("10.19.12.250"),
+				Metric:      uint32Ptr(100),
+				RouteType:   types.RouteTypeUnicast,
+			},
+		},
+		// Valid blackhole routes without gateway
+		{
+			name: "valid blackhole route without gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				RouteType:   types.RouteTypeBlackhole,
+			},
+		},
+		{
+			name: "valid blackhole route with metric",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Metric:      uint32Ptr(200),
+				RouteType:   types.RouteTypeBlackhole,
+			},
+		},
+		// Valid unreachable routes without gateway
+		{
+			name: "valid unreachable route without gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "192.168.100.0/24"),
+				RouteType:   types.RouteTypeUnreachable,
+			},
+		},
+		{
+			name: "valid unreachable route with metric",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "192.168.100.0/24"),
+				Metric:      uint32Ptr(150),
+				RouteType:   types.RouteTypeUnreachable,
+			},
+		},
+		// Valid prohibit routes without gateway
+		{
+			name: "valid prohibit route without gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "172.16.0.0/16"),
+				RouteType:   types.RouteTypeProhibit,
+			},
+		},
+		{
+			name: "valid prohibit route with metric",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "172.16.0.0/16"),
+				Metric:      uint32Ptr(50),
+				RouteType:   types.RouteTypeProhibit,
+			},
+		},
+		// IPv6 routes
+		{
+			name: "valid unicast IPv6 route",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "fd00:1::/64"),
+				Gateway:     net.ParseIP("fd00::1"),
+				RouteType:   types.RouteTypeUnicast,
+			},
+		},
+		{
+			name: "valid blackhole IPv6 route",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "fd00:2::/64"),
+				RouteType:   types.RouteTypeBlackhole,
+			},
+		},
+		// Invalid routes - unicast without gateway
+		{
+			name: "unicast route without gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				RouteType:   types.RouteTypeUnicast,
+			},
+			wantErr:     true,
+			errContains: "unicast route requires gateway",
+		},
+		{
+			name: "empty route type without gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				RouteType:   "",
+			},
+			wantErr:     true,
+			errContains: "unicast route requires gateway",
+		},
+		// Invalid routes - blackhole with gateway
+		{
+			name: "blackhole route with gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Gateway:     net.ParseIP("10.19.12.250"),
+				RouteType:   types.RouteTypeBlackhole,
+			},
+			wantErr:     true,
+			errContains: "blackhole route must not have a gateway",
+		},
+		// Invalid routes - unreachable with gateway
+		{
+			name: "unreachable route with gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "192.168.100.0/24"),
+				Gateway:     net.ParseIP("192.168.1.1"),
+				RouteType:   types.RouteTypeUnreachable,
+			},
+			wantErr:     true,
+			errContains: "unreachable route must not have a gateway",
+		},
+		// Invalid routes - prohibit with gateway
+		{
+			name: "prohibit route with gateway",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "172.16.0.0/16"),
+				Gateway:     net.ParseIP("172.16.1.1"),
+				RouteType:   types.RouteTypeProhibit,
+			},
+			wantErr:     true,
+			errContains: "prohibit route must not have a gateway",
+		},
+		// Invalid routes - invalid route type
+		{
+			name: "invalid route type",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.0/24"),
+				Gateway:     net.ParseIP("10.19.12.250"),
+				RouteType:   types.RouteType("invalid"),
+			},
+			wantErr:     true,
+			errContains: "invalid route type",
+		},
+		// Invalid routes - nil destination IP
+		{
+			name: "nil destination IP",
+			route: types.Route{
+				Destination: types.IPNet{IPNet: net.IPNet{IP: nil, Mask: net.CIDRMask(24, 32)}},
+				Gateway:     net.ParseIP("10.19.12.250"),
+				RouteType:   types.RouteTypeUnicast,
+			},
+			wantErr:     true,
+			errContains: "route destination ip nil",
+		},
+		// Invalid routes - nil destination mask
+		{
+			name: "nil destination mask",
+			route: types.Route{
+				Destination: types.IPNet{IPNet: net.IPNet{IP: net.ParseIP("10.21.0.0"), Mask: nil}},
+				Gateway:     net.ParseIP("10.19.12.250"),
+				RouteType:   types.RouteTypeUnicast,
+			},
+			wantErr:     true,
+			errContains: "route destination mask nil",
+		},
+		// Invalid routes - destination is an address not network
+		{
+			name: "destination is host address not network",
+			route: types.Route{
+				Destination: mustParseCIDR(t, "10.21.0.100/24"),
+				Gateway:     net.ParseIP("10.19.12.250"),
+				RouteType:   types.RouteTypeUnicast,
+			},
+			wantErr:     true,
+			errContains: "route destination invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRoute(tt.route)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func mustParseCIDR(t *testing.T, cidr string) types.IPNet {
+	t.Helper()
+	ipnet, err := types.ParseCIDR(cidr)
+	require.NoError(t, err)
+	return ipnet
+}
+
+func uint32Ptr(v uint32) *uint32 {
+	return &v
+}

--- a/vendor/go.podman.io/common/libnetwork/netavark/network.go
+++ b/vendor/go.podman.io/common/libnetwork/netavark/network.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libnetwork/internal/rootlessnetns"
 	"go.podman.io/common/libnetwork/internal/util"
@@ -357,6 +358,32 @@ func (n *netavarkNetwork) Len() int {
 // DefaultInterfaceName return the default cni bridge name, must be suffixed with a number.
 func (n *netavarkNetwork) DefaultInterfaceName() string {
 	return defaultBridgeName
+}
+
+// checkVersion checks if the netavark version is at least the required version.
+func (n *netavarkNetwork) checkVersion(minVersion string) error {
+	programVersion, err := version.Program(n.netavarkBinary)
+	if err != nil {
+		return fmt.Errorf("failed to get netavark version: %w", err)
+	}
+	// version.Program returns "netavark 1.2.3"
+	fields := strings.Fields(programVersion)
+	if len(fields) < 2 {
+		return fmt.Errorf("unexpected netavark version format: %q", programVersion)
+	}
+	versionStr := fields[1]
+	current, err := semver.Parse(versionStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse netavark version %q: %w", versionStr, err)
+	}
+	minVer, err := semver.Parse(minVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse minimum version %q: %w", minVersion, err)
+	}
+	if current.Compare(minVer) < 0 {
+		return fmt.Errorf("netavark version %s is less than required %s", programVersion, minVersion)
+	}
+	return nil
 }
 
 // NetworkInfo return the network information about binary path,

--- a/vendor/go.podman.io/common/libnetwork/netavark/run.go
+++ b/vendor/go.podman.io/common/libnetwork/netavark/run.go
@@ -39,6 +39,24 @@ func (n *netavarkNetwork) Setup(namespacePath string, options types.SetupOptions
 		return nil, err
 	}
 
+	// Check netavark version if blackhole routes are requested
+	for netName := range options.Networks {
+		net, err := n.getNetwork(netName)
+		if err != nil {
+			return nil, err
+		}
+		for _, route := range net.Routes {
+			if route.RouteType == types.RouteTypeBlackhole ||
+				route.RouteType == types.RouteTypeUnreachable ||
+				route.RouteType == types.RouteTypeProhibit {
+				if err := n.checkVersion("2.0.0-dev"); err != nil {
+					return nil, err
+				}
+				break
+			}
+		}
+	}
+
 	// allocate IPs in the IPAM db
 	err = n.allocIPs(&options.NetworkOptions)
 	if err != nil {

--- a/vendor/go.podman.io/common/libnetwork/types/network.go
+++ b/vendor/go.podman.io/common/libnetwork/types/network.go
@@ -201,15 +201,31 @@ type Subnet struct {
 	LeaseRange *LeaseRange `json:"lease_range,omitempty"`
 }
 
+// RouteType represents the type of a route.
+type RouteType string
+
+const (
+	// RouteTypeUnicast is a regular route with a gateway (default).
+	RouteTypeUnicast RouteType = "unicast"
+	// RouteTypeBlackhole silently discards packets.
+	RouteTypeBlackhole RouteType = "blackhole"
+	// RouteTypeUnreachable rejects with "destination unreachable".
+	RouteTypeUnreachable RouteType = "unreachable"
+	// RouteTypeProhibit rejects with "administratively prohibited".
+	RouteTypeProhibit RouteType = "prohibit"
+)
+
 type Route struct {
 	// Destination for this route in CIDR form.
 	// swagger:strfmt string
 	Destination IPNet `json:"destination"`
-	// Gateway IP for this route.
+	// Gateway IP for this route. Required for unicast routes, must be empty for blackhole/unreachable/prohibit.
 	// swagger:strfmt string
-	Gateway net.IP `json:"gateway"`
+	Gateway net.IP `json:"gateway,omitempty"`
 	// Metric for this route. Optional.
 	Metric *uint32 `json:"metric,omitempty"`
+	// RouteType is the type of route: unicast (default), blackhole, unreachable, prohibit.
+	RouteType RouteType `json:"route_type,omitempty"`
 }
 
 // LeaseRange contains the range where IP are leased.


### PR DESCRIPTION
Add support for blackhole, unreachable, and prohibit route types in podman networks. These route types allow silently discarding packets (blackhole), rejecting with destination unreachable (unreachable), or rejecting with administratively prohibited (prohibit).

Blackhole routes require netavark >= 2.0.0. Regular unicast routes remain backward compatible with all netavark versions.

Likely fixes https://github.com/containers/podman/issues/20222

Exposes this netavark feature: https://github.com/containers/netavark/pull/1417

Currently market as draft to get early feedback before I move libnetwork changes to common repository.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Add support for blackhole, unreachable, and prohibit route types in podman networks. Supported since netavark 2.0.
```
