### PR TITLE
Add list command to pod command --help

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -27,6 +27,7 @@ var (
 	psDescription = "Prints out information about the containers"
 	psCommand     = &cobra.Command{
 		Use:               "ps [options]",
+		Aliases:           []string{"ls", "list"},
 		Short:             "List containers",
 		Long:              psDescription,
 		RunE:              ps,
@@ -35,6 +36,18 @@ var (
 		Example: `podman ps -a
 podman ps -a --format "{{.ID}}  {{.Image}}  {{.Labels}}  {{.Mounts}}"
 podman ps --size --sort names`,
+	}
+
+	listCommand = &cobra.Command{
+		Use:               "list [options]",
+		Short:             "List containers",
+		Long:              psDescription,
+		RunE:              ps,
+		Args:              validate.NoArgs,
+		ValidArgsFunction: completion.AutocompleteNone,
+		Example: `podman ps -a
+  podman list -a --format "{{.ID}}  {{.Image}}  {{.Labels}}  {{.Mounts}}"
+  podman ls --size --sort names`,
 	}
 
 	psContainerCommand = &cobra.Command{
@@ -59,6 +72,9 @@ var (
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: psCommand,
+	})
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: listCommand,
 	})
 	listFlagSet(psCommand)
 	validate.AddLatestFlag(psCommand, &listOpts.Latest)

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -34,6 +34,15 @@ var (
 		Args:              validate.NoArgs,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
+	listCmd = &cobra.Command{
+		Use:               "list [options]",
+		Aliases:           []string{"ls", "ps"},
+		Short:             "List pods",
+		Long:              psDescription,
+		RunE:              pods,
+		Args:              validate.NoArgs,
+		ValidArgsFunction: completion.AutocompleteNone,
+	}
 )
 
 var (
@@ -45,6 +54,10 @@ var (
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: psCmd,
+		Parent:  podCmd,
+	})
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: listCmd,
 		Parent:  podCmd,
 	})
 	flags := psCmd.Flags()

--- a/docs/source/markdown/links/podman-list.1
+++ b/docs/source/markdown/links/podman-list.1
@@ -1,0 +1,1 @@
+.so man1/podman-ps.1

--- a/docs/source/markdown/links/podman-pod-list.1
+++ b/docs/source/markdown/links/podman-pod-list.1
@@ -1,0 +1,1 @@
+.so man1/podman-ps.1

--- a/docs/source/markdown/podman-pod.1.md
+++ b/docs/source/markdown/podman-pod.1.md
@@ -18,6 +18,7 @@ podman pod is a set of subcommands that manage pods, or groups of containers.
 | exists  | [podman-pod-exists(1)](podman-pod-exists.1.md)    | Check if a pod exists in local storage.                                           |
 | inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)  | Display information describing a pod.                                             |
 | kill    | [podman-pod-kill(1)](podman-pod-kill.1.md)        | Kill the main process of each container in one or more pods.                      |
+| list    | [podman-pod-ps(1)](podman-pod-ps.1.md)            | Print out information about pods.(alias ls)                                       |
 | logs    | [podman-pod-logs(1)](podman-pod-logs.1.md)        | Display logs for pod with one or more containers.                                 |
 | pause   | [podman-pod-pause(1)](podman-pod-pause.1.md)      | Pause one or more pods.                                                           |
 | prune   | [podman-pod-prune(1)](podman-pod-prune.1.md)      | Remove all stopped pods and their containers.                                     |

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -379,6 +379,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-init(1)](podman-init.1.md)               | Initialize one or more containers                                            |
 | [podman-inspect(1)](podman-inspect.1.md)         | Display artifact, container, image, volume, network, or pod's configuration. |
 | [podman-kill(1)](podman-kill.1.md)               | Kill the main process in one or more containers.                             |
+| [podman-list(1)](podman-ps.1.md)                 | Print out information about containers.                                      |
 | [podman-load(1)](podman-load.1.md)               | Load image(s) from a tar archive into container storage.                     |
 | [podman-login(1)](podman-login.1.md)             | Log in to a container registry.                                              |
 | [podman-logout(1)](podman-logout.1.md)           | Log out of a container registry.                                             |

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -37,6 +37,41 @@ for md in *.1.md;do
     fi
 done
 
+# Function: verify_list_and_ps_presence
+# When dealing with the list and ps commands, we can have two instances 
+# with the same description text from the parent.  Allow that for these commands.
+#
+# Arguments: 
+#   $1: The string to search
+#      When present, it should look like:
+#      "| [podman-list(1)](podman-ps.1.md) | Print out information about containers. | | [podman-ps(1)](podman-ps.1.md) | Print out information about containers. |
+#   $2: The description text to count.  From the above example that would be "Print out information about containers"
+verify_list_and_ps_presence() {
+    local input="$1"
+    local desc="$2"
+    local status=0
+
+    # 1. Check for two instances of "-ps.1.md)" 
+    count=$(echo "$input" | grep -o "\-ps\.1\.md" | wc -l)
+
+    if [ "$count" -ne 2 ]; then
+        echo "Error: Expected 2 instances of '-ps.1.md', but found $count."
+        status=1
+    fi
+
+    # 2. Count occurrences of the description, we expect 2 instances.
+    # Using 'grep -F' for fixed-string matching (faster and safer for plain text)
+    local count
+    count=$(echo "$input" | grep -oF "$desc" | wc -l)
+
+    if [[ "$count" -ne 2 ]]; then
+        echo " Expected 2 instances of description '$desc', found: $count"
+        status=1
+    fi
+
+    return $status
+}
+
 # Pass 2: compare descriptions.
 #
 # Make sure the descriptive text in podman-foo.1.md matches the one
@@ -63,13 +98,16 @@ for md in $(ls -1 *-*.1.md | grep -v remote);do
     parent_desc=$(grep $md $parent | awk -F'|' "{print \$$x}" | sed -e 's/^ \+//' -e 's/ \+$//' -e 's/\.$//')
 
     if [ "$desc" != "$parent_desc" ]; then
-        echo
-        printf "Inconsistent subcommand descriptions:\n"
-        printf "  %-32s = '%s'\n" $md "$desc"
-        printf "  %-32s = '%s'\n" $parent "$parent_desc"
-        printf "Please ensure that the NAME section of $md\n"
-        printf "matches the subcommand description in $parent\n"
-        rc=1
+       find_entries_in_parent=$(grep $md $parent)
+       if ! verify_list_and_ps_presence "$find_entries_in_parent" "$desc"; then
+          echo
+          printf "Inconsistent subcommand descriptions:\n"
+          printf "  %-32s = '%s'\n" $md "$desc"
+          printf "  %-32s = '%s'\n" $parent "$parent_desc"
+          printf "Please ensure that the NAME section of $md\n"
+          printf "matches the subcommand description in $parent\n"
+          rc=1
+       fi
     fi
 done
 

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -264,6 +264,11 @@ sub xref_by_help {
             }
         }
         else {
+            # As 'list' is an alias pointing to 'ps', there is no
+            # need to search for the non-existant list man page.
+            if ($k eq "list") {
+                next OPTION;
+            }
             # Not documented in man. However, handle '...' as a special case
             # in formatting strings. E.g., 'podman info .Host' is documented
             # in the man page as '.Host ...' to indicate that the subfields
@@ -378,8 +383,12 @@ sub xref_rst {
             }
         }
         else {
-            warn "$ME: Not found in rst: $k\n";
-            ++$Errs;
+            # The 'list' command is an alias for 'ps' and
+            # an entry for it will never be found.
+            if ($k ne "list") {
+                warn "$ME: Not found in rst: $k\n";
+                ++$Errs;
+            }
          }
     }
 
@@ -612,10 +621,16 @@ sub podman_man {
         # The format is slightly different between podman.1.md and subcommands.
         elsif ($section eq 'commands') {
             # In podman.1.md
+
             if ($line =~ /^\|\s*\[podman-(\S+?)\(\d\)\]/) {
-                # $1 will be changed by recursion _*BEFORE*_ left-hand assignment
-                my $subcmd = $1;
-                $man{$subcmd} = podman_man("podman-$subcmd");
+                # Some of the list man pages are only pointers to ps.
+                # If the main page has a 'list' manpage reference pointing
+                # at a 'ps' man page, skip this instance.
+                unless (index($line, "-list") != -1 && index($line, "-ps") != -1) {
+                    # $1 will be changed by recursion _*BEFORE*_ left-hand assignment
+                    my $subcmd = $1;
+                    $man{$subcmd} = podman_man("podman-$subcmd");
+                }
             }
 
             # In podman-<subcommand>.1.md
@@ -630,18 +645,23 @@ sub podman_man {
                     warn "$ME: $subpath:$.: duplicate subcommand '$subcmd'\n";
                     ++$Errs;
                 }
-                $previous_subcmd = $subcmd;
-                $man{$subcmd} = podman_man($link_name);
+                # Some of the list man pages are only pointers to ps.
+                # If the main page has a 'list' manpage reference pointing
+                # at a 'ps' man page, skip this instance.
+                unless (index($line, "-list") != -1 && index($line, "-ps") != -1) {
+                    $previous_subcmd = $subcmd;
+                    $man{$subcmd} = podman_man($link_name);
 
-                # Check for inconsistencies between the displayed man page name
-                # and the actual man page name, e.g.
-                #  '[podman-bar(1)](podman-baz.1.md)
-                $shown_name =~ s/\(\d\)$//;
-                $shown_name =~ s/\\//g;         # backslashed hyphens
-                (my $should_be = $link_name) =~ s/\.1\.md$//;
-                if ($shown_name ne $should_be) {
-                    warn "$ME: $subpath:$.: '$shown_name' should be '$should_be' in '$blob'\n";
-                    ++$Errs;
+                    # Check for inconsistencies between the displayed man page name
+                    # and the actual man page name, e.g.
+                    #  '[podman-bar(1)](podman-baz.1.md)
+                    $shown_name =~ s/\(\d\)$//;
+                    $shown_name =~ s/\\//g;         # backslashed hyphens
+                    (my $should_be = $link_name) =~ s/\.1\.md$//;
+                    if ($shown_name ne $should_be) {
+                        warn "$ME: $subpath:$.: '$shown_name' should be '$should_be' in '$blob'\n";
+                        ++$Errs;
+                    }
                 }
             }
         }


### PR DESCRIPTION
We had neglected to add the list command to the podman pod
command table.  It is an alias for ps.

Also do the same for the containers command while we're here.

This also required some hackery in our scripts that validate our
man pages during the CI runs.  Due to adding 'list' in a few places,
we came upon two hits of 'ps' in the man pages that the scripts
did not like.  Also, the scripts check the `help` output, and by
adding `list` there, things went south.

I had tried to tighten that logic up in those scripts, if you
have thoughts on making them better, I'd appreciate it.

My bash was very rusty, and my Perl was a bit rusty.  I made
good use of Gemini for the changes in the scripts.

Fixes: https://issues.redhat.com/browse/RHEL-99879

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
