### PR TITLE
kube play: resolve relative hostPath paths for remote connections

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -22,11 +23,13 @@ import (
 	"github.com/containers/podman/v6/pkg/annotations"
 	"github.com/containers/podman/v6/pkg/domain/entities"
 	"github.com/containers/podman/v6/pkg/errorhandling"
+	"github.com/containers/podman/v6/pkg/specgen"
 	"github.com/containers/podman/v6/pkg/util"
 	"github.com/spf13/cobra"
 	"go.podman.io/common/pkg/auth"
 	"go.podman.io/common/pkg/completion"
 	"go.podman.io/image/v5/types"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 // playKubeOptionsWrapper allows for separating CLI-only fields from API-only
@@ -380,6 +383,13 @@ func readerFromArgsWithStdin(args []string, stdin io.Reader) (*bytes.Reader, err
 		if err != nil {
 			return nil, err
 		}
+		if registry.IsRemote() {
+			// Resolve relative hostPath paths using the current working directory.
+			// The server does not know the client's working directory.
+			if cwd, err := os.Getwd(); err == nil {
+				data, _ = resolveRelativeHostPaths(data, cwd)
+			}
+		}
 		return bytes.NewReader(data), nil
 	}
 
@@ -415,8 +425,125 @@ func readerFromArg(fileOrURL string) (io.ReadCloser, error) {
 		}
 		return response.Body, nil
 	default:
-		return os.Open(fileOrURL)
+		f, err := os.Open(fileOrURL)
+		if err != nil {
+			return nil, err
+		}
+		if !registry.IsRemote() {
+			return f, nil
+		}
+		// In remote mode, resolve relative hostPath paths to absolute paths before
+		// sending the YAML to the server. The server cannot know the client's working
+		// directory, so relative paths would be incorrectly resolved against the
+		// server's cwd (typically /).
+		defer f.Close()
+		content, err := io.ReadAll(f)
+		if err != nil {
+			return nil, err
+		}
+		absPath, err := filepath.Abs(fileOrURL)
+		if err != nil {
+			return nil, err
+		}
+		resolved, err := resolveRelativeHostPaths(content, filepath.Dir(absPath))
+		if err != nil {
+			return nil, err
+		}
+		return io.NopCloser(bytes.NewReader(resolved)), nil
 	}
+}
+
+// resolveRelativeHostPaths parses the YAML content and rewrites any relative
+// hostPath.path values to absolute paths resolved against baseDir. This is
+// needed for remote connections where the server does not know the client cwd.
+// Returns the original content unchanged if no relative paths are found.
+func resolveRelativeHostPaths(content []byte, baseDir string) ([]byte, error) {
+	decoder := yamlv3.NewDecoder(bytes.NewReader(content))
+	var documents []*yamlv3.Node
+	modified := false
+
+	for {
+		var node yamlv3.Node
+		if err := decoder.Decode(&node); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// Return original content if we cannot parse.
+			return content, nil
+		}
+		if resolveHostPathsInNode(&node, baseDir) {
+			modified = true
+		}
+		documents = append(documents, &node)
+	}
+
+	if !modified {
+		return content, nil
+	}
+
+	var buf bytes.Buffer
+	encoder := yamlv3.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	for _, doc := range documents {
+		if err := encoder.Encode(doc); err != nil {
+			return content, nil
+		}
+	}
+	if err := encoder.Close(); err != nil {
+		return content, nil
+	}
+	return buf.Bytes(), nil
+}
+
+// resolveHostPathsInNode recursively walks a yaml.Node tree and converts any
+// relative hostPath.path scalar values to absolute paths under baseDir.
+// On Windows/WSL hosts the absolute path is further converted to the Linux
+// guest path expected by the Podman Machine (e.g. C:\foo → /mnt/c/foo).
+// Returns true if any path was modified.
+func resolveHostPathsInNode(node *yamlv3.Node, baseDir string) bool {
+	modified := false
+	switch node.Kind {
+	case yamlv3.DocumentNode:
+		for _, child := range node.Content {
+			if resolveHostPathsInNode(child, baseDir) {
+				modified = true
+			}
+		}
+	case yamlv3.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+			if key.Value == "hostPath" && value.Kind == yamlv3.MappingNode {
+				// Look only at the direct children of the hostPath map.
+				for j := 0; j+1 < len(value.Content); j += 2 {
+					pathKey := value.Content[j]
+					pathVal := value.Content[j+1]
+					if pathKey.Value == "path" && pathVal.Kind == yamlv3.ScalarNode {
+						if !filepath.IsAbs(pathVal.Value) {
+							abs := filepath.Join(baseDir, pathVal.Value)
+							// ConvertWinMountPath is a no-op on non-Windows/WSL hosts.
+							if converted, err := specgen.ConvertWinMountPath(abs); err == nil {
+								abs = converted
+							}
+							pathVal.Value = abs
+							modified = true
+						}
+					}
+				}
+			} else {
+				if resolveHostPathsInNode(value, baseDir) {
+					modified = true
+				}
+			}
+		}
+	case yamlv3.SequenceNode:
+		for _, child := range node.Content {
+			if resolveHostPathsInNode(child, baseDir) {
+				modified = true
+			}
+		}
+	}
+	return modified
 }
 
 func teardown(body io.Reader, options entities.PlayKubeDownOptions) error {

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -419,11 +419,16 @@ func readerFromArgsWithStdin(args []string, stdin io.Reader) (*bytes.Reader, err
 func readerFromArg(fileOrURL string) (io.ReadCloser, error) {
 	switch {
 	case parse.ValidWebURL(fileOrURL) == nil:
-		response, err := http.Get(fileOrURL)
+		response, err := http.Get(fileOrURL) //nolint:noctx
 		if err != nil {
 			return nil, err
 		}
-		return response.Body, nil
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			return nil, err
+		}
+		return io.NopCloser(bytes.NewReader(body)), nil
 	default:
 		f, err := os.Open(fileOrURL)
 		if err != nil {
@@ -486,11 +491,11 @@ func resolveRelativeHostPaths(content []byte, baseDir string) ([]byte, error) {
 	encoder.SetIndent(2)
 	for _, doc := range documents {
 		if err := encoder.Encode(doc); err != nil {
-			return content, nil
+			return content, err
 		}
 	}
 	if err := encoder.Close(); err != nil {
-		return content, nil
+		return content, err
 	}
 	return buf.Bytes(), nil
 }
@@ -530,10 +535,8 @@ func resolveHostPathsInNode(node *yamlv3.Node, baseDir string) bool {
 						}
 					}
 				}
-			} else {
-				if resolveHostPathsInNode(value, baseDir) {
-					modified = true
-				}
+			} else if resolveHostPathsInNode(value, baseDir) {
+				modified = true
 			}
 		}
 	case yamlv3.SequenceNode:

--- a/cmd/podman/kube/play_test.go
+++ b/cmd/podman/kube/play_test.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -145,5 +146,116 @@ func TestReaderFromArgs_Stdin(t *testing.T) {
 
 	if got := string(data); got != namespaceYAML {
 		t.Errorf("unexpected stdin result:\n--- got ---\n%s\n--- want ---\n%s", got, namespaceYAML)
+	}
+}
+
+func TestResolveRelativeHostPaths(t *testing.T) {
+	baseDir := "/some/base/dir"
+
+	tests := []struct {
+		name     string
+		input    string
+		wantPath string // expected value of hostPath.path after resolution
+	}{
+		{
+			name: "relative dot-slash path is resolved",
+			input: strings.Join([]string{
+				"apiVersion: v1",
+				"kind: Pod",
+				"spec:",
+				"  volumes:",
+				"  - name: html",
+				"    hostPath:",
+				"      path: ./html",
+				"      type: Directory",
+			}, "\n"),
+			wantPath: filepath.Join(baseDir, "html"),
+		},
+		{
+			name: "relative bare path is resolved",
+			input: strings.Join([]string{
+				"apiVersion: v1",
+				"kind: Pod",
+				"spec:",
+				"  volumes:",
+				"  - name: data",
+				"    hostPath:",
+				"      path: data/subdir",
+				"      type: Directory",
+			}, "\n"),
+			wantPath: filepath.Join(baseDir, "data/subdir"),
+		},
+		{
+			name: "absolute path is left unchanged",
+			input: strings.Join([]string{
+				"apiVersion: v1",
+				"kind: Pod",
+				"spec:",
+				"  volumes:",
+				"  - name: html",
+				"    hostPath:",
+				"      path: /absolute/path",
+				"      type: Directory",
+			}, "\n"),
+			wantPath: "/absolute/path",
+		},
+		{
+			name: "no hostPath volumes — content passes through",
+			input: strings.Join([]string{
+				"apiVersion: v1",
+				"kind: Pod",
+				"metadata:",
+				"  name: my-pod",
+			}, "\n"),
+			wantPath: "", // no hostPath to check
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := resolveRelativeHostPaths([]byte(tt.input), baseDir)
+			if err != nil {
+				t.Fatalf("resolveRelativeHostPaths returned error: %v", err)
+			}
+			if tt.wantPath == "" {
+				return
+			}
+			outStr := string(out)
+			if !strings.Contains(outStr, tt.wantPath) {
+				t.Errorf("expected output to contain path %q\ngot:\n%s", tt.wantPath, outStr)
+			}
+		})
+	}
+}
+
+func TestResolveRelativeHostPaths_MultiDoc(t *testing.T) {
+	baseDir := "/base"
+	input := strings.Join([]string{
+		"apiVersion: v1",
+		"kind: Pod",
+		"spec:",
+		"  volumes:",
+		"  - name: vol1",
+		"    hostPath:",
+		"      path: ./vol1",
+		"---",
+		"apiVersion: v1",
+		"kind: Pod",
+		"spec:",
+		"  volumes:",
+		"  - name: vol2",
+		"    hostPath:",
+		"      path: ./vol2",
+	}, "\n")
+
+	out, err := resolveRelativeHostPaths([]byte(input), baseDir)
+	if err != nil {
+		t.Fatalf("resolveRelativeHostPaths returned error: %v", err)
+	}
+	outStr := string(out)
+	for _, want := range []string{filepath.Join(baseDir, "vol1"), filepath.Join(baseDir, "vol2")} {
+		if !strings.Contains(outStr, want) {
+			t.Errorf("expected output to contain %q\ngot:\n%s", want, outStr)
+		}
 	}
 }

--- a/cmd/podman/kube/play_test.go
+++ b/cmd/podman/kube/play_test.go
@@ -6,7 +6,25 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/containers/podman/v6/pkg/specgen"
 )
+
+// expectedPath mirrors the exact decision tree of resolveHostPathsInNode:
+//   - if path is already absolute on this OS, return it unchanged;
+//   - otherwise join it with base and run ConvertWinMountPath so the result
+//     matches the actual output on every platform (e.g. C:\foo→/mnt/c/foo on
+//     Windows/WSL, no-op on Linux/macOS).
+func expectedPath(base, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	abs := filepath.Join(base, path)
+	if converted, err := specgen.ConvertWinMountPath(abs); err == nil {
+		return converted
+	}
+	return abs
+}
 
 var configMapYAML = strings.Join([]string{
 	"apiVersion: v1",
@@ -169,7 +187,7 @@ func TestResolveRelativeHostPaths(t *testing.T) {
 				"      path: ./html",
 				"      type: Directory",
 			}, "\n"),
-			wantPath: filepath.Join(baseDir, "html"),
+			wantPath: expectedPath(baseDir, "html"),
 		},
 		{
 			name: "relative bare path is resolved",
@@ -183,10 +201,10 @@ func TestResolveRelativeHostPaths(t *testing.T) {
 				"      path: data/subdir",
 				"      type: Directory",
 			}, "\n"),
-			wantPath: filepath.Join(baseDir, "data/subdir"),
+			wantPath: expectedPath(baseDir, "data/subdir"),
 		},
 		{
-			name: "absolute path is left unchanged",
+			name: "absolute path is passed through",
 			input: strings.Join([]string{
 				"apiVersion: v1",
 				"kind: Pod",
@@ -197,7 +215,11 @@ func TestResolveRelativeHostPaths(t *testing.T) {
 				"      path: /absolute/path",
 				"      type: Directory",
 			}, "\n"),
-			wantPath: "/absolute/path",
+			// On Linux/macOS filepath.IsAbs("/absolute/path") is true so the
+			// path is not modified. On Windows it is false (no drive letter),
+			// so ConvertWinMountPath converts it. expectedPath mirrors the
+			// exact IsAbs check the production code uses.
+			wantPath: expectedPath(baseDir, "/absolute/path"),
 		},
 		{
 			name: "no hostPath volumes — content passes through",
@@ -253,7 +275,7 @@ func TestResolveRelativeHostPaths_MultiDoc(t *testing.T) {
 		t.Fatalf("resolveRelativeHostPaths returned error: %v", err)
 	}
 	outStr := string(out)
-	for _, want := range []string{filepath.Join(baseDir, "vol1"), filepath.Join(baseDir, "vol2")} {
+	for _, want := range []string{expectedPath(baseDir, "vol1"), expectedPath(baseDir, "vol2")} {
 		if !strings.Contains(outStr, want) {
 			t.Errorf("expected output to contain %q\ngot:\n%s", want, outStr)
 		}


### PR DESCRIPTION
In remote mode (macOS, Windows, WSL2 with Podman Machine), `podman kube play` sends raw YAML bytes to the server. The server has no knowledge of the client's working directory, so a relative hostPath such as `./html` is resolved against the server's cwd (typically `/`), resulting in errors like `statfs /html: no such file or directory`.

Fix this by pre-processing the YAML on the client side before it is transmitted to the server. The new `resolveRelativeHostPaths` helper parses the YAML with gopkg.in/yaml.v3, walks the document tree, and rewrites every `hostPath.path` value that is not absolute into an absolute path anchored to the directory containing the YAML file (or the current working directory when reading from stdin). On Windows and WSL hosts the resulting absolute path is additionally run through `specgen.ConvertWinMountPath` so that Windows drive paths (e.g. `C:\Users\...`) are translated to the `/mnt/c/...` form expected by the Podman Machine Linux guest.

The transformation is a no-op — original bytes are returned unchanged — when no relative paths are present, preserving existing behaviour for YAML that uses only absolute paths or has no hostPath volumes at all.

Fixes: https://github.com/containers/podman/issues/25437

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
