### PR TITLE
docs: share --reload-systemd option between quadlet install and rm

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -55,7 +55,9 @@ podman-port.1.md
 podman-ps.1.md
 podman-pull.1.md
 podman-push.1.md
+podman-quadlet-install.1.md
 podman-quadlet-list.1.md
+podman-quadlet-rm.1.md
 podman-restart.1.md
 podman-rm.1.md
 podman-run.1.md

--- a/docs/source/markdown/options/reload-systemd.md
+++ b/docs/source/markdown/options/reload-systemd.md
@@ -1,0 +1,9 @@
+####> This option file is used in:
+####>   podman quadlet install, quadlet rm
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--reload-systemd**
+
+Reload systemd after the operation completes (default true).
+In order to disable it users need to manually set the value
+of this flag to `false`.

--- a/docs/source/markdown/podman-quadlet-install.1.md.in
+++ b/docs/source/markdown/podman-quadlet-install.1.md.in
@@ -37,11 +37,7 @@ directory with the application name. The application name is required when
 specifying a directory path. An application name can't have a quadlet extension
 as suffix. For example `foo.container` isn't a valid application name.
 
-#### **--reload-systemd**
-
-Reload systemd after installing Quadlets (default true).
-In order to disable it users need to manually set the value
-of this flag to `false`.
+@@option reload-systemd
 
 #### **--replace**, **-r**
 

--- a/docs/source/markdown/podman-quadlet-rm.1.md.in
+++ b/docs/source/markdown/podman-quadlet-rm.1.md.in
@@ -33,11 +33,7 @@ Do not error for Quadlets that do not exist.
 
 Required when removing applications (default false).
 
-#### **--reload-systemd**
-
-Reload systemd after removing Quadlets (default true).
-In order to disable it users need to manually set the value
-of this flag to `false`.
+@@option reload-systemd
 
 ## EXAMPLES
 


### PR DESCRIPTION
Extract the `--reload-systemd` option text into a shared option file
and reference it with `@@option` in both manpages, following the
established pattern for shared options.

Changes:
- Create `docs/source/markdown/options/reload-systemd.md` with the shared option text
- Rename `podman-quadlet-install.1.md` to `.md.in` and use `@@option reload-systemd`
- Rename `podman-quadlet-rm.1.md` to `.md.in` and use `@@option reload-systemd`

Fixes #28370