### PR TITLE
docs: fix [Build] Volume= to not reference named volumes

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -2059,7 +2059,7 @@ the `--volume` option of `podman build`, and has the form
 
 If `HOST-DIR` starts with `.`, Quadlet resolves the path relative to the location of the unit file.
 
-Note: unlike the `[Container]` section's `Volume=`, this option does not support named volumes or `.volume` Quadlet unit references, because `podman build --volume` only supports host directory bind mounts.
+Note: `podman build --volume` only supports host directory bind mounts. Because of this, `.volume` references and named volumes may not work as expected, even though Quadlet resolves them.
 
 This key can be listed multiple times.
 

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -2053,15 +2053,13 @@ This is equivalent to the `--variant` option of `podman build`.
 
 ### `Volume=`
 
-Mount a volume to containers when executing RUN instructions during the build. This is equivalent to
-the `--volume` option of `podman build`, and generally has the form
-`[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]`.
+Mount a host directory into containers when executing RUN instructions during the build. This is equivalent to
+the `--volume` option of `podman build`, and has the form
+`[HOST-DIR:]CONTAINER-DIR[:OPTIONS]`.
 
-If `SOURCE-VOLUME` starts with `.`, Quadlet resolves the path relative to the location of the unit file.
+If `HOST-DIR` starts with `.`, Quadlet resolves the path relative to the location of the unit file.
 
-Special case:
-
-* If `SOURCE-VOLUME` ends with `.volume`, Quadlet will look for the corresponding `.volume` Quadlet unit. If found, Quadlet will use the name of the Volume set in the Unit, otherwise, `systemd-$name` is used. The generated systemd service contains a dependency on the service unit generated for that `.volume` unit, or on `$name-volume.service` if the `.volume` unit is not found. Note: the corresponding `.volume` file must exist.
+Note: unlike the `[Container]` section's `Volume=`, this option does not support named volumes or `.volume` Quadlet unit references, because `podman build --volume` only supports host directory bind mounts.
 
 This key can be listed multiple times.
 


### PR DESCRIPTION
The `[Build] Volume=` documentation incorrectly described support for named volumes (`SOURCE-VOLUME`) and `.volume` Quadlet unit references. These features are only available in `[Container] Volume=`, not in `[Build] Volume=`, because `podman build --volume` only supports host directory bind mounts.

- Simplify the syntax description to `[HOST-DIR:]CONTAINER-DIR[:OPTIONS]`
- Remove the `.volume` special case section
- Add a note clarifying the difference from `[Container] Volume=`

Fixes #25514