### PR TITLE
[WIP] podman: propagate user namespace mappings to image pull

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -401,6 +401,12 @@ func pullImage(cmd *cobra.Command, imageName string, cliVals *entities.Container
 		pullOptions.RetryDelay = val
 	}
 
+	pullOptions.UserNS = cliVals.UserNS
+	pullOptions.UIDMap = cliVals.UIDMap
+	pullOptions.GIDMap = cliVals.GIDMap
+	pullOptions.SubUIDName = cliVals.SubUIDName
+	pullOptions.SubGIDName = cliVals.SubGIDName
+
 	if cliVals.Creds != "" {
 		creds, err := util.ParseRegistryCreds(cliVals.Creds)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -189,3 +189,9 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.1.0 // indirect
 )
+
+replace (
+	go.podman.io/common => github.com/giuseppe/container-libs/common v0.0.0-20260623201732-70f0f883e488
+	go.podman.io/image/v5 => github.com/giuseppe/container-libs/image/v5 v5.0.0-20260623201732-70f0f883e488
+	go.podman.io/storage => github.com/giuseppe/container-libs/storage v0.0.0-20260623201732-70f0f883e488
+)

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,12 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fsouza/go-dockerclient v1.13.1 h1:HbkJO8UPUhuQ1wHIgX+ho7AUucBmjtOfzSWYUgmWL/8=
 github.com/fsouza/go-dockerclient v1.13.1/go.mod h1:0gx0SIFGV1F+79sM9p5K+UCc8enYKA8DBp7BlwlixpM=
+github.com/giuseppe/container-libs/common v0.0.0-20260623201732-70f0f883e488 h1:JMubKp1TI9Ah2y+3NbjdpBe2td+DhYYrofb8MPYIgIA=
+github.com/giuseppe/container-libs/common v0.0.0-20260623201732-70f0f883e488/go.mod h1:dCQxj440jP8tcrZvNGQXZ64/xWtfHRaM9cyGrM1aGFo=
+github.com/giuseppe/container-libs/image/v5 v5.0.0-20260623201732-70f0f883e488 h1:qtfUDAX53CMVpCnNLUWvAq8KPCFERvfqH2Iy1vtCCiM=
+github.com/giuseppe/container-libs/image/v5 v5.0.0-20260623201732-70f0f883e488/go.mod h1:KHAOlj3wG1ILAI44h4DfWyDKM/KdcpzUJMIBnbKAowI=
+github.com/giuseppe/container-libs/storage v0.0.0-20260623201732-70f0f883e488 h1:LZ5jgFY7u81OLtK2+AhdqN4GKla134WQrJqS+gt7r/I=
+github.com/giuseppe/container-libs/storage v0.0.0-20260623201732-70f0f883e488/go.mod h1:XDDcZog79t4Kuw+4EMH4KhPQcJnc9POJyeLMgZ8U/wM=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=
@@ -435,12 +441,6 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.podman.io/buildah v1.44.0 h1:hxQh/fZtm/r1Xuo2UnDoQH0PRafCRJ53oUeDSDCtKkE=
 go.podman.io/buildah v1.44.0/go.mod h1:RUdF9lLmMmdD7K9Y6eO64ptYuUMdDZ84SkPJc4008Jc=
-go.podman.io/common v0.68.1-0.20260618110040-05e6930da882 h1:dIBt1j5ryNvhgqvg7TaGvA+X9SVNXbsP6CABeDMIIkk=
-go.podman.io/common v0.68.1-0.20260618110040-05e6930da882/go.mod h1:6a05TkXUTVuyF/Hdl+CTJmXynUlVvRiuZAGkLzNx5bc=
-go.podman.io/image/v5 v5.40.1-0.20260618110040-05e6930da882 h1:cX5q6k9mJHt2rJHtzxfAcO46nqBG9gyYuGO7PDd+F8w=
-go.podman.io/image/v5 v5.40.1-0.20260618110040-05e6930da882/go.mod h1:SL/HkR5FOeBoeCPNMQS4ZWLKcS5/4gGyTsQSQsOxbR8=
-go.podman.io/storage v1.63.1-0.20260618110040-05e6930da882 h1:SOnKWo4CLL8YquDpHl03JIK+RDMn1B4cKmsU9ubU+fM=
-go.podman.io/storage v1.63.1-0.20260618110040-05e6930da882/go.mod h1:XDDcZog79t4Kuw+4EMH4KhPQcJnc9POJyeLMgZ8U/wM=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -79,6 +79,17 @@ type ImagePullOptions struct {
 	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
 	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
 	OciDecryptConfig *encconfig.DecryptConfig
+	// UserNS is the user namespace mode (e.g., "keep-id", "nomap", "host").
+	// Mappings are resolved server-side from this mode.
+	UserNS string
+	// UIDMap and GIDMap are the raw user-provided UID/GID mappings
+	// (e.g., from --uidmap/--gidmap flags).
+	UIDMap []string
+	GIDMap []string
+	// SubUIDName and SubGIDName are the user/group names for subordinate
+	// UID/GID ranges.
+	SubUIDName string
+	SubGIDName string
 }
 
 // ImagePullStatus contains the status of the image pull

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -40,7 +40,9 @@ import (
 	"go.podman.io/podman/v6/pkg/domain/entities/reports"
 	domainUtils "go.podman.io/podman/v6/pkg/domain/utils"
 	"go.podman.io/podman/v6/pkg/errorhandling"
+	"go.podman.io/podman/v6/pkg/namespaces"
 	"go.podman.io/podman/v6/pkg/rootless"
+	"go.podman.io/podman/v6/pkg/util"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/unshare"
 	"go.podman.io/storage/types"
@@ -294,6 +296,36 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, options entiti
 	pullOptions.InsecureSkipTLSVerify = options.SkipTLSVerify
 	pullOptions.Writer = options.Writer
 	pullOptions.OciDecryptConfig = options.OciDecryptConfig
+	if options.UserNS != "" {
+		usernsMode := namespaces.UsernsMode(options.UserNS)
+		switch {
+		case usernsMode.IsKeepID():
+			keepIDOpts, err := usernsMode.GetKeepIDOptions()
+			if err != nil {
+				return nil, err
+			}
+			mapping, _, _, err := util.GetKeepIDMapping(keepIDOpts)
+			if err != nil {
+				return nil, err
+			}
+			pullOptions.UIDMap = mapping.UIDMap
+			pullOptions.GIDMap = mapping.GIDMap
+		case usernsMode.IsNoMap():
+			mapping, _, _, err := util.GetNoMapMapping()
+			if err != nil {
+				return nil, err
+			}
+			pullOptions.UIDMap = mapping.UIDMap
+			pullOptions.GIDMap = mapping.GIDMap
+		default:
+			mapping, err := util.ParseIDMapping(usernsMode, options.UIDMap, options.GIDMap, options.SubUIDName, options.SubGIDName)
+			if err != nil {
+				return nil, err
+			}
+			pullOptions.UIDMap = mapping.UIDMap
+			pullOptions.GIDMap = mapping.GIDMap
+		}
+	}
 	pullOptions.MaxRetries = options.Retry
 
 	if options.RetryDelay != "" {

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -204,3 +204,35 @@ EOF
 
     run_podman rm -f $cname
 }
+
+# CANNOT BE PARALLELIZED because other tests may use $NONLOCAL_IMAGE
+@test "podman run --userns=keep-id does not create mapped layers" {
+    skip_if_not_rootless "keep-id mapped layers only relevant for rootless"
+    skip_if_remote "reads local storage files"
+
+    NONLOCAL_IMAGE="$PODMAN_NONLOCAL_IMAGE_FQN"
+
+    run_podman '?' rmi -f $NONLOCAL_IMAGE
+    run_podman 1 image exists $NONLOCAL_IMAGE
+
+    run_podman run --rm --userns=keep-id $NONLOCAL_IMAGE true
+
+    run_podman image inspect --format '{{.Id}}' $NONLOCAL_IMAGE
+    local image_id="${output#sha256:}"
+
+    run_podman info --format '{{.Store.GraphRoot}}'
+    local graphroot="$output"
+    run_podman info --format '{{.Store.GraphDriverName}}'
+    local graphdriver="$output"
+    local images_json="$graphroot/${graphdriver}-images/images.json"
+
+    # Verify no mapped-layers were created for this image
+    local mapped_count
+    mapped_count=$(jq --arg id "$image_id" \
+        '[.[] | select(.id == $id) | (."mapped-layers" // []) | length] | .[0] // 0' \
+        "$images_json")
+    assert "$mapped_count" == "0" \
+        "Image should have no mapped-layers (got $mapped_count)"
+
+    run_podman rmi $NONLOCAL_IMAGE
+}

--- a/vendor/go.podman.io/common/libimage/copier.go
+++ b/vendor/go.podman.io/common/libimage/copier.go
@@ -27,6 +27,7 @@ import (
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/idtools"
 )
 
 const (
@@ -149,6 +150,17 @@ type CopyOptions struct {
 	// IdentityToken is used to authenticate the user and get
 	// an access token for the registry.
 	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// ----- ID Mapping ---------------------------------------------------
+
+	// UIDMap and GIDMap are used for setting up image layers with the
+	// correct UID/GID mappings when pulling into storage.
+	UIDMap []idtools.IDMap
+	GIDMap []idtools.IDMap
+	// HostUIDMapping and HostGIDMapping explicitly request host
+	// mappings, preventing inheritance from parent layers.
+	HostUIDMapping bool
+	HostGIDMapping bool
 
 	// ----- internal -----------------------------------------------------
 
@@ -279,6 +291,11 @@ func NewCopier(options *CopyOptions, sc *types.SystemContext) (*Copier, error) {
 	if options.CompressionLevel != nil {
 		c.systemContext.CompressionLevel = options.CompressionLevel
 	}
+
+	c.systemContext.UIDMap = options.UIDMap
+	c.systemContext.GIDMap = options.GIDMap
+	c.systemContext.HostUIDMapping = options.HostUIDMapping
+	c.systemContext.HostGIDMapping = options.HostGIDMapping
 
 	// NOTE: for the sake of consistency it's called Oci* in the CopyOptions.
 	c.systemContext.OCIAcceptUncompressedLayers = options.OciAcceptUncompressedLayers

--- a/vendor/go.podman.io/common/libnetwork/netavark/ipam.go
+++ b/vendor/go.podman.io/common/libnetwork/netavark/ipam.go
@@ -111,6 +111,12 @@ func (n *netavarkNetwork) allocIPs(opts *types.NetworkOptions) error {
 
 						// convert to 4 byte ipv4 if needed
 						util.NormalizeIP(&staticIP)
+
+						// Ensure the requested IP is not the subnet's Gateway
+						if subnet.Gateway != nil && staticIP.Equal(subnet.Gateway) {
+							return newIPAMError(nil, "address already in use: requested static IP %s matches the subnet gateway", staticIP.String())
+						}
+
 						id := subnetBkt.Get(staticIP)
 						if id != nil {
 							return newIPAMError(nil, "requested ip address %s is already allocated to container ID %s", staticIP.String(), string(id))

--- a/vendor/go.podman.io/image/v5/storage/storage_dest.go
+++ b/vendor/go.podman.io/image/v5/storage/storage_dest.go
@@ -37,7 +37,9 @@ import (
 	"go.podman.io/storage/pkg/archive"
 	"go.podman.io/storage/pkg/chunked"
 	"go.podman.io/storage/pkg/chunked/toc"
+	"go.podman.io/storage/pkg/idtools"
 	"go.podman.io/storage/pkg/ioutils"
+	storagetypes "go.podman.io/storage/types"
 )
 
 var (
@@ -58,6 +60,10 @@ type storageImageDestination struct {
 	stubs.AlwaysSupportsSignatures
 
 	imageRef              storageReference
+	uidMap                []idtools.IDMap
+	gidMap                []idtools.IDMap
+	hostUIDMapping        bool
+	hostGIDMapping        bool
 	directory             string                   // Temporary directory where we store blobs until Commit() time
 	nextTempFileID        atomic.Int32             // A counter that we use for computing filenames to assign to blobs
 	manifest              []byte                   // (Per-instance) manifest contents, or nil if not yet known.
@@ -184,8 +190,36 @@ func newImageDestination(sys *types.SystemContext, imageRef storageReference) (*
 			fileSizes:              make(map[digest.Digest]int64),
 		},
 	}
+	if sys != nil {
+		dest.uidMap = sys.UIDMap
+		dest.gidMap = sys.GIDMap
+		dest.hostUIDMapping = sys.HostUIDMapping
+		dest.hostGIDMapping = sys.HostGIDMapping
+	}
 	dest.Compat = impl.AddCompat(dest)
 	return dest, nil
+}
+
+// idMappingOptions returns the IDMappingOptions for layer creation.
+// When custom UID/GID maps are set, they are used directly.
+// When HostIDMapping is set, host mappings are requested explicitly,
+// preventing populateLayerOptions from inheriting parent mappings.
+// Otherwise, a zero-value IDMappingOptions is returned so that
+// populateLayerOptions preserves its default behavior.
+func (s *storageImageDestination) idMappingOptions() storagetypes.IDMappingOptions {
+	if len(s.uidMap) > 0 || len(s.gidMap) > 0 {
+		return storagetypes.IDMappingOptions{
+			UIDMap: s.uidMap,
+			GIDMap: s.gidMap,
+		}
+	}
+	if s.hostUIDMapping || s.hostGIDMapping {
+		return storagetypes.IDMappingOptions{
+			HostUIDMapping: s.hostUIDMapping,
+			HostGIDMapping: s.hostGIDMapping,
+		}
+	}
+	return storagetypes.IDMappingOptions{}
 }
 
 // Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
@@ -1134,6 +1168,9 @@ func (s *storageImageDestination) createNewLayer(index int, trusted trustedLayer
 		args := storage.ApplyStagedLayerOptions{
 			ID:          newLayerID,
 			ParentLayer: parentLayer,
+			LayerOptions: &storage.LayerOptions{
+				IDMappingOptions: s.idMappingOptions(),
+			},
 
 			DiffOutput: diffOutput,
 			DiffOptions: &graphdriver.ApplyDiffWithDifferOpts{
@@ -1274,12 +1311,14 @@ func (s *storageImageDestination) createNewLayer(index int, trusted trustedLayer
 	defer file.Close()
 	// Build the new layer using the diff, regardless of where it came from.
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
-	layer, _, err := s.imageRef.transport.store.PutLayer(newLayerID, parentLayer, nil, "", false, &storage.LayerOptions{
-		OriginalDigest: trustedOriginalDigest,
-		OriginalSize:   trustedOriginalSize, // nil in many cases
+	layerOptions := &storage.LayerOptions{
+		IDMappingOptions: s.idMappingOptions(),
+		OriginalDigest:   trustedOriginalDigest,
+		OriginalSize:     trustedOriginalSize, // nil in many cases
 		// This might be "" if trusted.layerIdentifiedByTOC; in that case PutLayer will compute the value from the stream.
 		UncompressedDigest: trusted.diffID,
-	}, file)
+	}
+	layer, _, err := s.imageRef.transport.store.PutLayer(newLayerID, parentLayer, nil, "", false, layerOptions, file)
 	if err != nil && !errors.Is(err, storage.ErrDuplicateID) {
 		return nil, fmt.Errorf("adding layer with blob %s: %w", trusted.logString(), err)
 	}

--- a/vendor/go.podman.io/image/v5/types/types.go
+++ b/vendor/go.podman.io/image/v5/types/types.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.podman.io/image/v5/docker/reference"
 	compression "go.podman.io/image/v5/pkg/compression/types"
+	"go.podman.io/storage/pkg/idtools"
 )
 
 // ImageTransport is a top-level namespace for ways to store/load an image.
@@ -700,6 +701,20 @@ type SystemContext struct {
 	CompressionFormat *compression.Algorithm
 	// CompressionLevel specifies what compression level is used
 	CompressionLevel *int
+
+	// === storage.Transport overrides ===
+	// UIDMap specifies the UID mappings to apply when creating layers for the storage transport.
+	UIDMap []idtools.IDMap
+	// GIDMap specifies the GID mappings to apply when creating layers for the storage transport.
+	GIDMap []idtools.IDMap
+	// HostUIDMapping explicitly requests host UID mapping for the
+	// storage transport, preventing inheritance from parent layers.
+	// Mutually exclusive with UIDMap.
+	HostUIDMapping bool
+	// HostGIDMapping explicitly requests host GID mapping for the
+	// storage transport, preventing inheritance from parent layers.
+	// Mutually exclusive with GIDMap.
+	HostGIDMapping bool
 }
 
 // ProgressEvent is the type of events a progress reader can produce

--- a/vendor/go.podman.io/storage/pkg/archive/archive_bsd.go
+++ b/vendor/go.podman.io/storage/pkg/archive/archive_bsd.go
@@ -9,10 +9,26 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// syscallMode maps a Go os.FileMode to chmod(2) bits, preserving the
+// setuid/setgid/sticky bits that a raw uint32(FileMode) cast silently drops.
+func syscallMode(i os.FileMode) (o uint32) {
+	o = uint32(i.Perm())
+	if i&os.ModeSetuid != 0 {
+		o |= unix.S_ISUID
+	}
+	if i&os.ModeSetgid != 0 {
+		o |= unix.S_ISGID
+	}
+	if i&os.ModeSticky != 0 {
+		o |= unix.S_ISVTX
+	}
+	return o
+}
+
 func handleLChmod(_ *tar.Header, path string, hdrInfo os.FileInfo, forceMask *os.FileMode) error {
 	permissionsMask := hdrInfo.Mode()
 	if forceMask != nil {
 		permissionsMask = *forceMask
 	}
-	return unix.Fchmodat(unix.AT_FDCWD, path, uint32(permissionsMask), unix.AT_SYMLINK_NOFOLLOW)
+	return unix.Fchmodat(unix.AT_FDCWD, path, syscallMode(permissionsMask), unix.AT_SYMLINK_NOFOLLOW)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -740,7 +740,7 @@ go.podman.io/buildah/pkg/sshagent
 go.podman.io/buildah/pkg/util
 go.podman.io/buildah/pkg/volumes
 go.podman.io/buildah/util
-# go.podman.io/common v0.68.1-0.20260618110040-05e6930da882
+# go.podman.io/common v0.68.1-0.20260618110040-05e6930da882 => github.com/giuseppe/container-libs/common v0.0.0-20260623201732-70f0f883e488
 ## explicit; go 1.25.7
 go.podman.io/common/internal
 go.podman.io/common/libimage
@@ -806,7 +806,7 @@ go.podman.io/common/pkg/umask
 go.podman.io/common/pkg/util
 go.podman.io/common/pkg/version
 go.podman.io/common/version
-# go.podman.io/image/v5 v5.40.1-0.20260618110040-05e6930da882
+# go.podman.io/image/v5 v5.40.1-0.20260618110040-05e6930da882 => github.com/giuseppe/container-libs/image/v5 v5.0.0-20260623201732-70f0f883e488
 ## explicit; go 1.25.7
 go.podman.io/image/v5/copy
 go.podman.io/image/v5/directory
@@ -883,7 +883,7 @@ go.podman.io/image/v5/transports
 go.podman.io/image/v5/transports/alltransports
 go.podman.io/image/v5/types
 go.podman.io/image/v5/version
-# go.podman.io/storage v1.63.1-0.20260618110040-05e6930da882
+# go.podman.io/storage v1.63.1-0.20260618110040-05e6930da882 => github.com/giuseppe/container-libs/storage v0.0.0-20260623201732-70f0f883e488
 ## explicit; go 1.25.0
 go.podman.io/storage
 go.podman.io/storage/drivers
@@ -1187,3 +1187,6 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v1.1.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
+# go.podman.io/common => github.com/giuseppe/container-libs/common v0.0.0-20260623201732-70f0f883e488
+# go.podman.io/image/v5 => github.com/giuseppe/container-libs/image/v5 v5.0.0-20260623201732-70f0f883e488
+# go.podman.io/storage => github.com/giuseppe/container-libs/storage v0.0.0-20260623201732-70f0f883e488


### PR DESCRIPTION
Needs: https://github.com/containers/container-libs/pull/717

When running `podman run --userns=keep-id` (or other userns modes) and the image is not yet present, podman pulls the image without any UID/GID mapping information.

This applies to all userns modes: keep-id, nomap, and explicit --uidmap/--gidmap mappings.  The auto mode (--userns=auto) is not supported because its mappings depend on the image size and are computed at container creation time, after the image has already been pulled.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
