### PR TITLE
compat: populate IPRange in IPAM config when listing networks

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -511,8 +511,10 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 
 // leaseRangeToIPRangePrefix converts a LeaseRange back to a CIDR prefix for the Docker
 // compat API. This is the reverse of the conversion done in createNetwork, where an
-// IPRange CIDR (e.g. "192.168.0.128/25") is expanded to [FirstIP, LastIP].
-// It only succeeds for IPv4 ranges that form a valid aligned CIDR block.
+// IPRange CIDR (e.g. "192.168.0.128/25") is expanded to [FirstIP, LastIP] via
+// FirstIPInSubnet/LastIPInSubnet. FirstIPInSubnet returns network+1 (first usable host),
+// so StartIP is one greater than the network address. LastIPInSubnet returns the broadcast.
+// Only succeeds for IPv4 ranges that form a valid aligned CIDR block.
 func leaseRangeToIPRangePrefix(lr *nettypes.LeaseRange) (netip.Prefix, bool) {
 	if lr == nil || lr.StartIP == nil || lr.EndIP == nil {
 		return netip.Prefix{}, false
@@ -528,19 +530,31 @@ func leaseRangeToIPRangePrefix(lr *nettypes.LeaseRange) (netip.Prefix, bool) {
 	if endU < startU {
 		return netip.Prefix{}, false
 	}
-	count := endU - startU + 1
-	// Verify the range is a power of two (required for a valid CIDR block).
-	if count&(count-1) != 0 {
+	// For /32, FirstIPInSubnet returns the address unchanged; StartIP == EndIP.
+	if startU == endU {
+		startAddr, _ := netip.AddrFromSlice(start4)
+		return netip.PrefixFrom(startAddr.Unmap(), 32), true
+	}
+	// For all other subnets, FirstIPInSubnet increments the network address by 1,
+	// so recover the network address by subtracting 1 from StartIP.
+	if startU == 0 {
 		return netip.Prefix{}, false
 	}
-	// Verify that startU is aligned to the block size.
-	if count > 1 && startU&(count-1) != 0 {
+	netU := startU - 1
+	size := endU - netU + 1
+	// Verify size is a power of two (required for a valid CIDR block).
+	if size&(size-1) != 0 {
+		return netip.Prefix{}, false
+	}
+	// Verify the network address is aligned to the block size.
+	if netU&(size-1) != 0 {
 		return netip.Prefix{}, false
 	}
 	prefixBits := 32
-	for n := count; n > 1; n >>= 1 {
+	for n := size; n > 1; n >>= 1 {
 		prefixBits--
 	}
-	startAddr, _ := netip.AddrFromSlice(start4)
-	return netip.PrefixFrom(startAddr.Unmap(), prefixBits), true
+	netBytes := []byte{byte(netU >> 24), byte(netU >> 16), byte(netU >> 8), byte(netU)}
+	netAddr, _ := netip.AddrFromSlice(netBytes)
+	return netip.PrefixFrom(netAddr.Unmap(), prefixBits), true
 }

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math/bits"
 	"net"
 	"net/http"
 	"net/netip"
@@ -522,39 +523,42 @@ func leaseRangeToIPRangePrefix(lr *nettypes.LeaseRange) (netip.Prefix, bool) {
 	start4 := lr.StartIP.To4()
 	end4 := lr.EndIP.To4()
 	if start4 == nil || end4 == nil {
-		// IPv6 not handled: no lossless round-trip without storing the original CIDR
+		// IPv6 not supported: no lossless round-trip without storing the original CIDR
 		return netip.Prefix{}, false
 	}
-	startU := uint32(start4[0])<<24 | uint32(start4[1])<<16 | uint32(start4[2])<<8 | uint32(start4[3])
-	endU := uint32(end4[0])<<24 | uint32(end4[1])<<16 | uint32(end4[2])<<8 | uint32(end4[3])
+
+	toUint32 := func(ip []byte) uint32 {
+		return uint32(ip[0])<<24 | uint32(ip[1])<<16 | uint32(ip[2])<<8 | uint32(ip[3])
+	}
+	startU := toUint32(start4)
+	endU := toUint32(end4)
+
 	if endU < startU {
 		return netip.Prefix{}, false
 	}
-	// For /32, FirstIPInSubnet returns the address unchanged; StartIP == EndIP.
+
+	// For /32, FirstIPInSubnet returns the address unchanged so StartIP == EndIP.
 	if startU == endU {
-		startAddr, _ := netip.AddrFromSlice(start4)
-		return netip.PrefixFrom(startAddr.Unmap(), 32), true
+		addr, _ := netip.AddrFromSlice(start4)
+		return netip.PrefixFrom(addr.Unmap(), 32), true
 	}
+
 	// For all other subnets, FirstIPInSubnet increments the network address by 1,
-	// so recover the network address by subtracting 1 from StartIP.
+	// so the actual network address is StartIP - 1.
 	if startU == 0 {
 		return netip.Prefix{}, false
 	}
 	netU := startU - 1
 	size := endU - netU + 1
-	// Verify size is a power of two (required for a valid CIDR block).
-	if size&(size-1) != 0 {
+
+	// size must be a power of two (valid CIDR block) and the network address
+	// must be aligned to that block size.
+	if bits.OnesCount32(size) != 1 || netU&(size-1) != 0 {
 		return netip.Prefix{}, false
 	}
-	// Verify the network address is aligned to the block size.
-	if netU&(size-1) != 0 {
-		return netip.Prefix{}, false
-	}
-	prefixBits := 32
-	for n := size; n > 1; n >>= 1 {
-		prefixBits--
-	}
+
+	prefixLen := 32 - bits.TrailingZeros32(size)
 	netBytes := []byte{byte(netU >> 24), byte(netU >> 16), byte(netU >> 8), byte(netU)}
 	netAddr, _ := netip.AddrFromSlice(netBytes)
-	return netip.PrefixFrom(netAddr.Unmap(), prefixBits), true
+	return netip.PrefixFrom(netAddr.Unmap(), prefixLen), true
 }

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -3,6 +3,7 @@
 package compat
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -527,11 +528,8 @@ func leaseRangeToIPRangePrefix(lr *nettypes.LeaseRange) (netip.Prefix, bool) {
 		return netip.Prefix{}, false
 	}
 
-	toUint32 := func(ip []byte) uint32 {
-		return uint32(ip[0])<<24 | uint32(ip[1])<<16 | uint32(ip[2])<<8 | uint32(ip[3])
-	}
-	startU := toUint32(start4)
-	endU := toUint32(end4)
+	startU := binary.BigEndian.Uint32(start4)
+	endU := binary.BigEndian.Uint32(end4)
 
 	if endU < startU {
 		return netip.Prefix{}, false
@@ -548,17 +546,23 @@ func leaseRangeToIPRangePrefix(lr *nettypes.LeaseRange) (netip.Prefix, bool) {
 	if startU == 0 {
 		return netip.Prefix{}, false
 	}
-	netU := startU - 1
-	size := endU - netU + 1
+	networkU := startU - 1
+	totalIPs := endU - networkU + 1
 
-	// size must be a power of two (valid CIDR block) and the network address
-	// must be aligned to that block size.
-	if bits.OnesCount32(size) != 1 || netU&(size-1) != 0 {
+	// A valid CIDR block size must be a power of two.
+	if bits.OnesCount32(totalIPs) != 1 {
 		return netip.Prefix{}, false
 	}
+	prefixLen := 32 - bits.TrailingZeros32(totalIPs)
 
-	prefixLen := 32 - bits.TrailingZeros32(size)
-	netBytes := []byte{byte(netU >> 24), byte(netU >> 16), byte(netU >> 8), byte(netU)}
-	netAddr, _ := netip.AddrFromSlice(netBytes)
-	return netip.PrefixFrom(netAddr.Unmap(), prefixLen), true
+	var netBytes [4]byte
+	binary.BigEndian.PutUint32(netBytes[:], networkU)
+	networkAddr, _ := netip.AddrFromSlice(netBytes[:])
+	proposedPrefix := netip.PrefixFrom(networkAddr.Unmap(), prefixLen)
+
+	// Verify network boundary alignment: network address must be at the subnet boundary.
+	if proposedPrefix.Masked() != proposedPrefix {
+		return netip.Prefix{}, false
+	}
+	return proposedPrefix, true
 }

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -123,7 +123,9 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, statuses []abi
 		ipamConfig := dockerNetwork.IPAMConfig{
 			Subnet:  subnet,
 			Gateway: gateway,
-			// TODO add range
+		}
+		if ipRange, ok := leaseRangeToIPRangePrefix(sub.LeaseRange); ok {
+			ipamConfig.IPRange = ipRange
 		}
 		ipamConfigs = append(ipamConfigs, ipamConfig)
 	}
@@ -505,4 +507,40 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 		prunedNetworks = append(prunedNetworks, pr.Name)
 	}
 	utils.WriteResponse(w, http.StatusOK, response{NetworksDeleted: prunedNetworks})
+}
+
+// leaseRangeToIPRangePrefix converts a LeaseRange back to a CIDR prefix for the Docker
+// compat API. This is the reverse of the conversion done in createNetwork, where an
+// IPRange CIDR (e.g. "192.168.0.128/25") is expanded to [FirstIP, LastIP].
+// It only succeeds for IPv4 ranges that form a valid aligned CIDR block.
+func leaseRangeToIPRangePrefix(lr *nettypes.LeaseRange) (netip.Prefix, bool) {
+	if lr == nil || lr.StartIP == nil || lr.EndIP == nil {
+		return netip.Prefix{}, false
+	}
+	start4 := lr.StartIP.To4()
+	end4 := lr.EndIP.To4()
+	if start4 == nil || end4 == nil {
+		// IPv6 not handled: no lossless round-trip without storing the original CIDR
+		return netip.Prefix{}, false
+	}
+	startU := uint32(start4[0])<<24 | uint32(start4[1])<<16 | uint32(start4[2])<<8 | uint32(start4[3])
+	endU := uint32(end4[0])<<24 | uint32(end4[1])<<16 | uint32(end4[2])<<8 | uint32(end4[3])
+	if endU < startU {
+		return netip.Prefix{}, false
+	}
+	count := endU - startU + 1
+	// Verify the range is a power of two (required for a valid CIDR block).
+	if count&(count-1) != 0 {
+		return netip.Prefix{}, false
+	}
+	// Verify that startU is aligned to the block size.
+	if count > 1 && startU&(count-1) != 0 {
+		return netip.Prefix{}, false
+	}
+	prefixBits := 32
+	for n := count; n > 1; n >>= 1 {
+		prefixBits--
+	}
+	startAddr, _ := netip.AddrFromSlice(start4)
+	return netip.PrefixFrom(startAddr.Unmap(), prefixBits), true
 }

--- a/pkg/api/handlers/compat/networks_test.go
+++ b/pkg/api/handlers/compat/networks_test.go
@@ -1,0 +1,118 @@
+//go:build !remote && (linux || freebsd)
+
+package compat
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	nettypes "go.podman.io/common/libnetwork/types"
+)
+
+func TestLeaseRangeToIPRangePrefix(t *testing.T) {
+	mustPrefix := func(s string) netip.Prefix {
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			t.Fatalf("invalid prefix %q: %v", s, err)
+		}
+		return p
+	}
+	leaseRange := func(start, end string) *nettypes.LeaseRange {
+		return &nettypes.LeaseRange{
+			StartIP: net.ParseIP(start),
+			EndIP:   net.ParseIP(end),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		lr      *nettypes.LeaseRange
+		want    netip.Prefix
+		wantOK  bool
+	}{
+		{
+			name:   "nil LeaseRange",
+			lr:     nil,
+			wantOK: false,
+		},
+		{
+			name:   "nil StartIP",
+			lr:     &nettypes.LeaseRange{EndIP: net.ParseIP("192.168.1.1")},
+			wantOK: false,
+		},
+		{
+			name:   "nil EndIP",
+			lr:     &nettypes.LeaseRange{StartIP: net.ParseIP("192.168.1.1")},
+			wantOK: false,
+		},
+		{
+			// /24: StartIP = network+1 = .1, EndIP = broadcast = .255
+			name:   "/24 subnet",
+			lr:     leaseRange("192.168.1.1", "192.168.1.255"),
+			want:   mustPrefix("192.168.1.0/24"),
+			wantOK: true,
+		},
+		{
+			// /25: StartIP = .129, EndIP = .255
+			name:   "/25 subnet",
+			lr:     leaseRange("10.10.61.129", "10.10.61.255"),
+			want:   mustPrefix("10.10.61.128/25"),
+			wantOK: true,
+		},
+		{
+			// /16: StartIP = .0.1, EndIP = .255.255
+			name:   "/16 subnet",
+			lr:     leaseRange("10.10.0.1", "10.10.255.255"),
+			want:   mustPrefix("10.10.0.0/16"),
+			wantOK: true,
+		},
+		{
+			// /32: single host, StartIP == EndIP (FirstIPInSubnet returns address unchanged)
+			name:   "/32 single host",
+			lr:     leaseRange("10.0.0.5", "10.0.0.5"),
+			want:   mustPrefix("10.0.0.5/32"),
+			wantOK: true,
+		},
+		{
+			// misaligned: StartIP and EndIP do not form a valid CIDR block
+			name:   "misaligned range",
+			lr:     leaseRange("192.168.1.2", "192.168.1.255"),
+			wantOK: false,
+		},
+		{
+			// non-power-of-two size: 3 addresses
+			name:   "non-power-of-two size",
+			lr:     leaseRange("192.168.1.1", "192.168.1.3"),
+			wantOK: false,
+		},
+		{
+			// end before start
+			name:   "end before start",
+			lr:     leaseRange("192.168.1.5", "192.168.1.1"),
+			wantOK: false,
+		},
+		{
+			// IPv6 not supported
+			name: "IPv6 not supported",
+			lr: &nettypes.LeaseRange{
+				StartIP: net.ParseIP("::1"),
+				EndIP:   net.ParseIP("::1"),
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := leaseRangeToIPRangePrefix(tt.lr)
+			if ok != tt.wantOK {
+				t.Errorf("leaseRangeToIPRangePrefix() ok = %v, want %v", ok, tt.wantOK)
+				return
+			}
+			if ok && got != tt.want {
+				t.Errorf("leaseRangeToIPRangePrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -257,4 +257,10 @@ t POST networks/netcon/connect Container=c1 200 OK
 # cleanup
 podman network rm -f netcon
 
+# IPRange is populated in IPAM config when a network is created with --ip-range
+podman network create --subnet 10.10.61.0/24 --ip-range 10.10.61.128/25 iprange-test
+t GET networks/iprange-test 200 \
+  .IPAM.Config[0].IPRange="10.10.61.128/25"
+podman network rm -f iprange-test
+
 # vim: filetype=sh


### PR DESCRIPTION
## Summary

When converting a libpod network to a Docker-compatible network in
`convertLibpodNetworktoDockerNetwork`, the `IPAMConfig.IPRange` field
was left empty with a `// TODO add range` comment.

This PR resolves the TODO by reconstructing the CIDR prefix from the
`LeaseRange` stored on each subnet. The forward conversion (Docker
`IPRange` CIDR → `LeaseRange{StartIP, EndIP}`) already exists in the
`createNetwork` path. This adds the reverse direction:
- Given `StartIP` and `EndIP` from `LeaseRange`, check whether they
  form a valid aligned IPv4 CIDR block (power-of-two size, aligned
  start address).
- If so, return the corresponding `netip.Prefix` as `IPAMConfig.IPRange`.
- Otherwise (non-CIDR-aligned ranges, IPv6) leave `IPRange` empty.

This means `docker network inspect` now shows the `IPRange` for
networks created with `--ip-range` (or the Docker compat API equivalent),
restoring round-trip fidelity for the IPAM configuration.

Fixes #28378