### PR TITLE
machine: ensure disk image is writable before resize (fix read-only image init failure)

### DIFF
--- a/pkg/machine/compression/decompress.go
+++ b/pkg/machine/compression/decompress.go
@@ -90,7 +90,12 @@ func runDecompression(d decompressor, decompressedFilePath string) (retErr error
 
 	var decompressedFileWriter *os.File
 
-	if decompressedFileWriter, err = os.OpenFile(decompressedFilePath, decompressedFileFlag, d.compressedFileMode()); err != nil {
+	mode := d.compressedFileMode()
+
+	// Ensure the owner always has write permission.
+	mode |= 0o200
+
+	if decompressedFileWriter, err = os.OpenFile(decompressedFilePath, decompressedFileFlag, mode); err != nil {
 		logrus.Errorf("Unable to open destination file %s for writing: %q", decompressedFilePath, err)
 		return err
 	}

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -741,6 +742,37 @@ var _ = Describe("podman machine init", func() {
 			}
 			Expect(p).To(Equal(l.VMType))
 		}
+	})
+
+	It("init with read-only image should succeed", func() {
+		// Step 1: create temp image
+		img := filepath.Join(GinkgoT().TempDir(), "test.qcow2")
+
+		// Step 2: copy existing image and make it read-only
+		src, err := os.Open(mb.imagePath)
+		Expect(err).ToNot(HaveOccurred())
+
+		dst, err := os.Create(img)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = io.Copy(dst, src)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = dst.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = src.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.Chmod(img, 0o444)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Step 3: run podman machine init
+		i := new(initMachine)
+		session, err := mb.setCmd(i.withImage(img)).run()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
 	})
 })
 


### PR DESCRIPTION
## Problem

Initializing a Podman machine with a read-only disk image (e.g. `chmod 444`) fails during the resize step with a permission denied error.

## Root Cause

The disk image created from user input may retain read-only permissions. The resize operation requires write access, but no step ensures the image is writable before it is used.

## Solution

This fixes #2756 by ensuring machine disk images are writable before resize/decompression operations. The fix is implemented in the shared decompression path, so it applies to all machine image providers.

## Test

Added an e2e test covering initialization with a read-only image.