### PR TITLE
machine: add vfkit timesync device for Apple VMs

### DIFF
--- a/contrib/cirrus/mac_env.sh
+++ b/contrib/cirrus/mac_env.sh
@@ -24,3 +24,6 @@ go env
 # The latest version is installed system-wide when instances are created. Make the
 # current version known.
 vfkit --version
+
+# Make the current version of krunkit known.
+krunkit --version

--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -180,6 +180,14 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 	}
 	vm.Devices = append(vm.Devices, mounts...)
 
+	timesync, err := vfConfig.TimeSyncNew(1234)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := vm.AddDevice(timesync); err != nil {
+		return nil, nil, err
+	}
+
 	// To start the VM, we need to call vfkit
 	cfg, err := config.Default()
 	if err != nil {

--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -180,7 +180,7 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 	}
 	vm.Devices = append(vm.Devices, mounts...)
 
-	timesync, err := vfConfig.TimeSyncNew(1234)
+	timesync, err := vfConfig.TimeSyncNew(define.TimeSyncVsockPort)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/machine/define/config.go
+++ b/pkg/machine/define/config.go
@@ -6,6 +6,9 @@ const (
 	UserCertsTargetPath = "/etc/containers/certs.d"
 	DefaultIdentityName = "machine"
 	DefaultMachineName  = "podman-machine-default"
+	// TimeSyncVsockPort is the vsock port for host->guest time sync via qemu-guest-agent.
+	// Podman passes this to vfkit/krunkit --timesync; podman-machine-os configures qemu-guest-agent on the same port.
+	TimeSyncVsockPort = 1234
 )
 
 // MountTag is an identifier to mount a VirtioFS file system tag on a mount point in the VM.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

Related PR: https://github.com/containers/podman-machine-os/pull/175

```release-note
None
```
