### PR TITLE
Machine config mount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,9 +65,9 @@ require (
 	github.com/vishvananda/netlink v1.3.1
 	go.etcd.io/bbolt v1.4.3
 	go.podman.io/buildah v1.42.1-0.20260501153811-377cf64e213b
-	go.podman.io/common v0.67.2-0.20260506114327-35c76125c5b5
-	go.podman.io/image/v5 v5.39.3-0.20260506114327-35c76125c5b5
-	go.podman.io/storage v1.62.1-0.20260506114327-35c76125c5b5
+	go.podman.io/common v0.67.2-0.20260511131139-020a2274da88
+	go.podman.io/image/v5 v5.39.3-0.20260511131139-020a2274da88
+	go.podman.io/storage v1.62.1-0.20260511131139-020a2274da88
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0
 	golang.org/x/sync v0.20.0
@@ -188,3 +188,9 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.1.0 // indirect
 )
+
+replace go.podman.io/common => github.com/Luap99/container-libs/common v0.0.0-20260507114201-8488036ffdbc
+
+replace go.podman.io/image/v5 => github.com/Luap99/container-libs/image/v5 v5.0.0-20260507114201-8488036ffdbc
+
+replace go.podman.io/storage => github.com/Luap99/container-libs/storage v0.0.0-20260507114201-8488036ffdbc

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,12 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/Luap99/container-libs/common v0.0.0-20260507114201-8488036ffdbc h1:XmY0KOb6HkYOETGKD9fsTU65LgdZv4GbzEaVhTgIY5I=
+github.com/Luap99/container-libs/common v0.0.0-20260507114201-8488036ffdbc/go.mod h1:TYI+ocF4gfL8QCBo5GqOSUAOA3QnVgkjjg/nQZRG3o0=
+github.com/Luap99/container-libs/image/v5 v5.0.0-20260507114201-8488036ffdbc h1:36O4RycVrjqNeYHRBPCF2240RomNXBRlHKWUI8Sjlz0=
+github.com/Luap99/container-libs/image/v5 v5.0.0-20260507114201-8488036ffdbc/go.mod h1:D+09OPzsrFuzeKqsJEaaxtItkSd12+eZyOdFyuJF8TY=
+github.com/Luap99/container-libs/storage v0.0.0-20260507114201-8488036ffdbc h1:CvYOTQYMWI4zo43NuBwdLK9WRlC0CkzEMnrtsfLRxxY=
+github.com/Luap99/container-libs/storage v0.0.0-20260507114201-8488036ffdbc/go.mod h1:eZIqDigffFi9NlPezLvUVw/nsUIruaui436E5E4GmXs=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -431,12 +437,6 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.podman.io/buildah v1.42.1-0.20260501153811-377cf64e213b h1:i8ntFzITajbJA3ojnA0ZdpbC+I+ccweZvZaGIhQb4i8=
 go.podman.io/buildah v1.42.1-0.20260501153811-377cf64e213b/go.mod h1:hPvgsjBU09C+15fKoIZJvKvNaxR+c0QvMg/n4NgBS7A=
-go.podman.io/common v0.67.2-0.20260506114327-35c76125c5b5 h1:rjsl4OiSteuD58lb76F9f0e3VOapd7cKdpL6sc+77PI=
-go.podman.io/common v0.67.2-0.20260506114327-35c76125c5b5/go.mod h1:TYI+ocF4gfL8QCBo5GqOSUAOA3QnVgkjjg/nQZRG3o0=
-go.podman.io/image/v5 v5.39.3-0.20260506114327-35c76125c5b5 h1:xkEpeE5/HO2MryNXLk443DJhXayWGJC7mku9CjRqHrg=
-go.podman.io/image/v5 v5.39.3-0.20260506114327-35c76125c5b5/go.mod h1:D+09OPzsrFuzeKqsJEaaxtItkSd12+eZyOdFyuJF8TY=
-go.podman.io/storage v1.62.1-0.20260506114327-35c76125c5b5 h1:yPIjkKjl5VTjz66zg8pStN2ysvd2OFMIzCvsO3CJYn0=
-go.podman.io/storage v1.62.1-0.20260506114327-35c76125c5b5/go.mod h1:eZIqDigffFi9NlPezLvUVw/nsUIruaui436E5E4GmXs=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/gomega/gexec"
 	"go.podman.io/podman/v6/pkg/machine/define"
 	"go.podman.io/podman/v6/version/rawversion"
+	"go.podman.io/storage/pkg/configfile"
 )
 
 const TESTIMAGE = "quay.io/libpod/testimage:20241011"
@@ -31,6 +32,27 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
+		// Check that we mount the host config dir to the machine /etc/containers and and can write content from the host there.
+		path, err := configfile.UserConfigPath()
+		Expect(err).ToNot(HaveOccurred())
+		err = os.MkdirAll(path, 0o755)
+		Expect(err).ToNot(HaveOccurred())
+
+		content := randomString()
+		f, err := os.Create(filepath.Join(path, "podman-machine-tmpfile"))
+		Expect(err).ToNot(HaveOccurred())
+		_, err = f.WriteString(content)
+		Expect(err).ToNot(HaveOccurred())
+		err = f.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		ssh := new(sshMachine).withSSHCommand([]string{"cat /etc/containers/podman-machine-tmpfile"})
+		sshRun, err := mb.setName(name).setCmd(ssh).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sshRun).To(Exit(0))
+		Expect(sshRun.outputToString()).To(Equal(content))
+
+		// check some basic podman commands
 		bm := basicMachine{}
 		imgs, err := mb.setCmd(bm.withPodmanCommand([]string{"images", "-q"})).run()
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -105,18 +105,8 @@ var _ = Describe("run basic podman commands", func() {
 		build, err := mb.setCmd(bm.withPodmanCommand([]string{"build", "-t", name, "-v", tDir + ":/test", tDir})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(build).To(Exit(0))
-	})
 
-	It("Single character volume mount", func() {
-		name := randomString()
-		i := new(initMachine).withImage(mb.imagePath).withNow()
-
-		session, err := mb.setName(name).setCmd(i).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		bm := basicMachine{}
-
+		// check we can use a single character volume name as mount
 		volumeCreate, err := mb.setCmd(bm.withPodmanCommand([]string{"volume", "create", "a"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(volumeCreate).To(Exit(0))
@@ -124,33 +114,15 @@ var _ = Describe("run basic podman commands", func() {
 		run, err := mb.setCmd(bm.withPodmanCommand([]string{"run", "-v", "a:/test:Z", TESTIMAGE, "true"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(run).To(Exit(0))
-	})
 
-	It("Volume should be virtiofs", func() {
-		// In theory this could run on MacOS too, but we know virtiofs works for that now,
-		// this is just testing linux
-		skipIfNotVmtype(define.QemuVirt, "This is just adding coverage for virtiofs on linux")
-
-		tDir, err := filepath.Abs(GinkgoT().TempDir())
-		Expect(err).ToNot(HaveOccurred())
-
-		err = os.WriteFile(filepath.Join(tDir, "testfile"), []byte("some test contents"), 0o644)
-		Expect(err).ToNot(HaveOccurred())
-
-		name := randomString()
-		i := new(initMachine).withImage(mb.imagePath).withNow()
-
-		// Ensure that this is a volume, it may not be automatically on qemu
-		i.withVolume(tDir)
-		session, err := mb.setName(name).setCmd(i).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		ssh := new(sshMachine).withSSHCommand([]string{"findmnt", "-no", "FSTYPE", tDir})
-		findmnt, err := mb.setName(name).setCmd(ssh).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(findmnt).To(Exit(0))
-		Expect(findmnt.outputToString()).To(ContainSubstring("virtiofs"))
+		if isVmtype(define.QemuVirt) {
+			// ensure we are actually using virtiofs on linux
+			ssh := new(sshMachine).withSSHCommand([]string{"findmnt", "-no", "FSTYPE", tDir})
+			findmnt, err := mb.setName(name).setCmd(ssh).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(findmnt).To(Exit(0))
+			Expect(findmnt.outputToString()).To(ContainSubstring("virtiofs"))
+		}
 	})
 
 	It("Volume should be disabled by command line", func() {

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -150,6 +150,9 @@ func setup() (string, *machineTestBuilder) {
 			Fail("unable to set home dir on windows")
 		}
 	}
+	if err := os.Setenv("XDG_CONFIG_HOME", filepath.Join(homeDir, ".config")); err != nil {
+		Fail("failed to set XDG_CONFIG_HOME dir")
+	}
 	if err := os.Setenv("XDG_RUNTIME_DIR", homeDir); err != nil {
 		Fail("failed to set xdg_runtime dir")
 	}

--- a/pkg/machine/e2e/proxy_test.go
+++ b/pkg/machine/e2e/proxy_test.go
@@ -2,12 +2,10 @@ package e2e_test
 
 import (
 	"os"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"go.podman.io/podman/v6/pkg/machine/define"
 )
 
 var _ = Describe("podman machine proxy settings propagation", func() {
@@ -15,20 +13,7 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 		defer func() {
 			os.Unsetenv("HTTP_PROXY")
 			os.Unsetenv("HTTPS_PROXY")
-			os.Unsetenv("SSL_CERT_DIR")
-			os.Unsetenv("SSL_CERT_FILE")
 		}()
-
-		certFileDir := GinkgoT().TempDir()
-		certDir := GinkgoT().TempDir()
-		certFile := filepath.Join(certFileDir, "cert1")
-		err := os.WriteFile(certFile, []byte("cert1 content\n"), os.ModePerm)
-		Expect(err).ToNot(HaveOccurred())
-		err = os.WriteFile(filepath.Join(certDir, "cert2"), []byte("cert2 content\n"), os.ModePerm)
-		Expect(err).ToNot(HaveOccurred())
-
-		os.Setenv("SSL_CERT_FILE", certFile)
-		os.Setenv("SSL_CERT_DIR", certDir)
 
 		name := randomString()
 		i := new(initMachine)
@@ -56,19 +41,6 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 		Expect(sshSession).To(Exit(0))
 		Expect(sshSession.outputToString()).To(ContainSubstring(proxyURL))
 
-		// SSL_CERT not implemented for WSL
-		if !isVmtype(define.WSLVirt) {
-			sshSession, err = mb.setName(name).setCmd(sshProxy.withSSHCommand([]string{"printenv", "SSL_CERT_DIR", "SSL_CERT_FILE"})).run()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sshSession).To(Exit(0))
-			Expect(string(sshSession.Out.Contents())).To(Equal(define.UserCertsTargetPath + "\n" + define.UserCertsTargetPath + "/cert1" + "\n"))
-
-			sshSession, err = mb.setName(name).setCmd(sshProxy.withSSHCommand([]string{"cat", "$SSL_CERT_DIR/cert2", "$SSL_CERT_FILE"})).run()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sshSession).To(Exit(0))
-			Expect(string(sshSession.Out.Contents())).To(Equal("cert2 content\ncert1 content\n"))
-		}
-
 		stop := new(stopMachine)
 		stopSession, err := mb.setName(name).setCmd(stop).run()
 		Expect(err).ToNot(HaveOccurred())
@@ -82,10 +54,6 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 		os.Setenv("HTTPS_PROXY", proxy2)
 		os.Setenv("NO_PROXY", noproxy)
 
-		// changing SSL_CERT vars should not have an effect
-		os.Setenv("SSL_CERT_FILE", "/tmp/1")
-		os.Setenv("SSL_CERT_DIR", "/tmp")
-
 		// start it again should update the proxies
 		startSession, err = mb.setName(name).setCmd(s).run()
 		Expect(err).ToNot(HaveOccurred())
@@ -95,14 +63,5 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sshSession).To(Exit(0))
 		Expect(string(sshSession.Out.Contents())).To(Equal(proxy1 + "\n" + proxy2 + "\n" + noproxy + "\n"))
-
-		// SSL_CERT not implemented for WSL
-		if !isVmtype(define.WSLVirt) {
-			// SSL_CERT... must still be the same as before
-			sshSession, err = mb.setName(name).setCmd(sshProxy.withSSHCommand([]string{"cat", "$SSL_CERT_DIR/cert2", "$SSL_CERT_FILE"})).run()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sshSession).To(Exit(0))
-			Expect(string(sshSession.Out.Contents())).To(Equal("cert2 content\ncert1 content\n"))
-		}
 	})
 })

--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -323,8 +323,9 @@ pids_limit=0
 	files = append(files, File{
 		Node: Node{
 			Group: GetNodeGrp("root"),
-			Path:  "/etc/containers/podman-machine",
-			User:  GetNodeUsr("root"),
+			// Files used to /etc/containers/podman-machine but had to be moved so we do not overmount it.
+			Path: "/etc/podman-machine",
+			User: GetNodeUsr("root"),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,

--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -5,17 +5,14 @@ package ignition
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 
 	"github.com/sirupsen/logrus"
 	"go.podman.io/podman/v6/pkg/machine/define"
 	"go.podman.io/podman/v6/pkg/systemd/parser"
-	"go.podman.io/storage/pkg/fileutils"
 )
 
 /*
@@ -367,161 +364,7 @@ pids_limit=0
 		})
 	}
 
-	// get certs for current user
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		logrus.Warnf("Unable to copy certs via ignition %s", err.Error())
-		return files
-	}
-
-	certFiles := getCerts(filepath.Join(userHome, ".config/containers/certs.d"), true)
-	files = append(files, certFiles...)
-
-	certFiles = getCerts(filepath.Join(userHome, ".config/docker/certs.d"), true)
-	files = append(files, certFiles...)
-
-	sslCertFileName, ok := os.LookupEnv(sslCertFile)
-	if ok {
-		if err := fileutils.Exists(sslCertFileName); err == nil {
-			certFiles = getCerts(sslCertFileName, false)
-			files = append(files, certFiles...)
-		} else {
-			logrus.Warnf("Invalid path in %s: %q", sslCertFile, err)
-		}
-	}
-
-	sslCertDirName, ok := os.LookupEnv(sslCertDir)
-	if ok {
-		if err := fileutils.Exists(sslCertDirName); err == nil {
-			certFiles = getCerts(sslCertDirName, true)
-			files = append(files, certFiles...)
-		} else {
-			logrus.Warnf("Invalid path in %s: %q", sslCertDir, err)
-		}
-	}
-	if sslCertFileName != "" || sslCertDirName != "" {
-		// If we copied certs via env then also make the to set the env in the VM.
-		files = append(files, getSSLEnvironmentFiles(sslCertFileName, sslCertDirName)...)
-	}
-
 	return files
-}
-
-func getCerts(certsDir string, isDir bool) []File {
-	var files []File
-
-	if isDir {
-		err := filepath.WalkDir(certsDir, func(path string, d fs.DirEntry, err error) error {
-			if err == nil && !d.IsDir() {
-				certPath, err := filepath.Rel(certsDir, path)
-				if err != nil {
-					logrus.Warnf("%s", err)
-					return nil
-				}
-
-				file, err := prepareCertFile(filepath.Join(certsDir, certPath), certPath)
-				if err == nil {
-					files = append(files, file)
-				}
-			}
-
-			return nil
-		})
-		if err != nil {
-			if !os.IsNotExist(err) {
-				logrus.Warnf("Unable to copy certs via ignition, error while reading certs from %s:  %s", certsDir, err.Error())
-			}
-		}
-	} else {
-		fileName := filepath.Base(certsDir)
-		file, err := prepareCertFile(certsDir, fileName)
-		if err == nil {
-			files = append(files, file)
-		}
-	}
-
-	return files
-}
-
-func prepareCertFile(fpath string, name string) (File, error) {
-	b, err := os.ReadFile(fpath)
-	if err != nil {
-		logrus.Warnf("Unable to read cert file %v", err)
-		return File{}, err
-	}
-
-	// Note path is required here as we always create a path for the linux VM
-	// even when the client run on windows so we cannot use filepath.
-	targetPath := path.Join(define.UserCertsTargetPath, name)
-
-	logrus.Debugf("Copying cert file from '%s' to '%s'.", fpath, targetPath)
-
-	file := File{
-		Node: Node{
-			Group: GetNodeGrp("root"),
-			Path:  targetPath,
-			User:  GetNodeUsr("root"),
-		},
-		FileEmbedded1: FileEmbedded1{
-			Append: nil,
-			Contents: Resource{
-				Source: EncodeDataURLPtr(string(b)),
-			},
-			Mode: IntToPtr(0o644),
-		},
-	}
-	return file, nil
-}
-
-const (
-	systemdSSLConf = "/etc/systemd/system.conf.d/podman-machine-ssl.conf"
-	envdSSLConf    = "/etc/environment.d/podman-machine-ssl.conf"
-	profileSSLConf = "/etc/profile.d/podman-machine-ssl.sh"
-	sslCertFile    = "SSL_CERT_FILE"
-	sslCertDir     = "SSL_CERT_DIR"
-)
-
-func getSSLEnvironmentFiles(sslFileName, sslDirName string) []File {
-	systemdFileContent := "[Manager]\n"
-	envdFileContent := ""
-	profileFileContent := ""
-	if sslFileName != "" {
-		// certs are written to UserCertsTargetPath see prepareCertFile()
-		// Note the mix of path/filepath is intentional and required, we want to get the name of
-		// a path on the client (i.e. windows) but then join to linux path that will be used inside the VM.
-		env := fmt.Sprintf("%s=%q\n", sslCertFile, path.Join(define.UserCertsTargetPath, filepath.Base(sslFileName)))
-		systemdFileContent += "DefaultEnvironment=" + env
-		envdFileContent += env
-		profileFileContent += "export " + env
-	}
-	if sslDirName != "" {
-		// certs are written to UserCertsTargetPath see prepareCertFile()
-		env := fmt.Sprintf("%s=%q\n", sslCertDir, define.UserCertsTargetPath)
-		systemdFileContent += "DefaultEnvironment=" + env
-		envdFileContent += env
-		profileFileContent += "export " + env
-	}
-	return []File{
-		getSSLFile(systemdSSLConf, systemdFileContent),
-		getSSLFile(envdSSLConf, envdFileContent),
-		getSSLFile(profileSSLConf, profileFileContent),
-	}
-}
-
-func getSSLFile(path, content string) File {
-	return File{
-		Node: Node{
-			Group: GetNodeGrp("root"),
-			Path:  path,
-			User:  GetNodeUsr("root"),
-		},
-		FileEmbedded1: FileEmbedded1{
-			Contents: Resource{
-				Source: EncodeDataURLPtr(content),
-			},
-			Mode: IntToPtr(0o644),
-		},
-	}
 }
 
 func getLinks() []Link {

--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -14,9 +14,6 @@ const containersConf = `[containers]
 cgroup_manager = "cgroupfs"
 `
 
-const registriesConf = `unqualified-search-registries=["docker.io"]
-`
-
 const appendPort = `grep -q Port\ %d /etc/ssh/sshd_config || echo Port %d >> /etc/ssh/sshd_config`
 
 const changePort = `sed -E -i 's/^Port[[:space:]]+[0-9]+/Port %d/' /etc/ssh/sshd_config`

--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -104,6 +104,18 @@ const overrideSysusers = `[Service]
 LoadCredential=
 `
 
+const bindMountConfigDirSystemService = `
+[Unit]
+Description=Bind mount for config directory
+Before=podman.socket
+
+[Service]
+RemainAfterExit=true
+Type=oneshot
+ExecStart=mount --bind %[1]s /etc/containers
+ExecStop=umount /etc/containers
+`
+
 const bindMountSystemService = `
 [Unit]
 Description=Bind mount for system podman sockets
@@ -153,11 +165,16 @@ const (
 	bindSysUnitWant        = sysSystemdWants + "/" + bindUnitFileName
 	podmanSocketDropin     = "podman.socket.d"
 	podmanSocketDropinPath = sysSystemdPath + "/" + podmanSocketDropin
+
+	configBindSysUnitName = "podman-mnt-config.service"
+	configBindSysUnitPath = sysSystemdPath + "/" + configBindSysUnitName
+	configBindSysUnitWant = sysSystemdWants + "/" + configBindSysUnitName
 )
 
 const configBindServices = "mkdir -p " + userSystemdWants + " " + sysSystemdWants + " " + podmanSocketDropinPath + "\n" +
 	"ln -fs " + bindUserUnitPath + " " + bindUserUnitWant + "\n" +
-	"ln -fs " + bindSysUnitPath + " " + bindSysUnitWant + "\n"
+	"ln -fs " + bindSysUnitPath + " " + bindSysUnitWant + "\n" +
+	"ln -fs " + configBindSysUnitPath + " " + configBindSysUnitWant + "\n"
 
 const overrideSocketGroup = `
 [Socket]

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -179,7 +179,7 @@ func configureSystem(mc *vmconfigs.MachineConfig, dist string, ansibleConfig *vm
 		return err
 	}
 
-	if err := wslInvoke(dist, "sh", "-c", "echo wsl > /etc/containers/podman-machine"); err != nil {
+	if err := wslInvoke(dist, "sh", "-c", "echo wsl > /etc/podman-machine"); err != nil {
 		return fmt.Errorf("could not create podman-machine file for guest OS: %w", err)
 	}
 

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -171,10 +171,6 @@ func configureSystem(mc *vmconfigs.MachineConfig, dist string, ansibleConfig *vm
 		return fmt.Errorf("could not create containers.conf for guest OS: %w", err)
 	}
 
-	if err := configureRegistries(dist); err != nil {
-		return err
-	}
-
 	if err := setupPodmanDockerSock(dist, mc.HostUser.Rootful); err != nil {
 		return err
 	}
@@ -259,15 +255,6 @@ func enableUserLinger(mc *vmconfigs.MachineConfig, dist string) error {
 	lingerCmd := "mkdir -p /var/lib/systemd/linger; touch /var/lib/systemd/linger/" + mc.SSH.RemoteUsername
 	if err := wslInvoke(dist, "sh", "-c", lingerCmd); err != nil {
 		return fmt.Errorf("could not enable linger for remote user on guest OS: %w", err)
-	}
-
-	return nil
-}
-
-func configureRegistries(dist string) error {
-	cmd := "cat > /etc/containers/registries.conf.d/999-podman-machine.conf"
-	if err := wslPipe(registriesConf, dist, "sh", "-c", cmd); err != nil {
-		return fmt.Errorf("could not configure registries on guest OS: %w", err)
 	}
 
 	return nil

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -22,7 +22,9 @@ import (
 	"go.podman.io/podman/v6/pkg/machine/vmconfigs"
 	winutil "go.podman.io/podman/v6/pkg/machine/windows"
 	"go.podman.io/podman/v6/pkg/machine/wsl/wutil"
+	"go.podman.io/podman/v6/pkg/specgen"
 	"go.podman.io/podman/v6/utils"
+	"go.podman.io/storage/pkg/configfile"
 )
 
 var (
@@ -189,6 +191,19 @@ func configureSystem(mc *vmconfigs.MachineConfig, dist string, ansibleConfig *vm
 }
 
 func configureBindMounts(dist string, user string) error {
+	winPath, err := configfile.UserConfigPath()
+	if err != nil {
+		return err
+	}
+	wslPath, err := specgen.ConvertWinMountPath(winPath)
+	if err != nil {
+		return err
+	}
+
+	if err := wslPipe(fmt.Sprintf(bindMountConfigDirSystemService, wslPath), dist, "sh", "-c", "cat > "+configBindSysUnitPath); err != nil {
+		return fmt.Errorf("could not create podman config mount service file for guest OS: %w", err)
+	}
+
 	if err := wslPipe(fmt.Sprintf(bindMountSystemService, dist), dist, "sh", "-c", "cat > /etc/systemd/system/podman-mnt-bindings.service"); err != nil {
 		return fmt.Errorf("could not create podman binding service file for guest OS: %w", err)
 	}

--- a/vendor/go.podman.io/common/pkg/config/default.go
+++ b/vendor/go.podman.io/common/pkg/config/default.go
@@ -201,6 +201,11 @@ func defaultConfig() (*Config, error) {
 		return nil, err
 	}
 
+	machineConfig, err := defaultMachineConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	return &Config{
 		Containers: ContainersConfig{
 			Annotations:         configfile.Slice{},
@@ -247,7 +252,7 @@ func defaultConfig() (*Config, error) {
 		},
 		Engine:   *defaultEngineConfig,
 		Secrets:  defaultSecretConfig(),
-		Machine:  defaultMachineConfig(),
+		Machine:  machineConfig,
 		Farms:    defaultFarmConfig(),
 		Podmansh: defaultPodmanshConfig(),
 	}, nil
@@ -262,20 +267,33 @@ func defaultSecretConfig() SecretConfig {
 }
 
 // defaultMachineConfig returns the default machine configuration.
-func defaultMachineConfig() MachineConfig {
+func defaultMachineConfig() (MachineConfig, error) {
 	cpus := runtime.NumCPU() / 2
 	if cpus == 0 {
 		cpus = 1
 	}
+
+	volumes := getDefaultMachineVolumes()
+	path, err := configfile.UserConfigPath()
+	if err != nil {
+		return MachineConfig{}, err
+	}
+	// Mount the (host side) user config dir to the machine /etc/containers.
+	// It removes some confusion for machine users where they did not know
+	// if the config setting applies on the host or sever, with the mount host
+	// and server should see the same files and thus there is only one place to
+	// put it into.
+	volumes = append(volumes, path+":/etc/containers")
+
 	return MachineConfig{
 		CPUs:     uint64(cpus),
 		DiskSize: 100,
 		Image:    "docker://quay.io/podman/machine-os",
 		Memory:   2048,
 		User:     getDefaultMachineUser(),
-		Volumes:  configfile.NewSlice(getDefaultMachineVolumes()),
+		Volumes:  configfile.NewSlice(volumes),
 		Rosetta:  false,
-	}
+	}, nil
 }
 
 // defaultFarmConfig returns the default farms configuration.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -735,7 +735,7 @@ go.podman.io/buildah/pkg/sshagent
 go.podman.io/buildah/pkg/util
 go.podman.io/buildah/pkg/volumes
 go.podman.io/buildah/util
-# go.podman.io/common v0.67.2-0.20260506114327-35c76125c5b5
+# go.podman.io/common v0.67.2-0.20260511131139-020a2274da88 => github.com/Luap99/container-libs/common v0.0.0-20260507114201-8488036ffdbc
 ## explicit; go 1.25.6
 go.podman.io/common/internal
 go.podman.io/common/libimage
@@ -801,7 +801,7 @@ go.podman.io/common/pkg/umask
 go.podman.io/common/pkg/util
 go.podman.io/common/pkg/version
 go.podman.io/common/version
-# go.podman.io/image/v5 v5.39.3-0.20260506114327-35c76125c5b5
+# go.podman.io/image/v5 v5.39.3-0.20260511131139-020a2274da88 => github.com/Luap99/container-libs/image/v5 v5.0.0-20260507114201-8488036ffdbc
 ## explicit; go 1.25.6
 go.podman.io/image/v5/copy
 go.podman.io/image/v5/directory
@@ -878,7 +878,7 @@ go.podman.io/image/v5/transports
 go.podman.io/image/v5/transports/alltransports
 go.podman.io/image/v5/types
 go.podman.io/image/v5/version
-# go.podman.io/storage v1.62.1-0.20260506114327-35c76125c5b5
+# go.podman.io/storage v1.62.1-0.20260511131139-020a2274da88 => github.com/Luap99/container-libs/storage v0.0.0-20260507114201-8488036ffdbc
 ## explicit; go 1.25.0
 go.podman.io/storage
 go.podman.io/storage/drivers
@@ -1182,3 +1182,6 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v1.1.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
+# go.podman.io/common => github.com/Luap99/container-libs/common v0.0.0-20260507114201-8488036ffdbc
+# go.podman.io/image/v5 => github.com/Luap99/container-libs/image/v5 v5.0.0-20260507114201-8488036ffdbc
+# go.podman.io/storage => github.com/Luap99/container-libs/storage v0.0.0-20260507114201-8488036ffdbc


### PR DESCRIPTION
see commits


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Podman machine now mounts the hosts containers user configuration directory, (i.e. ~/.config/containers) to into the machine to /etc/containers. This is done to allow users to edit the containers config files (i.e. containers.conf, registries.conf) on their host system without having to copy the files into VM.
```
