### PR TITLE
fix: return tty size in container_inspect.go

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -626,12 +626,6 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 		}
 	}
 
-	// Terminal size
-	// We can't actually get this for now...
-	// So default to something sane.
-	// TODO: Populate this.
-	hostConfig.ConsoleSize = []uint{0, 0}
-
 	return hostConfig, nil
 }
 

--- a/libpod/container_inspect_freebsd.go
+++ b/libpod/container_inspect_freebsd.go
@@ -24,5 +24,11 @@ func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostC
 		return err
 	}
 
+	// Console size
+	// We can't actually get this for now...
+	// So default to something sane.
+	// TODO: Populate this.
+	hostConfig.ConsoleSize = []uint{0, 0}
+
 	return nil
 }

--- a/libpod/container_inspect_linux.go
+++ b/libpod/container_inspect_linux.go
@@ -4,6 +4,7 @@ package libpod
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	"go.podman.io/podman/v6/libpod/define"
 	"go.podman.io/podman/v6/pkg/util"
 	"go.podman.io/storage/types"
+	"golang.org/x/term"
 )
 
 func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostConfig *define.InspectContainerHostConfig) error {
@@ -304,6 +306,29 @@ func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostC
 	hostConfig.Devices, err = c.GetDevices(hostConfig.Privileged, *ctrSpec, deviceNodes)
 	if err != nil {
 		return err
+	}
+
+	// ConsoleSize.
+	// Default to [0,0] if we can't get it for some reason,
+	// or if the container doesn't have a TTY.
+	hostConfig.ConsoleSize = []uint{0, 0}
+
+	if c.Terminal() {
+		procPath := fmt.Sprintf("/proc/%d/fd/0", c.state.PID)
+
+		f, err := os.Open(procPath)
+		if err != nil {
+			logrus.Debugf("unable to get console size for container %s: %v", c.ID(), err)
+		} else {
+			defer f.Close()
+
+			width, height, err := term.GetSize(int(f.Fd()))
+			if err != nil {
+				logrus.Debugf("could not get terminal size: %v", err)
+			} else {
+				hostConfig.ConsoleSize = []uint{uint(height), uint(width)}
+			}
+		}
 	}
 
 	return nil

--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -142,4 +142,53 @@ function teardown() {
     run_podman volume rm testVol --force
 }
 
+@test "podman inspect returns attached tty size" {
+
+    # Skip on FreeBSD
+    if [[ "$(uname -s)" == "FreeBSD" ]]; then
+        skip "ConsoleSize not implemented on FreeBSD"
+    fi
+
+    rows=$(( 15 + RANDOM % 60 |   1 ))
+    cols=$(( 15 + RANDOM % 60 & 126 ))
+
+    cname=c-$(safename)
+
+    stty rows $rows cols $cols <$PODMAN_TEST_PTY
+
+    # Run container with attached tty in background.
+    run_podman run -it --name $cname $IMAGE top <$PODMAN_TEST_PTY &
+
+    # Wait for container to appear
+    local timeout=10
+    while :;do
+          sleep 0.5
+          run_podman '?' container exists $cname
+          if [[ $status -eq 0 ]]; then
+              break
+          fi
+          timeout=$((timeout - 1))
+          if [[ $timeout -eq 0 ]]; then
+              run_podman ps -a
+              die "Timed out waiting for container $cname to start"
+          fi
+    done
+
+    # Now that container exists, wait for it to be in running state
+    _ensure_container_running $cname true
+
+    run_podman inspect $cname --format '{{ index .HostConfig.ConsoleSize 0 }} {{ index .HostConfig.ConsoleSize 1 }}'
+    is "$output" "$rows $cols" "podman returns non-zero size when tty is attached"
+
+    run_podman rm -t 0 -f $cname
+
+    # Run container without attached tty in detached mode.
+    run_podman run -dt --name $cname $IMAGE top
+
+    run_podman inspect $cname --format '{{ index .HostConfig.ConsoleSize 0 }} {{ index .HostConfig.ConsoleSize 1 }}'
+    is "$output" "0 0" "podman returns zero size when tty is not attached"
+
+    run_podman rm -t 0 -f $cname
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
In the output of podman inspect, there is a field for the container's TTY size (ConsoleSize), which Podman presently only returns [0,0]. 
This PR updates the tty size for containers which have terminal enabled and are in running state. 
For cases where there is an issue with getting the size or the container is not running, suitable warning is given, no update happens and default [0,0] is returned.

Fixes: #28368

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fix podman inspect to return console size of a running container.
```
