### PR TITLE
fix: include IPRange in Docker-compat network IPAM config

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -3,6 +3,7 @@
 package compat
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -22,6 +23,57 @@ import (
 	dockerNetwork "github.com/moby/moby/api/types/network"
 	"github.com/sirupsen/logrus"
 )
+
+// leaseRangeToDockerIPRange maps Libpod LeaseRange back to Docker IPAM IPRange when it is exactly
+// the usable span of some CIDR (same semantics as FirstIPInSubnet/LastIPInSubnet used when creating from Docker API).
+func leaseRangeToDockerIPRange(lr *nettypes.LeaseRange) netip.Prefix {
+	if lr == nil || lr.StartIP == nil || lr.EndIP == nil {
+		return netip.Prefix{}
+	}
+	start := append(net.IP(nil), lr.StartIP...)
+	end := append(net.IP(nil), lr.EndIP...)
+	netutil.NormalizeIP(&start)
+	netutil.NormalizeIP(&end)
+
+	switch {
+	case start.To4() != nil && end.To4() != nil:
+		return leaseSpanToPrefix(start.To4(), end.To4(), 32)
+	case len(start) == net.IPv6len && len(end) == net.IPv6len:
+		s := start.To16()
+		e := end.To16()
+		return leaseSpanToPrefix(s, e, 128)
+	default:
+		return netip.Prefix{}
+	}
+}
+
+func leaseSpanToPrefix(start, end net.IP, ipLen int) netip.Prefix {
+	if bytes.Compare(start, end) > 0 {
+		return netip.Prefix{}
+	}
+	for ones := ipLen; ones >= 0; ones-- {
+		mask := net.CIDRMask(ones, ipLen)
+		ipNet := &net.IPNet{
+			IP:   start.Mask(mask),
+			Mask: mask,
+		}
+		first, err1 := netutil.FirstIPInSubnet(ipNet)
+		last, err2 := netutil.LastIPInSubnet(ipNet)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		netutil.NormalizeIP(&first)
+		netutil.NormalizeIP(&last)
+		if first.Equal(start) && last.Equal(end) {
+			pfx, err := netip.ParsePrefix(ipNet.String())
+			if err != nil {
+				continue
+			}
+			return pfx
+		}
+	}
+	return netip.Prefix{}
+}
 
 func normalizeNetworkName(rt *libpod.Runtime, name string) (string, bool) {
 	if name == nettypes.BridgeNetworkDriver {
@@ -119,9 +171,9 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, statuses []abi
 			return nil, fmt.Errorf("invalid gateway IP %v", sub.Gateway)
 		}
 		ipamConfig := dockerNetwork.IPAMConfig{
-			Subnet:  subnet,
-			Gateway: gateway,
-			// TODO add range
+			Subnet:   subnet,
+			Gateway:  gateway,
+			IPRange:  leaseRangeToDockerIPRange(sub.LeaseRange),
 		}
 		ipamConfigs = append(ipamConfigs, ipamConfig)
 	}

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -192,6 +192,21 @@ t DELETE libpod/networks/macvlan1 200 \
   .[0].Name~macvlan1 \
   .[0].Err=null
 
+# test IPRange in Docker-compat IPAM config (#28378)
+t POST networks/create Name='"iprange-net"' \
+  IPAM='{"Config":[{"Subnet":"10.10.200.0/24","Gateway":"10.10.200.1","IPRange":"10.10.200.128/25"}]}' 201 \
+  .Id~[0-9a-f]\\{64\\}
+
+# inspect should return the IPRange field in IPAM.Config
+t GET networks/iprange-net 200 \
+  .Name=iprange-net \
+  .IPAM.Config[0].Subnet=10.10.200.0/24 \
+  .IPAM.Config[0].Gateway=10.10.200.1 \
+  .IPAM.Config[0].IPRange=10.10.200.128/25
+
+# clean up
+t DELETE networks/iprange-net 204
+
 #
 # test networks with containers
 #


### PR DESCRIPTION
## Problem

The Docker-compatible network API omits the `IPRange` field from IPAM config even though Libpod stores this data, so tools reading the Docker API cannot see the configured IP range.

## Change

Map Libpod's `LeaseRange` to Docker-compatible `IPAMConfig.IPRange` in `convertLibpodNetworkToDockerNetwork`, when it aligns with a full CIDR span derived from `FirstIPInSubnet`/`LastIPInSubnet`.

Adds an integration test in `test/apiv2/35-networks.at` that creates a network via the compat API with an explicit `IPRange` and asserts it is returned on inspect.

Fixes: #28378
