### PR TITLE
Add --retry support to manifest push

### DIFF
--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -88,6 +88,13 @@ func init() {
 	flags.BoolVarP(&manifestPushOpts.Quiet, "quiet", "q", false, "don't output progress information when pushing lists")
 	flags.SetNormalizeFunc(utils.AliasFlags)
 
+	retryFlagName := "retry"
+	flags.Uint(retryFlagName, registry.RetryDefault(), "number of times to retry in case of failure when performing push")
+	_ = pushCmd.RegisterFlagCompletionFunc(retryFlagName, completion.AutocompleteNone)
+	retryDelayFlagName := "retry-delay"
+	flags.String(retryDelayFlagName, registry.RetryDelayDefault(), "delay between retries in case of push failures")
+	_ = pushCmd.RegisterFlagCompletionFunc(retryDelayFlagName, completion.AutocompleteNone)
+
 	compressionFormat := "compression-format"
 	flags.StringVar(&manifestPushOpts.CompressionFormat, compressionFormat, "", "compression format to use")
 	_ = pushCmd.RegisterFlagCompletionFunc(compressionFormat, common.AutocompleteCompressionFormat)
@@ -134,6 +141,24 @@ func push(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer signingCleanup()
+
+	if cmd.Flags().Changed("retry") {
+		retry, err := cmd.Flags().GetUint("retry")
+		if err != nil {
+			return err
+		}
+
+		manifestPushOpts.Retry = &retry
+	}
+
+	if cmd.Flags().Changed("retry-delay") {
+		val, err := cmd.Flags().GetString("retry-delay")
+		if err != nil {
+			return err
+		}
+
+		manifestPushOpts.RetryDelay = val
+	}
 
 	// TLS verification in c/image is controlled via a `types.OptionalBool`
 	// which allows for distinguishing among set-true, set-false, unspecified

--- a/docs/source/markdown/options/retry-delay.md
+++ b/docs/source/markdown/options/retry-delay.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman artifact pull, artifact push, build, podman-build.unit.5.md.in, podman-container.unit.5.md.in, create, farm build, podman-image.unit.5.md.in, pull, push, run
+####>   podman artifact pull, artifact push, build, podman-build.unit.5.md.in, podman-container.unit.5.md.in, create, farm build, podman-image.unit.5.md.in, manifest push, pull, push, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 << if is_quadlet >>

--- a/docs/source/markdown/options/retry.md
+++ b/docs/source/markdown/options/retry.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman artifact pull, artifact push, build, podman-build.unit.5.md.in, podman-container.unit.5.md.in, create, farm build, podman-image.unit.5.md.in, pull, push, run
+####>   podman artifact pull, artifact push, build, podman-build.unit.5.md.in, podman-container.unit.5.md.in, create, farm build, podman-image.unit.5.md.in, manifest push, pull, push, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 << if is_quadlet >>

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -56,6 +56,10 @@ When writing the manifest, suppress progress output
 
 Don't copy signatures when pushing images.
 
+@@option retry
+
+@@option retry-delay
+
 #### **--rm**
 
 Delete the manifest list or image index from local storage if pushing succeeds.

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -359,6 +359,8 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		ForceCompressionFormat bool     `schema:"forceCompressionFormat"`
 		Format                 string   `schema:"format"`
 		RemoveSignatures       bool     `schema:"removeSignatures"`
+		Retry                  uint     `schema:"retry"`
+		RetryDelay             string   `schema:"retryDelay"`
 		TLSVerify              bool     `schema:"tlsVerify"`
 		Quiet                  bool     `schema:"quiet"`
 		AddCompression         []string `schema:"addCompression"`
@@ -418,6 +420,10 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
 	}
+	if _, found := r.URL.Query()["retry"]; found {
+		options.Retry = &query.Retry
+	}
+	options.RetryDelay = query.RetryDelay
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	source := utils.GetName(r)

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -94,6 +94,14 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    description: "silences extra stream data on push"
 	//    type: boolean
 	//    default: true
+	//  - in: query
+	//    name: retry
+	//    description: Number of times to retry push in case of failure.
+	//    type: integer
+	//  - in: query
+	//    name: retryDelay
+	//    description: Delay between retries in case of push failures.
+	//    type: string
 	// responses:
 	//   200:
 	//     schema:

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -502,13 +503,31 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 	pushOptions.CompressionLevel = opts.CompressionLevel
 	pushOptions.AddCompression = opts.AddCompression
 	pushOptions.ForceCompressionFormat = opts.ForceCompressionFormat
+	pushOptions.MaxRetries = opts.Retry
 
-	compressionFormat := opts.CompressionFormat
-	if compressionFormat == "" {
-		config, err := ir.Libpod.GetConfigNoCopy()
+	config, err := ir.Libpod.GetConfigNoCopy()
+	if err != nil {
+		return "", err
+	}
+
+	if pushOptions.MaxRetries == nil {
+		retry := config.Engine.Retry
+		pushOptions.MaxRetries = &retry
+	}
+	retryDelay := opts.RetryDelay
+	if retryDelay == "" {
+		retryDelay = config.Engine.RetryDelay
+	}
+	if retryDelay != "" {
+		duration, err := time.ParseDuration(retryDelay)
 		if err != nil {
 			return "", err
 		}
+		pushOptions.RetryDelay = &duration
+	}
+
+	compressionFormat := opts.CompressionFormat
+	if compressionFormat == "" {
 		compressionFormat = config.Engine.CompressionFormat
 	}
 	if compressionFormat != "" {
@@ -519,10 +538,6 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 		pushOptions.CompressionFormat = &algo
 	}
 	if pushOptions.CompressionLevel == nil {
-		config, err := ir.Libpod.GetConfigNoCopy()
-		if err != nil {
-			return "", err
-		}
 		pushOptions.CompressionLevel = config.Engine.CompressionLevel
 	}
 

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -191,6 +191,12 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 	options := new(images.PushOptions)
 	options.WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithRemoveSignatures(opts.RemoveSignatures).WithAll(opts.All).WithFormat(opts.Format).WithCompressionFormat(opts.CompressionFormat).WithQuiet(opts.Quiet).WithProgressWriter(opts.Writer).WithAddCompression(opts.AddCompression).WithForceCompressionFormat(opts.ForceCompressionFormat)
 
+	if opts.Retry != nil {
+		options.WithRetry(*opts.Retry)
+	}
+	if opts.RetryDelay != "" {
+		options.WithRetryDelay(opts.RetryDelay)
+	}
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
 			options.WithSkipTLSVerify(true)

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -602,7 +602,7 @@ RUN touch /file
 		Expect(output).To(ContainSubstring("Storing list signatures"))
 	})
 
-	It("push must retry", func() {
+	It("push must retry with defaults", func() {
 		SkipIfRemote("warning is not relayed in remote setup")
 		session := podmanTest.Podman([]string{"manifest", "create", "foo", imageList})
 		session.WaitWithDefaultTimeout()
@@ -612,6 +612,19 @@ RUN touch /file
 		push.WaitWithDefaultTimeout()
 		Expect(push).Should(ExitWithError(125, "Failed, retrying in 1s ... (1/3)"))
 		Expect(push.ErrorToString()).To(MatchRegexp("Copying blob.*Failed, retrying in 1s \\.\\.\\. \\(1/3\\).*Copying blob.*Failed, retrying in 2s"))
+	})
+
+	It("push must retry with options", func() {
+		podmanTest.PodmanExitCleanly("manifest", "create", "foo", imageList)
+
+		push := podmanTest.Podman([]string{"manifest", "push", "--all", "--retry", "2", "--retry-delay", "100ms", "--tls-verify=false", "--remove-signatures", "foo", "localhost:7000/bogus"})
+		push.WaitWithDefaultTimeout()
+		Expect(push).Should(ExitWithError(125, "connect: connection refused"))
+		// The retrying warning is not relayed in the remote setup, so only
+		// assert it for the local client.
+		if !IsRemote() {
+			Expect(push.ErrorToString()).To(MatchRegexp("Copying blob.*Failed, retrying in 100ms \\.\\.\\. \\(1/2\\).*Copying blob.*Failed, retrying in 100ms \\.\\.\\. \\(2/2\\)"))
+		}
 	})
 
 	It("authenticated push", func() {


### PR DESCRIPTION
This PR enables retry behavior for podman manifest push across CLI, remote clients, and REST API.

Changes include:

New flags: --retry, --retry-delay
CLI flags stored in ImagePushOptions and applied to local and remote pushes
REST API accepts retry and retryDelay query parameters
Manpages and Swagger docs updated
e2e tests ensure retry settings take effect

Fixes: #28590
