### PR TITLE
troubleshooting: document setgroups requirement

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -531,8 +531,9 @@ Any access inside the container is rejected with "Permission denied".
 
 The runtime uses `setgroups(2)` hence the process loses all additional groups
 the non-root user has. Use the `--group-add keep-groups` flag to pass the
-user's supplementary group access into the container. Currently only available
-with the `crun` OCI runtime.
+user's supplementary group access into the container. For it to work,
+the container itself must not call `setgroups()`.
+Currently only available with the `crun` OCI runtime.
 
 ### 21) A rootless container running in detached mode is closed at logout
 <!-- This is the same as section 17 above and should be deleted -->


### PR DESCRIPTION
Document additional requirement for `--group-add keep-groups`  to work.

Mentioned by @Luap99 in
https://github.com/containers/podman/discussions/25172#discussioncomment-12016911

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
