### PR TITLE
Allow running exec with no attach streams requested

### DIFF
--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -166,6 +166,19 @@ func ExecStartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// If no streams were requested for attach, detach is implied
+	if !bodyParams.Detach {
+		execSession, err := sessionCtr.ExecSession(sessionID)
+		if err != nil {
+			utils.InternalServerError(w, err)
+			return
+		}
+
+		if !execSession.Config.AttachStderr && !execSession.Config.AttachStdout && !execSession.Config.AttachStdin {
+			bodyParams.Detach = true
+		}
+	}
+
 	if bodyParams.Detach {
 		// If we are detaching, we do NOT want to hijack.
 		// Instead, we perform a detached start, and return 200 if

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -916,6 +916,27 @@ t POST libpod/containers/$cid/update \
 
 t DELETE containers/$cid 204
 
+# Verify that exec session with no attach streams specified can be started
+CTRNAME=exectest
+podman run -d --name $CTRNAME $IMAGE top
+echo '{ "Cmd":["sh", "-c", "echo hello > /tmp/testfile"]}' >${TMPD}/exec_empty.json
+t POST "containers/$CTRNAME/exec" ${TMPD}/exec_empty.json 201 .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t POST exec/$eid/start 200
+# Need to wait for the exec to actually run, given it's detached
+TRIES=5
+while [[ $TRIES -gt 0 ]]; do
+    podman exec $CTRNAME ls /tmp/testfile
+    if [[ "$output" = "/tmp/testfile" ]]; then
+	break
+    fi
+    sleep 1
+    TRIES=$((TRIES - 1))
+done
+podman exec $CTRNAME cat /tmp/testfile
+is "$output" "hello"
+podman rm -f $CTRNAME
+
 rm -rf $TMPD
 
 podman container rm -fa


### PR DESCRIPTION
This is a small Docker compat fix with the API exec endpoints. With Docker, sending a bare Exec Create (command only, nothing else set) and then an Exec Start without Detach set performs a detached exec. With Podman, we threw an error that at least one stream must be attached to. Fix is trivial; look up the session before start, check the config for attach streams, and force detach on if none are set.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed  a bug where the Exec Start endpoint would return an error when trying to start an exec session with no standard streams attached without specifying `Detach=true`
```
