### PR TITLE
api: emit aux trailer with manifest digest on image push

### DIFF
--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -224,6 +224,22 @@ loop: // break out of for/select infinite loop
 			if pushReport != nil {
 				digestStr = pushReport.ManifestDigest
 			}
+			// Match Docker's behaviour: emit the manifest digest as an
+			// `aux` JSON trailer at the end of the push stream so clients
+			// can recover it without round-tripping the registry.
+			auxPayload, auxErr := json.Marshal(struct {
+				Tag    string `json:"Tag"`
+				Digest string `json:"Digest"`
+				Size   int    `json:"Size"`
+			}{
+				Tag:    tag,
+				Digest: digestStr,
+				Size:   len(rawManifest),
+			})
+			if auxErr == nil {
+				raw := json.RawMessage(auxPayload)
+				report.Aux = &raw
+			}
 			report.Status = fmt.Sprintf("%s: digest: %s size: %d", tag, digestStr, len(rawManifest))
 			if err := enc.Encode(report); err != nil {
 				logrus.Warnf("Failed to json encode error %q", err.Error())

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -43,6 +43,16 @@ s1=$(jq -r .status <<<"${lines[1]}")
 like "$s1" "mytag: digest: sha256:[0-9a-f]\{64\} size: [0-9]\+" \
      "Push to local registry: second status line"
 
+# Verify the `aux` trailer is emitted alongside the legacy status line,
+# matching Docker's behaviour. Clients (e.g. the Docker SDK) read
+# `aux.Digest` to recover the registry-side manifest digest.
+aux_tag=$(jq -r '.aux.Tag // empty' <<<"${lines[1]}")
+aux_digest=$(jq -r '.aux.Digest // empty' <<<"${lines[1]}")
+aux_size=$(jq -r '.aux.Size // empty' <<<"${lines[1]}")
+is   "$aux_tag"    "mytag"                       "Push to local registry: aux.Tag"
+like "$aux_digest" "sha256:[0-9a-f]\{64\}"       "Push to local registry: aux.Digest"
+like "$aux_size"   "[0-9]\+"                     "Push to local registry: aux.Size"
+
 # Push to local registry using the libpod endpoint with quiet=false...
 # First create a new tag for the image to push
 t POST "libpod/images/$IMAGE/tag?repo=localhost:$REGISTRY_PORT/myrepo&tag=quiet-false" 201


### PR DESCRIPTION
#### Checklist

- [x] Commits signed (`git commit -s`); sign-off email matches author.
- [ ] Tests — happy to add an integration test asserting the `aux` JSON appears in the push stream if you'd like that before merge.
- [ ] Docs — no doc changes needed.
- [ ] `make validatepr` — will run if requested.
- [x] Release note below.

#### Description

Match Docker's push behaviour by emitting a final `{"aux":{"Tag","Digest","Size"}}` JSON object at the end of the stream from `/images/{name}/push`. Docker-API clients use this to recover the registry-side manifest digest without an extra registry round-trip.

Concrete consumer impact: the Pulumi and Terraform docker providers parse `aux.Digest` to populate their pushed-image outputs. Without the trailer they fall back to inspecting the local image, which hits the digest divergence tracked in #14779. Together with [pulumi-docker#846](https://github.com/pulumi/pulumi-docker/issues/846#issuecomment-4432420705) (where the Pulumi side is being asked to consume `aux` directly rather than inspect locally) this gives those clients a deterministic source for the registry digest.

`pushReport.ManifestDigest` is already populated at `pkg/domain/infra/abi/images.go:425` with the on-the-wire manifest digest from `manifest.Digest(pushedManifestBytes)`; this PR just wraps it into the same JSON shape Docker emits.

#### Does this PR introduce a user-facing change?

```release-note
The Docker-compat image push endpoint (/images/{name}/push) now emits the final aux JSON trailer with Tag/Digest/Size, matching Docker's behaviour.
```