### PR TITLE
bump selinux to v1.15.1, use SetProcessKind

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,6 +91,11 @@ linters:
       - linters:
           - unused
         text: "(rootlessPortSyncR|rootlessPortSyncW)"
+      # TODO: remove once https://github.com/leighmcculloch/gocheckcompilerdirectives/issues/7 is fixed.
+      - text: "compiler directive unrecognized: //go:fix"
+        linters:
+          - gocheckcompilerdirectives
+
 
 issues:
   max-issues-per-linter: 0

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20260316125833-8a4db579f5c8
-	github.com/opencontainers/selinux v1.14.1
+	github.com/opencontainers/selinux v1.15.1
 	github.com/openshift/imagebuilder v1.2.21
 	github.com/rootless-containers/rootlesskit/v2 v2.3.6
 	github.com/shirou/gopsutil/v4 v4.26.4

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5
 github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20260316125833-8a4db579f5c8 h1:2NAWFjN0PmdIe3XojVL9wf3lJ1//VqAgc7MOSYHQslE=
 github.com/opencontainers/runtime-tools v0.9.1-0.20260316125833-8a4db579f5c8/go.mod h1:DKDEfzxvRkoQ6n9TGhxQgg2IM1lY4aM0eaQP4e3oElw=
-github.com/opencontainers/selinux v1.14.1 h1:a7XlXV/nN/l5zFP1FWZYoExpClu1QOPMfWUV2CZ8kEQ=
-github.com/opencontainers/selinux v1.14.1/go.mod h1:LenyElirjUHszfxrjuFqC85HIeXZKumHcKMQtnaDlQQ=
+github.com/opencontainers/selinux v1.15.1 h1:ERxeh5caJvCzNAKdI8WQbJmB1LDTn4BuaAg8wihLBpA=
+github.com/opencontainers/selinux v1.15.1/go.mod h1:LenyElirjUHszfxrjuFqC85HIeXZKumHcKMQtnaDlQQ=
 github.com/openshift/imagebuilder v1.2.21 h1:XX0tZVznWTxzYevvNVZ/0eeTzmgY6cfcT4/xjs5ToyU=
 github.com/openshift/imagebuilder v1.2.21/go.mod h1:+L09sXUQ0RPdCU1tmzKrfBhqMlYvZtaA3MHb7aTjVU8=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -24,6 +24,7 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/buildah/copier"
@@ -44,7 +45,6 @@ import (
 	envLib "go.podman.io/podman/v6/pkg/env"
 	"go.podman.io/podman/v6/pkg/lookup"
 	"go.podman.io/podman/v6/pkg/rootless"
-	"go.podman.io/podman/v6/pkg/selinux"
 	"go.podman.io/podman/v6/pkg/systemd/notifyproxy"
 	"go.podman.io/podman/v6/pkg/util"
 	"go.podman.io/storage"
@@ -573,9 +573,9 @@ func (c *Container) processLabel(processLabel string) (string, error) {
 	if !ok || !strings.Contains(label, "type:") {
 		switch {
 		case c.ociRuntime.SupportsKVM():
-			return selinux.KVMLabel(processLabel)
+			return selinux.SetProcessKind(processLabel, selinux.ProcessKindKVM)
 		case c.Systemd():
-			return selinux.InitLabel(processLabel)
+			return selinux.SetProcessKind(processLabel, selinux.ProcessKindInit)
 		}
 	}
 	return processLabel, nil

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -4,43 +4,20 @@ import (
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
-// KVMLabel returns labels for running kvm isolated containers
+// KVMLabel returns labels for running kvm isolated containers.
+//
+// Deprecated: use [selinux.SetProcessKind].
+//
+//go:fix inline
 func KVMLabel(cLabel string) (string, error) {
-	if cLabel == "" {
-		// selinux is disabled
-		return "", nil
-	}
-	processLabel, err := selinux.KVMContainerLabel()
-	if err != nil {
-		return "", err
-	}
-	selinux.ReleaseLabel(processLabel)
-	return swapSELinuxLabel(cLabel, processLabel)
+	return selinux.SetProcessKind(cLabel, selinux.ProcessKindKVM)
 }
 
-// InitLabel returns labels for running systemd based containers
+// InitLabel returns labels for running systemd based containers.
+//
+// Deprecated: use [selinux.SetProcessKind].
+//
+//go:fix inline
 func InitLabel(cLabel string) (string, error) {
-	if cLabel == "" {
-		// selinux is disabled
-		return "", nil
-	}
-	processLabel, err := selinux.InitContainerLabel()
-	if err != nil {
-		return "", err
-	}
-	selinux.ReleaseLabel(processLabel)
-	return swapSELinuxLabel(cLabel, processLabel)
-}
-
-func swapSELinuxLabel(cLabel, processLabel string) (string, error) {
-	dcon, err := selinux.NewContext(cLabel)
-	if err != nil {
-		return "", err
-	}
-	scon, err := selinux.NewContext(processLabel)
-	if err != nil {
-		return "", err
-	}
-	dcon["type"] = scon["type"]
-	return dcon.Get(), nil
+	return selinux.SetProcessKind(cLabel, selinux.ProcessKindInit)
 }

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_linux.go
@@ -10,7 +10,6 @@ import (
 
 // Valid Label Options
 var validOptions = map[string]bool{
-	"disable":  true,
 	"type":     true,
 	"filetype": true,
 	"user":     true,
@@ -35,9 +34,13 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 	if !selinux.GetEnabled() {
 		return "", "", nil
 	}
+	if len(options) > 0 && options[0] == "disable" {
+		return "", selinux.PrivContainerMountLabel(), nil
+	}
 	processLabel, mountLabel := selinux.ContainerLabels() //nolint:staticcheck // ContainerLabels will be moved to an internal package.
-	if processLabel == "" {
-		// processLabel is required; if empty, do nothing.
+	if processLabel == "" || len(options) == 0 {
+		// 1. processLabel is required; if empty, do nothing.
+		// 2. If there are no options to process, we're done.
 		return processLabel, mountLabel, nil
 	}
 	defer func() {
@@ -55,6 +58,8 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 		return "", "", err
 	}
 	for _, opt := range options {
+		// For backward compatibility, process "disable"
+		// even if it's not the only option.
 		if opt == "disable" {
 			selinux.ReleaseLabel(mountLabel)
 			return "", selinux.PrivContainerMountLabel(), nil

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
@@ -48,6 +48,21 @@ var (
 	privContainerMountLabel string
 )
 
+// ProcessKind selects which process domain [SetProcessKind] applies to a label.
+type ProcessKind int
+
+const (
+	ProcessKindRegular ProcessKind = 1
+	ProcessKindInit    ProcessKind = 2
+	ProcessKindKVM     ProcessKind = 3
+)
+
+// SetProcessKind returns label with its type component replaced by the one
+// corresponding to kind. Other label components are kept intact.
+func SetProcessKind(label string, kind ProcessKind) (string, error) {
+	return setProcessKind(label, kind)
+}
+
 // Context is a representation of the SELinux label broken into 4 parts
 type Context map[string]string
 
@@ -231,6 +246,7 @@ func ReserveLabel(label string) {
 }
 
 // ReserveLabelV2 reserves the MLS/MCS level component of the specified label.
+// Labels without MLS/MCS category component (":c") are ignored.
 // Returns an error if the label can't be reserved.
 //
 // Callers that are intentionally reusing an existing level/MCS (e.g. multiple
@@ -292,6 +308,8 @@ func KVMContainerLabels() (string, string) {
 
 // KVMContainerLabel returns the default process label to be used
 // for KVM containers by the calling process.
+//
+// If you only need to change a type of existing label, use [SetProcessKind] instead.
 func KVMContainerLabel() (string, error) {
 	return kvmContainerLabel()
 }
@@ -306,6 +324,8 @@ func InitContainerLabels() (string, string) {
 
 // InitContainerLabel returns the default process label to be used
 // for containers running an init system like systemd by the calling process.
+//
+// If you only need to change a type of existing label, use [SetProcessKind] instead.
 func InitContainerLabel() (string, error) {
 	return initContainerLabel()
 }

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -890,8 +890,10 @@ func defaultEnforceMode() int {
 	return Disabled
 }
 
+// mcsAdd reserves a level. If the argument is empty or does not contain
+// MCS/MLS category component (no ":c"), it is ignored.
 func mcsAdd(mcs string) error {
-	if mcs == "" {
+	if !strings.Contains(mcs, ":c") {
 		return nil
 	}
 	state.Lock()
@@ -1512,4 +1514,47 @@ func getDefaultContextWithLevel(user, level, scon string) (string, error) {
 	}
 
 	return getDefaultContextFromReaders(&c)
+}
+
+func (k ProcessKind) keys() (primary, fallback string, ok bool) {
+	switch k {
+	case ProcessKindRegular:
+		return "process", "", true
+	case ProcessKindInit:
+		return "init_process", "process", true
+	case ProcessKindKVM:
+		return "kvm_process", "process", true
+	}
+	return "", "", false
+}
+
+func setProcessKind(cLabel string, k ProcessKind) (string, error) {
+	if cLabel == "" {
+		return "", nil
+	}
+	primary, fallback, ok := k.keys()
+	if !ok {
+		return "", fmt.Errorf("selinux.SetProcessKind: invalid ProcessKind %d", k)
+	}
+
+	src := label(primary)
+	if src == "" && fallback != "" {
+		src = label(fallback)
+	}
+	if src == "" {
+		return cLabel, nil
+	}
+
+	// Replace cLabel type with one from src.
+	srcCtx, err := newContext(src)
+	if err != nil {
+		return "", fmt.Errorf("selinux.SetProcessKind: invalid %s label %s: %w", primary, src, err)
+	}
+	dstCtx, err := newContext(cLabel)
+	if err != nil {
+		return "", fmt.Errorf("selinux.SetProcessKind: invalid label %s: %w", cLabel, err)
+	}
+
+	dstCtx["type"] = srcCtx["type"]
+	return dstCtx.get(), nil
 }

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
@@ -157,3 +157,7 @@ func getDefaultContextWithLevel(string, string, string) (string, error) {
 func label(_ string) string {
 	return ""
 }
+
+func setProcessKind(string, ProcessKind) (string, error) {
+	return "", nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -511,7 +511,7 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/runtime-tools/generate
 github.com/opencontainers/runtime-tools/generate/seccomp
 github.com/opencontainers/runtime-tools/validate/capabilities
-# github.com/opencontainers/selinux v1.14.1
+# github.com/opencontainers/selinux v1.15.1
 ## explicit; go 1.22
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label


### PR DESCRIPTION
Use [oc/selinux v1.15.1](https://github.com/opencontainers/selinux/releases/tag/v1.15.1) and its new [SetProcessKind](https://pkg.go.dev/github.com/opencontainers/selinux@v1.15.1/go-selinux#SetProcessKind) to streamline changing the label type.

Notes:
 - I was not able to find any external users of pkg/selinux but kept it
  for now (and marked as deprecated and with [go:fix inline](https://go.dev/blog/inliner)) so
  any users can switch away, and the whole package can be removed later;
 - `go:fix` directives are not (yet) recognized by the gocheckcompilerdirectives linter,
    thus a a temporary exception in .golangci.yml.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
