### PR TITLE
Added --dry-run option to image prune

### DIFF
--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -47,6 +47,7 @@ func init() {
 	flags := pruneCmd.Flags()
 	flags.BoolVarP(&pruneOpts.All, "all", "a", false, "Remove all images not in use by containers, not just dangling ones")
 	flags.BoolVarP(&pruneOpts.BuildCache, "build-cache", "", false, "Remove persistent build cache created by --mount=type=cache")
+	flags.BoolVarP(&pruneOpts.DryRun, "dry-run", "", false, "Display images to be removed")
 	flags.BoolVarP(&pruneOpts.External, "external", "", false, "Remove images even when they are used by external containers (e.g., by build containers)")
 	flags.BoolVarP(&force, "force", "f", false, "Do not prompt for confirmation")
 

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -21,6 +21,10 @@ Remove dangling images and images that have no associated containers.
 
 Remove persistent build cache created for `--mount=type=cache`.
 
+#### **--dry-run**
+
+Display images that would have been removed by the prune command.
+
 #### **--external**
 
 Remove images even when they are used by external containers (e.g., build containers).
@@ -98,6 +102,20 @@ f3e20dc537fb04cb51672a5cb6fdf2292e61d411315549391a0d1f64e4e3097e
 Remove all unused images from local storage with label version 1.0:
 ```
 $ sudo podman image prune -a -f --filter label=version=1.0
+e813d2135f17fadeffeea8159a34cfdd4c30b98d8111364b913a91fd930643e9
+5e6572320437022e2746467ddf5b3561bf06e099e8e6361df27e0b2a7ed0b17b
+58fda2abf5042b35dfe04e5f8ee458a3cc26375bf309efb42c078b551a2055c7
+6d2bd30fe924d3414b64bd3920760617e6ced872364bc3bc6959a623252da002
+33d1c829be64a1e1d379caf4feec1f05a892c3ef7aa82c0be53d3c08a96c59c5
+f9f0a8a58c9e02a2b3250b88cc5c95b1e10245ca2c4161d19376580aaa90f55c
+1ef14d5ede80db78978b25ad677fd3e897a578c3af614e1fda608d40c8809707
+45e1482040e441a521953a6da2eca9bafc769e15667a07c23720d6e0cafc3ab2
+```
+
+Display unused images that would have been removed:
+```
+$ sudo podman image prune --dry-run -a  
+Are you sure you want to continue? [y/N] y
 e813d2135f17fadeffeea8159a34cfdd4c30b98d8111364b913a91fd930643e9
 5e6572320437022e2746467ddf5b3561bf06e099e8e6361df27e0b2a7ed0b17b
 58fda2abf5042b35dfe04e5f8ee458a3cc26375bf309efb42c078b551a2055c7

--- a/go.mod
+++ b/go.mod
@@ -188,3 +188,4 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.1.0 // indirect
 )
+replace go.podman.io/common => github.com/zvenigorodsky/container-libs/common v0.0.0-20260513201046-29c417f5d0a4

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -237,6 +237,7 @@ type ImagePruneOptions struct {
 	External   bool     `json:"external" schema:"external"`
 	BuildCache bool     `json:"buildcache" schema:"buildcache"`
 	Filter     []string `json:"filter" schema:"filter"`
+	DryRun     bool     `json:"dryrun" schema:"dryrun"`
 }
 
 type (

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -63,6 +63,7 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 		ExternalContainers:      opts.External,
 		Filters:                 append(opts.Filter, "readonly=false"),
 		WithSize:                true,
+		DryRun:                  opts.DryRun,
 	}
 
 	if !opts.All {
@@ -104,7 +105,7 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 		}
 
 		numRemovedImages := len(removedImages)
-		if numRemovedImages+numPreviouslyRemovedImages == 0 {
+		if numRemovedImages+numPreviouslyRemovedImages == 0 || pruneOptions.DryRun {
 			break
 		}
 		numPreviouslyRemovedImages = numRemovedImages

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -86,6 +86,10 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 		pruneOptions.Filters = append(pruneOptions.Filters, "containers=false")
 	}
 
+	if opts.DryRun {
+		pruneOptions.Ignore = true	
+	}
+
 	pruneReports := make([]*reports.PruneReport, 0)
 
 	// Now prune all images until we converge.

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -215,6 +215,26 @@ var _ = Describe("Podman prune", func() {
 		Expect(images.OutputToStringArray()).To(HaveLen(len(CACHE_IMAGES)))
 	})
 
+	It("podman image prune dry run", func() {
+		SkipIfNotAMD64() // List of images is different
+		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(BB)
+
+		images := podmanTest.Podman([]string{"images", "-a"})
+		images.WaitWithDefaultTimeout()
+		Expect(images).Should(ExitCleanly())
+
+		prune := podmanTest.Podman([]string{"image", "prune", "-af", "--dry-run"})
+		prune.WaitWithDefaultTimeout()
+		Expect(prune).Should(ExitCleanly())
+
+		after := podmanTest.Podman([]string{"images", "-a"})
+		after.WaitWithDefaultTimeout()
+		Expect(after).Should(ExitCleanly())
+		// the dry run should not remove or untag any images
+		Expect(after.OutputToStringArray()).To(HaveLen(len(images.OutputToStringArray())))
+	})
+	
 	It("podman system image prune unused images", func() {
 		SkipIfNotAMD64() // List of images is different
 		useCustomNetworkDir(podmanTest, tempdir)


### PR DESCRIPTION
Partially resolving: https://github.com/containers/podman/issues/27838

Need to merge with https://github.com/containers/container-libs/pull/843 

When adding the --dry-run flag to image prune, it will display all images about to be deleted without deleting them