### PR TITLE
test/system: log socat output in retry loop

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -802,6 +802,7 @@ nameserver 8.8.8.8" "nameserver order is correct"
                 if [[ $status -eq 0 ]]; then
                     break
                 fi
+                echo "socat output: $output"
                 sleep 0.5
                 retries=$((retries -1))
             done


### PR DESCRIPTION
This test is currently flaking with the latest pasta update[1]. As part of debugging this it was hard to see why socat fails 5 times in this loop as the run function does not log the output so I had to add an echo here.

[1] https://bugs.passt.top/show_bug.cgi?id=202

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
