### PR TITLE
quadlet API: fix tar install when non-quadlet file sorts first

### DIFF
--- a/pkg/api/handlers/libpod/quadlets.go
+++ b/pkg/api/handlers/libpod/quadlets.go
@@ -232,6 +232,16 @@ func InstallQuadlets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// QuadletInstall expects the quadlet file to be first in the list.
+	// filepath.Walk returns files in lexicographic order, so a non-quadlet
+	// file (e.g. "Containerfile") may sort before the ".container" file.
+	for i, filePath := range filePaths {
+		if quadlet.IsExtSupported(filePath) {
+			filePaths[0], filePaths[i] = filePaths[i], filePaths[0]
+			break
+		}
+	}
+
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	installOptions := entities.QuadletInstallOptions{
 		Replace:       query.Replace,

--- a/test/apiv2/36-quadlets.at
+++ b/test/apiv2/36-quadlets.at
@@ -188,7 +188,8 @@ is "$output" "$quadlet_2_content" "quadlet-1 should be overwritten by quadlet-2"
 # Scenario: install tar that contains one quadlet file and a non-quadlet file will succeed
 # then update the quadlet file, and the non-quadlet file, and verify the update is successful
 quadlet_5=quadlet-test-5-$(cat /proc/sys/kernel/random/uuid).container
-containerfile_1=quadlet-test-containerfile-1-$(cat /proc/sys/kernel/random/uuid).Containerfile
+containerfile_1=quadlet-test-containerfile-1-$(cat /proc/sys/kernel/random/uuid)
+configfile_1=quadlet-test-configfile-1-$(cat /proc/sys/kernel/random/uuid).conf
 
 containerfile_1_content=$(cat << EOF
 FROM quay.io/podman/hello
@@ -216,17 +217,25 @@ CMD ["echo", "Updated"]
 EOF
 )
 
+configfile_1_content=$(cat << EOF
+[ini]
+foo=bar
+EOF
+)
+
 echo "$quadlet_5_content" > "$TMPD/$quadlet_5"
 echo "$containerfile_1_content" > "$TMPD/$containerfile_1"
-tar --format=posix -C "$TMPD" -cvf "$TMPD/$quadlet_5$containerfile_1.tar" "$quadlet_5" "$containerfile_1" &> /dev/null
+echo "$configfile_1_content" > "$TMPD/$configfile_1"
+tar --format=posix -C "$TMPD" -cvf "$TMPD/$quadlet_5$containerfile_1.tar" "$quadlet_5" "$containerfile_1" "$configfile_1" &> /dev/null
 
 t POST "libpod/quadlets?application=bar" "$TMPD/$quadlet_5$containerfile_1.tar" 200 \
-    '.InstalledQuadlets|length=2' \
+    '.InstalledQuadlets|length=3' \
     '.QuadletErrors|length=0'
 
 t GET "libpod/quadlets/$quadlet_5/file" 200
 is "$output" "$quadlet_5_content" "quadlet-5 should be installed"
 is "$(cat "$quadlet_install_dir/bar/$containerfile_1")" "$containerfile_1_content" "containerfile_1 should be installed"
+is "$(cat "$quadlet_install_dir/bar/$configfile_1")" "$configfile_1_content" "configfile_1 should be installed"
 
 echo "$quadlet_5_updated_content" > "$TMPD/$quadlet_5"
 echo "$containerfile_1_updated_content" > "$TMPD/$containerfile_1"
@@ -247,6 +256,36 @@ t POST "libpod/quadlets?replace=true&application=bar" "$TMPD/$quadlet_5$containe
 t GET "libpod/quadlets/$quadlet_5/file" 200
 is "$output" "$quadlet_5_updated_content" "quadlet-5 should be updated"
 is "$(cat "$quadlet_install_dir/bar/$containerfile_1")" "$containerfile_1_updated_content" "containerfile_1 should be installed"
+
+# Scenario: install tar where a non-quadlet file sorts lexicographically before the quadlet file.
+# "AAA-" sorts before "quadlet-test-", exercising the file ordering in the API handler.
+quadlet_7=quadlet-test-7-$(cat /proc/sys/kernel/random/uuid).container
+containerfile_3=AAA-containerfile-$(cat /proc/sys/kernel/random/uuid)
+
+quadlet_7_content=$(cat << EOF
+[Container]
+ContainerName=quadlet-7
+Image=quay.io/podman/hello
+EOF
+)
+
+containerfile_3_content=$(cat << EOF
+FROM quay.io/podman/hello
+CMD ["echo", "hello"]
+EOF
+)
+
+echo "$quadlet_7_content" > "$TMPD/$quadlet_7"
+echo "$containerfile_3_content" > "$TMPD/$containerfile_3"
+tar --format=posix -C "$TMPD" -cvf "$TMPD/$quadlet_7$containerfile_3.tar" "$quadlet_7" "$containerfile_3" &> /dev/null
+
+t POST "libpod/quadlets" "$TMPD/$quadlet_7$containerfile_3.tar" 200 \
+    '.InstalledQuadlets|length=2' \
+    '.QuadletErrors|length=0'
+
+t GET "libpod/quadlets/$quadlet_7/file" 200
+is "$output" "$quadlet_7_content" "quadlet-7 should be installed"
+is "$(cat "$quadlet_install_dir/$containerfile_3")" "$containerfile_3_content" "containerfile_3 should be installed"
 
 # Scenario: test a multipart call, then update without replace, and then replace
 quadlet_6=quadlet-test-6-$(cat /proc/sys/kernel/random/uuid).container
@@ -356,10 +395,13 @@ t GET "libpod/quadlets/$quadlet_app_2/file" 404
 
 podman quadlet rm --recursive "$quadlet_1" \
     "$quadlet_5" \
-    "$quadlet_6"
+    "$quadlet_6" \
+    "$quadlet_7"
 
-rm -f "$quadlet_install_dir/$containerfile_1"
+rm -f "$quadlet_install_dir/bar/$containerfile_1"
+rm -f "$quadlet_install_dir/bar/$configfile_1"
 rm -f "$quadlet_install_dir/$containerfile_2"
+rm -f "$quadlet_install_dir/$containerfile_3"
 rm -rf $TMPD
 
 # DELETE endpoint tests


### PR DESCRIPTION
QuadletInstall expects the quadlet file to be first in the file list, The API handler passes files in filepath.Walk order (lexicographic). Install would fail if a file like "Containerfile" comes before the quadlet file.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
