### PR TITLE
fix: duplicated words in decompress.go log message and annotations.go comment

### DIFF
--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -156,7 +156,7 @@ const (
 	// of the container
 	UlimitAnnotation = "io.podman.annotations.ulimit"
 
-	// VolumesFromAnnotation is used by by play kube when playing a kube
+	// VolumesFromAnnotation is used by play kube when playing a kube
 	// yaml to specify volumes-from of the container
 	// It is expected to be a semicolon-separated list of container names and/or
 	// IDs optionally with colon separated mount options.

--- a/pkg/machine/compression/decompress.go
+++ b/pkg/machine/compression/decompress.go
@@ -96,7 +96,7 @@ func runDecompression(d decompressor, decompressedFilePath string) (retErr error
 	}
 	defer func() {
 		if err := decompressedFileWriter.Close(); err != nil {
-			logrus.Warnf("Unable to to close destination file %s: %q", decompressedFilePath, err)
+			logrus.Warnf("Unable to close destination file %s: %q", decompressedFilePath, err)
 			if retErr == nil {
 				retErr = err
 			}


### PR DESCRIPTION
Two one-line typo fixes for duplicated words:
- `pkg/machine/compression/decompress.go` — `logrus.Warnf("Unable to to close destination file ...")` → `logrus.Warnf("Unable to close destination file ...")`
- `libpod/define/annotations.go` — "// VolumesFromAnnotation is used by by play kube when playing a kube" → "// VolumesFromAnnotation is used by play kube when playing a kube"

No code/behavior change.

Signed-off-by: Maya Chen <275405107+otjdiepluong@users.noreply.github.com>