### PR TITLE
docs: clarify podman pod ps default output

### DIFF
--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -7,7 +7,7 @@ podman\-pod\-ps - Print out information about pods
 **podman pod ps** [*options*]
 
 ## DESCRIPTION
-**podman pod ps** lists the pods on the system.
+**podman pod ps** lists all pods on the system.
 By default it lists:
 
  * pod ID
@@ -95,7 +95,7 @@ Default: created
 
 ## EXAMPLES
 
-List all running pods.
+List all pods.
 ```
 $ podman pod ps
 POD ID         NAME              STATUS    CREATED          INFRA ID       # OF CONTAINERS
@@ -103,7 +103,7 @@ POD ID         NAME              STATUS    CREATED          INFRA ID       # OF 
 f4df8692e116   nifty_torvalds    Created   10 minutes ago   331693bff40a   2
 ```
 
-List all running pods along with container names within the pods.
+List all pods along with container names within the pods.
 ```
 $ podman pod ps --ctr-names
 POD ID         NAME              STATUS    CREATED          INFRA ID       NAMES
@@ -111,7 +111,7 @@ POD ID         NAME              STATUS    CREATED          INFRA ID       NAMES
 f4df8692e116   nifty_torvalds    Created   10 minutes ago   331693bff40a   thirsty_hawking,wizardly_golick
 ```
 
-List all running pods along with status, names and ids.
+List all pods along with status, names and ids.
 ```
 $ podman pod ps --ctr-status --ctr-names --ctr-ids
 POD ID         NAME              STATUS    CREATED          INFRA ID       IDS                         NAMES                             STATUS
@@ -119,21 +119,21 @@ POD ID         NAME              STATUS    CREATED          INFRA ID       IDS  
 f4df8692e116   nifty_torvalds    Created   10 minutes ago   331693bff40a   331693bff40a,8e428daeb89e   thirsty_hawking,wizardly_golick   configured,configured
 ```
 
-List all running pods and print ID, Container Names, and cgroups.
+List all pods and print ID, Container Names, and cgroups.
 ```
 $ podman pod ps --format "{{.ID}}  {{.ContainerNames}}  {{.Cgroup}}"
 00dfd6fa02c0   loving_archimedes   /libpod_parent
 f4df8692e116   thirsty_hawking,wizardly_golick   /libpod_parent
 ```
 
-List all running pods with two containers sorted by pod ID.
+List all pods with two containers sorted by pod ID.
 ```
 $ podman pod ps --sort id --filter ctr-number=2
 POD ID         NAME             STATUS    CREATED          INFRA ID       # OF CONTAINERS
 f4df8692e116   nifty_torvalds   Created   10 minutes ago   331693bff40a   2
 ```
 
-List all running pods with their container ids.
+List all pods with their container ids.
 ```
 $ podman pod ps  --ctr-ids
 POD ID         NAME              STATUS    CREATED          INFRA ID       IDS
@@ -141,7 +141,7 @@ POD ID         NAME              STATUS    CREATED          INFRA ID       IDS
 f4df8692e116   nifty_torvalds    Created   10 minutes ago   331693bff40a   331693bff40a,8e428daeb89e
 ```
 
-List all running pods with container ids without truncating IDs.
+List all pods with container ids without truncating IDs.
 ```
 $ podman pod ps --no-trunc --ctr-ids
 POD ID                                                             NAME              STATUS    CREATED          INFRA ID                                                           IDS
@@ -149,14 +149,14 @@ POD ID                                                             NAME         
 f4df8692e116a3e6d1d62572644ed36ca475d933808cc3c93435c45aa139314b   nifty_torvalds    Created   10 minutes ago   331693bff40a926b6d52b184e116afd15497610c378d5d4c42945dd6e33b75b0   331693bff40a926b6d52b184e116afd15497610c378d5d4c42945dd6e33b75b0,8e428daeb89e69b71e7916a13accfb87d122889442b5c05c2d99cf94a3230e9d
 ```
 
-List all running pods with container names.
+List all pods with container names.
 ```
 $ podman pod ps --ctr-names
 POD ID         NAME   STATUS    CREATED        INFRA ID       NAMES
 314f4da82d74   hi     Created   17 hours ago   a9f2d2165675   jovial_jackson,hopeful_archimedes,vibrant_ptolemy,heuristic_jennings,keen_raman,hopeful_newton,mystifying_bose,silly_lalande,serene_lichterman ...
 ```
 
-List all running pods with container IDs
+List pods containing the specified container ID
 ```
 $ podman pod ps --filter ctr-ids=aceb3b775797
 POD ID        NAME        STATUS      CREATED        INFRA ID      # OF CONTAINERS
@@ -176,17 +176,6 @@ $ podman pod ps --filter ctr-status=exited
 POD ID        NAME         STATUS      CREATED        INFRA ID      # OF CONTAINERS
 06c3a107763a  maintenance  Degraded    4 minutes ago  67e500cbb678  3
 1e3424d7e9c0  db-cluster   Degraded    4 minutes ago  d6650a490b69  3
-```
-
-List all current pods
-```
-$ podman pod ps
-POD ID        NAME         STATUS      CREATED        INFRA ID      # OF CONTAINERS
-95938982244d  nettest      Running     4 minutes ago  a28d133e8c63  3
-deee8956522e  utility      Running     4 minutes ago  6b730e3ac334  3
-06c3a107763a  maintenance  Degraded    4 minutes ago  67e500cbb678  3
-1e3424d7e9c0  db-cluster   Degraded    4 minutes ago  d6650a490b69  3
-952330c7cff0  web-app      Running     4 minutes ago  b0f247c49669  3
 ```
 
 Filter pod by ID


### PR DESCRIPTION
#### Summary

- clarify that `podman pod ps` lists all pods on the system by default
- update example headings that incorrectly referred to "running" pods
- make the filtered example wording more specific and consistent


#### Checklist


- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
Fixes: #28702 