### PR TITLE
Document tmpcopyup default behavior for tmpfs mounts

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -116,9 +116,13 @@ Options specific to type=**tmpfs** and **ramfs**:
 
 - *tmpcopyup*: Enable copyup from the image directory at the same location to the tmpfs/ramfs. Used by default.
 
+When the tmpfs destination is inside a volume or bind mount, files from the parent mount are also copied into the tmpfs, so the parent content remains visible. Use **notmpcopyup** to mount an empty tmpfs that shadows the parent mount's subtree.
+
 - *noatime*: Disable updating file access times when the file is read.
 
 - *notmpcopyup*: Disable copying files from the image to the tmpfs/ramfs.
+
+Use this option when mounting a tmpfs inside a volume or bind mount to ensure the tmpfs properly shadows the parent mount's subtree.
 
 - *U*, *chown*: *true* or *false* (default if unspecified: *false*). Set the uid and gid options for the tmpfs filesystem based on the UID and GID of the container. This is **not** recursive.
 

--- a/docs/source/markdown/options/tmpfs.md
+++ b/docs/source/markdown/options/tmpfs.md
@@ -20,3 +20,14 @@ This command mounts a **tmpfs** at _/tmp_ within the container. The supported mo
 options are the same as the Linux default mount flags. If no options are specified,
 the system uses the following options:
 **rw,noexec,nosuid,nodev**.
+
+By default, Podman enables **tmpcopyup** on tmpfs mounts, which copies the contents
+of the underlying image directory into the tmpfs before mounting it. This also
+applies when the tmpfs destination is inside a volume or bind mount: files from
+the parent mount are copied into the tmpfs, so the parent content remains visible.
+To mount an empty tmpfs that shadows a parent mount's subtree, use the
+**notmpcopyup** option:
+
+```
+$ podman <<subcommand>> --volume myvolume:/data --tmpfs /data/sub:notmpcopyup my_image
+```


### PR DESCRIPTION
Related to: https://github.com/containers/podman/issues/28684

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
