### PR TITLE
inspect: do not show <nil> as gateway

### DIFF
--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -325,7 +325,9 @@ func resultToBasicNetworkConfig(result types.StatusBlock) define.InspectBasicNet
 				if config.IPAddress == "" {
 					config.IPAddress = netAddress.IPNet.IP.String()
 					config.IPPrefixLen = size
-					config.Gateway = netAddress.Gateway.String()
+					if netAddress.Gateway != nil {
+						config.Gateway = netAddress.Gateway.String()
+					}
 				} else {
 					config.SecondaryIPAddresses = append(config.SecondaryIPAddresses, define.Address{Addr: netAddress.IPNet.IP.String(), PrefixLength: size})
 				}
@@ -334,7 +336,9 @@ func resultToBasicNetworkConfig(result types.StatusBlock) define.InspectBasicNet
 				if config.GlobalIPv6Address == "" {
 					config.GlobalIPv6Address = netAddress.IPNet.IP.String()
 					config.GlobalIPv6PrefixLen = size
-					config.IPv6Gateway = netAddress.Gateway.String()
+					if netAddress.Gateway != nil {
+						config.IPv6Gateway = netAddress.Gateway.String()
+					}
 				} else {
 					config.SecondaryIPv6Addresses = append(config.SecondaryIPv6Addresses, define.Address{Addr: netAddress.IPNet.IP.String(), PrefixLength: size})
 				}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -366,6 +366,21 @@ t POST  containers/${cid_top}/start 204
 t GET containers/${cid_top}/json 200 \
   .State.Status="running"
 
+# check that gateway is empty not "<nil>", https://github.com/containers/podman/issues/28705
+podman network create testnet --ipv6 --internal --disable-dns
+podman run --name testcon --network testnet -d $IMAGE top
+
+t GET containers/testcon/json 200 \
+  .NetworkSettings.Networks.testnet.Gateway="" \
+  .NetworkSettings.Networks.testnet.IPAddress~10\..* \
+  .NetworkSettings.Networks.testnet.IPPrefixLen=24 \
+  .NetworkSettings.Networks.testnet.IPv6Gateway="" \
+  .NetworkSettings.Networks.testnet.GlobalIPv6Address~fd.* \
+  .NetworkSettings.Networks.testnet.GlobalIPv6PrefixLen=64
+
+podman rm -f -t0 testcon
+podman network rm testnet
+
 # 0 means unlimited, need same with docker
 t GET containers/json?limit=0 200 \
   .[0].Id~[0-9a-f]\\{64\\}


### PR DESCRIPTION
When a network is created without gateway, i.e. --internal --disable-dns then the gateway will be nil. But converting a nil ip to string produces "<nil>" which is not what we want as we like an empty string there to signal that the network has no gateway.

Fixes: #28705

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed an issue where networks without a gateway showed "<nil>" as gateway string instead of an empty string in inspect.
```
