### PR TITLE
bindings/artifacts: remove redundant nameOrID parameter from Remove for 6.0

### DIFF
--- a/pkg/bindings/artifacts/remove.go
+++ b/pkg/bindings/artifacts/remove.go
@@ -9,15 +9,10 @@ import (
 )
 
 // Remove removes an artifact from local storage.
-// TODO (6.0): nameOrID parameter should be removed
-func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) (*entities.ArtifactRemoveReport, error) {
+func Remove(ctx context.Context, options *RemoveOptions) (*entities.ArtifactRemoveReport, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	if nameOrID != "" {
-		options.Artifacts = append(options.Artifacts, nameOrID)
 	}
 
 	params, err := options.ToParams()

--- a/pkg/domain/infra/tunnel/artifact.go
+++ b/pkg/domain/infra/tunnel/artifact.go
@@ -65,7 +65,7 @@ func (ir *ImageEngine) ArtifactRm(_ context.Context, opts entities.ArtifactRemov
 		Ignore:    &opts.Ignore,
 	}
 
-	return artifacts.Remove(ir.ClientCtx, "", &removeOptions)
+	return artifacts.Remove(ir.ClientCtx, &removeOptions)
 }
 
 func (ir *ImageEngine) ArtifactPush(_ context.Context, name string, opts entities.ArtifactPushOptions) (*entities.ArtifactPushReport, error) {
@@ -146,7 +146,7 @@ func artifactAddErrorCleanup(ctx context.Context, index int, name string, err er
 	removeOptions := artifacts.RemoveOptions{
 		Artifacts: []string{name},
 	}
-	_, recoverErr := artifacts.Remove(ctx, "", &removeOptions)
+	_, recoverErr := artifacts.Remove(ctx, &removeOptions)
 	if recoverErr != nil {
 		return fmt.Errorf("failed to cleanup unfinished artifact add: %w", errors.Join(err, recoverErr))
 	}


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
The unused `nameOrID` parameter was removed from the `artifacts.Remove()` function signature. 

[ACTION REQUIRED] Users migrating to this version must update their code to remove the `nameOrID` argument when calling `artifacts.Remove()`, as the parameter is no longer used.
```
