### PR TITLE
pkg/trust: fix directory handle leak in loadAndMergeConfig

### DIFF
--- a/pkg/trust/registries.go
+++ b/pkg/trust/registries.go
@@ -63,6 +63,7 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 		}
 		return nil, err
 	}
+	defer dir.Close()
 	configNames, err := dir.Readdirnames(0)
 	if err != nil {
 		return nil, err

--- a/pkg/trust/registries_test.go
+++ b/pkg/trust/registries_test.go
@@ -1,0 +1,29 @@
+package trust
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAndMergeConfig(t *testing.T) {
+	// Non-existent directory returns empty config without error.
+	config, err := loadAndMergeConfig(filepath.Join(t.TempDir(), "nonexistent"))
+	require.NoError(t, err)
+	assert.Empty(t, config.Docker)
+	assert.Nil(t, config.DefaultDocker)
+
+	// Empty directory returns empty config.
+	emptyDir := t.TempDir()
+	config, err = loadAndMergeConfig(emptyDir)
+	require.NoError(t, err)
+	assert.Empty(t, config.Docker)
+	assert.Nil(t, config.DefaultDocker)
+
+	// Existing testdata directory returns valid config.
+	config, err = loadAndMergeConfig("./testdata")
+	require.NoError(t, err)
+	assert.NotEmpty(t, config.Docker)
+}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### How Has This Been Tested?

- `go build ./pkg/trust/...` passes
- `go vet ./pkg/trust/...` passes
- `gofmt` clean

#### Description

`loadAndMergeConfig()` in `pkg/trust/registries.go` opens a directory with `os.Open()` to read YAML config file names via `Readdirnames()`, but never closes the directory handle. This leaks one file descriptor per invocation.

The fix adds `defer dir.Close()` immediately after the error check, following the standard Go pattern for resource cleanup.

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>
