### PR TITLE
Close leaked file handles in container config, CRIU stats, and playbook read

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -393,6 +393,7 @@ func (c *Container) specFromState() (*spec.Spec, error) {
 	returnSpec := c.config.Spec
 
 	if f, err := os.Open(c.state.ConfigPath); err == nil {
+		defer f.Close()
 		returnSpec = new(spec.Spec)
 		content, err := io.ReadAll(f)
 		if err != nil {

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1380,6 +1380,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 		if err != nil {
 			return nil, fmt.Errorf("not able to open %q: %w", c.bundlePath(), err)
 		}
+		defer statsDirectory.Close()
 
 		dumpStatistics, err := stats.CriuGetDumpStats(statsDirectory)
 		if err != nil {
@@ -1833,6 +1834,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 		if err != nil {
 			return nil, fmt.Errorf("not able to open %q: %w", c.bundlePath(), err)
 		}
+		defer statsDirectory.Close()
 
 		restoreStatistics, err := stats.CriuGetRestoreStats(statsDirectory)
 		if err != nil {

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -239,6 +239,7 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 		s, err := io.ReadAll(f)
 		if err != nil {
 			return fmt.Errorf("read playbook: %w", err)


### PR DESCRIPTION
### What does this PR do?

Adds missing `defer Close()` calls in four locations where file handles are opened but never closed:

1. **`libpod/container.go` (`specFromState`)**: `os.Open(c.state.ConfigPath)` reads the container config but the file handle `f` is never closed, leaking one fd per call. Introduced in #2114 (2019-01-09).

2. **`libpod/container_internal_common.go` (`checkpoint`)**: `os.Open(c.bundlePath())` opens the bundle directory for CRIU dump statistics but the `statsDirectory` handle is never closed, leaking one fd per checkpoint operation. Introduced in #15632 (2022-08-27).

3. **`libpod/container_internal_common.go` (`restore`)**: Same pattern as checkpoint; `statsDirectory` opened for CRIU restore statistics is never closed. Introduced in #15632 (2022-08-27).

4. **`pkg/machine/shim/host.go` (`Init`)**: `os.Open(opts.PlaybookPath)` reads the playbook file but the handle `f` is never closed after `io.ReadAll`. Introduced in #25043 (2025-01-17).

### How was this tested?

These are mechanical `defer Close()` additions following the same pattern as #28723 (which was accepted for the same class of fix in `pkg/trust/registries.go`). The functions involved require complex runtime state (Container with CRIU, machine providers) that makes isolated unit testing impractical. Requesting the `No New Tests` label.

### Release note

```release-note
Fixed file handle leaks in container config parsing (`specFromState`), CRIU checkpoint/restore statistics, and machine playbook reading.
```