### PR TITLE
Fixes for Hyper-V user experience

### DIFF
--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -58,7 +58,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		dirs, err := env.GetMachineDirs(machineProvider.VMType())
+		dirs, err := env.GetMachineDirs(vmProvider.VMType())
 		if err != nil {
 			return err
 		}

--- a/pkg/machine/hyperv/hutil.go
+++ b/pkg/machine/hyperv/hutil.go
@@ -20,6 +20,7 @@ var (
 	ErrHypervRegistryUpdateRequiresElevation = errors.New("this machine's configuration requires additional Hyper-V networking (hvsock) entries in the Windows Registry. Please run Podman as an administrator")
 	ErrHypervLegacyMachineRequiresElevation  = errors.New("starting or stopping Hyper-V machines created with Podman 5.x or earlier requires admin rights. Please run Podman as an administrator")
 	ErrHypervPrepareHostForHyperV            = errors.New("podman needs to prepare the host to run Hyper-V machines without requiring Administrator rights in the future. This involves a one-time setup of the Windows Registry and adding your account to the 'Hyper-V Administrators' group")
+	ErrHypervUserSessionNotUpdated           = errors.New("we have added you to the Hyper-V Administrators group, but your active session needs to be updated. Log out and log back in to apply the new permissions. Or, if you can't log out, run the command as an administrator")
 
 	// Lazily load the NetAPI32 DLL and the function we need
 	modnetapi32                 = syswindows.NewLazySystemDLL("netapi32.dll")
@@ -250,7 +251,7 @@ func VerifyHyperVPermissions() error {
 
 	inGroup, _ := isUserInGroup(groupPtr, userSid)
 	if inGroup {
-		return errors.New("you have been added to the Hyper-V Administrators group, but your active session has not updated. Please log out of Windows and log back in to apply the permissions")
+		return ErrHypervUserSessionNotUpdated
 	}
 
 	// They are not an Admin, not in the token, and not in the group database.

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -33,7 +33,7 @@ type HyperVStubber struct {
 
 type permissionChecks struct {
 	isElevatedProcess   func() bool
-	isHyperVAdminMember func() bool
+	isHyperVAdminMember func() error
 	vsockEntriesExist   func(int) bool
 	existingMachinesNum func() (int, error)
 }
@@ -41,7 +41,7 @@ type permissionChecks struct {
 func (h HyperVStubber) defaultPermissionChecks() permissionChecks {
 	return permissionChecks{
 		isElevatedProcess:   windows.HasAdminRights,
-		isHyperVAdminMember: IsHyperVAdminsGroupMember,
+		isHyperVAdminMember: VerifyHyperVPermissions,
 		vsockEntriesExist:   vsock.CheckIfHVSockRegistryEntriesExist,
 		existingMachinesNum: h.countMachinesWithToolname,
 	}
@@ -296,10 +296,7 @@ func checkCanCreate(checks permissionChecks, mounts int) error {
 	if !checks.vsockEntriesExist(mounts) {
 		return ErrHypervRegistryInitRequiresElevation
 	}
-	if !checks.isHyperVAdminMember() {
-		return ErrHypervUserNotInAdminGroup
-	}
-	return nil
+	return checks.isHyperVAdminMember()
 }
 
 // launchElevate attempts to automatically re-run the command as administrator
@@ -359,8 +356,8 @@ func checkCanRemove(mc *vmconfigs.MachineConfig, checks permissionChecks) error 
 	if isLegacyMachine(mc) {
 		return ErrHypervLegacyMachineRequiresElevation
 	}
-	if !checks.isHyperVAdminMember() {
-		return ErrHypervUserNotInAdminGroup
+	if err := checks.isHyperVAdminMember(); err != nil {
+		return err
 	}
 	machines, err := checks.existingMachinesNum()
 	if err != nil {
@@ -541,11 +538,14 @@ func (h HyperVStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func(
 // State is returns the state as a define.status.  for hyperv, state differs from others because
 // state is determined by the VM itself.  normally this can be done with vm.State() and a conversion
 // but doing here as well.  this requires a little more interaction with the hypervisor
-func (h HyperVStubber) State(mc *vmconfigs.MachineConfig, _ bool) (define.Status, error) {
+func (h HyperVStubber) State(mc *vmconfigs.MachineConfig, bypass bool) (define.Status, error) {
 	// If the user does not have permissions, WMI will fail with an error anyway.
-	// Just return Unknown.
-	if !windows.HasAdminRights() && !IsHyperVAdminsGroupMember() {
-		return define.Unknown, nil
+	if err := VerifyHyperVPermissions(); err != nil {
+		if bypass {
+			logrus.Warnf("unable to get state for machine %s: %v", mc.Name, err)
+			return define.Unknown, nil
+		}
+		return define.Unknown, fmt.Errorf("unable to get state for machine %s: %w", mc.Name, err)
 	}
 
 	_, vm, err := GetVMFromMC(mc)

--- a/pkg/machine/hyperv/stubber_test.go
+++ b/pkg/machine/hyperv/stubber_test.go
@@ -17,7 +17,7 @@ func TestCanCreate(t *testing.T) {
 		name              string
 		isElevated        bool
 		vsockEntriesExist bool
-		isHyperVAdmin     bool
+		isHyperVAdmin     error
 		mounts            int
 		expectedErr       error
 	}{
@@ -25,7 +25,7 @@ func TestCanCreate(t *testing.T) {
 			name:              "in elevated process can always create",
 			isElevated:        true,
 			vsockEntriesExist: false,
-			isHyperVAdmin:     false,
+			isHyperVAdmin:     ErrHypervUserNotInAdminGroup,
 			mounts:            2,
 			expectedErr:       nil,
 		},
@@ -33,21 +33,21 @@ func TestCanCreate(t *testing.T) {
 			name:              "not elevated, no vsock entries",
 			isElevated:        false,
 			vsockEntriesExist: false,
-			isHyperVAdmin:     true,
+			isHyperVAdmin:     nil,
 			expectedErr:       ErrHypervRegistryInitRequiresElevation,
 		},
 		{
 			name:              "not elevated, vsock entries exist, not hyperv admin",
 			isElevated:        false,
 			vsockEntriesExist: true,
-			isHyperVAdmin:     false,
+			isHyperVAdmin:     ErrHypervUserNotInAdminGroup,
 			expectedErr:       ErrHypervUserNotInAdminGroup,
 		},
 		{
 			name:              "not elevated, vsock entries exist, hyperv admin",
 			isElevated:        false,
 			vsockEntriesExist: true,
-			isHyperVAdmin:     true,
+			isHyperVAdmin:     nil,
 			expectedErr:       nil,
 		},
 	}
@@ -58,7 +58,7 @@ func TestCanCreate(t *testing.T) {
 
 			checks := permissionChecks{
 				isElevatedProcess:   func() bool { return tt.isElevated },
-				isHyperVAdminMember: func() bool { return tt.isHyperVAdmin },
+				isHyperVAdminMember: func() error { return tt.isHyperVAdmin },
 				vsockEntriesExist:   func(int) bool { return tt.vsockEntriesExist },
 			}
 
@@ -74,7 +74,7 @@ func TestCanRemove(t *testing.T) {
 	tests := []struct {
 		name                    string
 		isElevatedProcess       bool
-		isHyperVAdminMember     bool
+		isHyperVAdminMember     error
 		isLegacyMachine         bool
 		skipVsockEntriesRemoval bool
 		isLastMachine           bool
@@ -83,7 +83,7 @@ func TestCanRemove(t *testing.T) {
 		{
 			name:                    "elevated process can always remove",
 			isElevatedProcess:       true,
-			isHyperVAdminMember:     false,
+			isHyperVAdminMember:     ErrHypervUserNotInAdminGroup,
 			isLegacyMachine:         false,
 			skipVsockEntriesRemoval: false,
 			isLastMachine:           true,
@@ -92,7 +92,7 @@ func TestCanRemove(t *testing.T) {
 		{
 			name:                    "not elevated, legacy machine requires elevation",
 			isElevatedProcess:       false,
-			isHyperVAdminMember:     false,
+			isHyperVAdminMember:     ErrHypervUserNotInAdminGroup,
 			isLegacyMachine:         true,
 			skipVsockEntriesRemoval: false,
 			isLastMachine:           true,
@@ -101,7 +101,7 @@ func TestCanRemove(t *testing.T) {
 		{
 			name:                    "not elevated, not hyperv admins member",
 			isElevatedProcess:       false,
-			isHyperVAdminMember:     false,
+			isHyperVAdminMember:     ErrHypervUserNotInAdminGroup,
 			isLegacyMachine:         false,
 			skipVsockEntriesRemoval: false,
 			isLastMachine:           true,
@@ -110,7 +110,7 @@ func TestCanRemove(t *testing.T) {
 		{
 			name:                    "not elevated, hyperv admins member, not last machine",
 			isElevatedProcess:       false,
-			isHyperVAdminMember:     true,
+			isHyperVAdminMember:     nil,
 			isLegacyMachine:         false,
 			skipVsockEntriesRemoval: false,
 			isLastMachine:           false,
@@ -119,7 +119,7 @@ func TestCanRemove(t *testing.T) {
 		{
 			name:                    "not elevated, hyperv admins member, last machine, skip vsock entries removal",
 			isElevatedProcess:       false,
-			isHyperVAdminMember:     true,
+			isHyperVAdminMember:     nil,
 			isLegacyMachine:         false,
 			skipVsockEntriesRemoval: true,
 			isLastMachine:           true,
@@ -128,7 +128,7 @@ func TestCanRemove(t *testing.T) {
 		{
 			name:                    "not elevated, hyperv admins member, last machine, don't skip vsock entries removal",
 			isElevatedProcess:       false,
-			isHyperVAdminMember:     true,
+			isHyperVAdminMember:     nil,
 			isLegacyMachine:         false,
 			skipVsockEntriesRemoval: false,
 			isLastMachine:           true,
@@ -142,7 +142,7 @@ func TestCanRemove(t *testing.T) {
 
 			checks := permissionChecks{
 				isElevatedProcess:   func() bool { return tt.isElevatedProcess },
-				isHyperVAdminMember: func() bool { return tt.isHyperVAdminMember },
+				isHyperVAdminMember: func() error { return tt.isHyperVAdminMember },
 				existingMachinesNum: func() (int, error) {
 					if tt.isLastMachine {
 						return 1, nil

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -42,7 +42,8 @@ func List(vmstubbers []vmconfigs.VMProvider, _ machine.ListOptions) ([]*machine.
 		return nil, err
 	}
 	for name, mc := range mcs {
-		state, err := mc.Provider.State(mc.MachineConfig, false)
+		// set bypass=true so it doesn't fail the entire list if one provider can't determine state
+		state, err := mc.Provider.State(mc.MachineConfig, true)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR contains two small fixes to improve the Hyper-V user experience. I have separated them into two distinct commits since they are minor.

To set up the environment, users run system hyperv-prep, which creates Registry entries and adds the user to the Hyper-V admin group. Previously, the success message stated that the user needs to log out and back in to use Podman in a non-elevated shell. However, it failed to mention that they can continue running commands in an elevated (admin) shell immediately without logging out.

The second is about the machine directory returned in the inspect command. It was displaying the default system provider instead of the specific machine provider.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
