### PR TITLE
docs(api): drop trailing slash on podman.io/community contact URL

### DIFF
--- a/pkg/api/server/doc.go
+++ b/pkg/api/server/doc.go
@@ -48,7 +48,7 @@
 //	BasePath: /
 //	Version: 5.0.0
 //	License: Apache-2.0 https://opensource.org/licenses/Apache-2.0
-//	Contact: Podman <podman@lists.podman.io> https://podman.io/community/
+//	Contact: Podman <podman@lists.podman.io> https://podman.io/community
 //
 //	InfoExtensions:
 //	x-logo:


### PR DESCRIPTION
Drops the trailing slash on the `https://podman.io/community/` contact URL in `pkg/api/server/doc.go`. The generated swagger spec carries that URL into the ReDoc-rendered API reference at the top of the page, where issue #28298 reports it as a 404.

`https://podman.io/community/` returns 404 today; `https://podman.io/community` (no trailing slash) returns 200 and is the form the live site uses in its own navigation, so dropping the slash restores a working link without changing the destination.

This addresses only the 404 portion of #28298. The deep-link regression (URLs like `?version=latest#tag/.../operation/...` clearing on load) is a separate ReDoc / single-page-app behavior change and is out of scope for this PR.

#### Does this PR introduce a user-facing change?
```release-note
Fixed broken contact URL at the top of the rendered API reference (`https://podman.io/community/` 404 → `https://podman.io/community`).
```