### PR TITLE
machine: add SSHSession to reuse SSH connections

### DIFF
--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -338,24 +338,32 @@ func (q *QEMUStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
 // machine
 // TODO this should probably be temporary; mount code should probably be its own package and shared completely
 func (q *QEMUStubber) MountVolumesToVM(mc *vmconfigs.MachineConfig, quiet bool) error {
+	if len(mc.Mounts) == 0 {
+		return nil
+	}
+
+	sess, err := machine.NewSSHSession(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port)
+	if err != nil {
+		return err
+	}
+	defer sess.Close()
+
 	for _, mount := range mc.Mounts {
 		if !quiet {
 			fmt.Printf("Mounting volume... %s:%s\n", mount.Source, mount.Target)
 		}
-		// create mountpoint directory if it doesn't exist
-		// because / is immutable, we have to monkey around with permissions
+		// create mountpoint directory if it doesn't exist, then mount
+		// combined into a single SSH command per volume.
+		// Because / is immutable, we have to monkey around with permissions
 		// if we dont mount in /home or /mnt
-		var args []string
-		if !strings.HasPrefix(mount.Target, "/home") && !strings.HasPrefix(mount.Target, "/mnt") {
-			args = append(args, "sudo", "chattr", "-i", "/", ";")
+		var parts []string
+		requiresChattr := !strings.HasPrefix(mount.Target, "/home") && !strings.HasPrefix(mount.Target, "/mnt")
+		if requiresChattr {
+			parts = append(parts, "sudo chattr -i /")
 		}
-		args = append(args, "sudo", "mkdir", "-p", strconv.Quote(mount.Target))
-		if !strings.HasPrefix(mount.Target, "/home") && !strings.HasPrefix(mount.Target, "/mnt") {
-			args = append(args, ";", "sudo", "chattr", "+i", "/", ";")
-		}
-		err := machine.LocalhostSSH(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port, args)
-		if err != nil {
-			return err
+		parts = append(parts, "sudo mkdir -p "+strconv.Quote(mount.Target))
+		if requiresChattr {
+			parts = append(parts, "sudo chattr +i /")
 		}
 
 		mountFlags := fmt.Sprintf("context=\"%s\"", machine.NFSSELinuxContext)
@@ -366,13 +374,12 @@ func (q *QEMUStubber) MountVolumesToVM(mc *vmconfigs.MachineConfig, quiet bool) 
 		// but we ignore it now because we want the mount type to be dynamic, not static.  Or
 		// in other words we don't want to make people unnecessarily reprovision their machines
 		// to upgrade from 9p to virtiofs.
-		mountOptions := []string{
-			"-t", "virtiofs",
-			mount.Tag, strconv.Quote(mount.Target),
-			"-o", mountFlags,
-		}
-		err = machine.LocalhostSSH(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port, append([]string{"sudo", "mount"}, mountOptions...))
-		if err != nil {
+		parts = append(parts, fmt.Sprintf("sudo mount -t virtiofs %s %s -o %s",
+			mount.Tag, strconv.Quote(mount.Target), mountFlags))
+
+		script := strings.Join(parts, " && ")
+		args := []string{"bash", "-c", script}
+		if err := sess.Run(args, true, nil); err != nil {
 			return err
 		}
 	}

--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
@@ -59,6 +60,59 @@ func LocalhostSSHCopy(username, identityPath string, sshPort int, srcPath, destP
 	}
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// SSHSession holds a reusable SSH connection to a guest VM, allowing multiple
+// commands to be run over a single TCP connection and SSH handshake.
+type SSHSession struct {
+	client *ssh.Client
+	name   string
+}
+
+// NewSSHSession dials an SSH connection to the guest VM and returns a session
+// that can run multiple commands without re-dialing.
+func NewSSHSession(username, identityPath, name string, sshPort int) (*SSHSession, error) {
+	config, err := createLocalhostConfig(username, identityPath)
+	if err != nil {
+		return nil, err
+	}
+	start := time.Now()
+	client, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%d", sshPort), config)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("SSH session to %q opened: dial=%v", name, time.Since(start))
+	return &SSHSession{client: client, name: name}, nil
+}
+
+func (s *SSHSession) Close() error {
+	return s.client.Close()
+}
+
+// Run executes a command on the guest VM over the existing SSH connection.
+func (s *SSHSession) Run(inputArgs []string, passOutput bool, stdin io.Reader) error {
+	start := time.Now()
+	session, err := s.client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	cmd := strings.Join(inputArgs, " ")
+	logrus.Debugf("Running ssh command on machine %q: %s", s.name, cmd)
+	session.Stdin = stdin
+	if passOutput {
+		session.Stdout = os.Stdout
+		session.Stderr = os.Stderr
+	} else if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		err = runSessionWithDebug(session, cmd)
+		logrus.Debugf("SSH to %q: dial=0s run=%v total=%v cmd=%s", s.name, time.Since(start), time.Since(start), cmd)
+		return err
+	}
+
+	err = session.Run(cmd)
+	logrus.Debugf("SSH to %q: dial=0s run=%v total=%v cmd=%s", s.name, time.Since(start), time.Since(start), cmd)
+	return err
 }
 
 func localhostBuiltinSSH(username, identityPath, name string, sshPort int, inputArgs []string, passOutput bool, stdin io.Reader) error {

--- a/pkg/machine/update.go
+++ b/pkg/machine/update.go
@@ -12,16 +12,11 @@ import (
 
 func UpdatePodmanDockerSockService(mc *vmconfigs.MachineConfig) error {
 	content := ignition.GetPodmanDockerTmpConfig(mc.HostUser.UID, mc.HostUser.Rootful, false)
-	command := fmt.Sprintf("'echo %q > %s'", content, ignition.PodmanDockerTmpConfPath)
+	command := fmt.Sprintf("'echo %q > %s && systemd-tmpfiles --create --prefix=/run/docker.sock'",
+		content, ignition.PodmanDockerTmpConfPath)
 	args := []string{"sudo", "bash", "-c", command}
 	if err := LocalhostSSH(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port, args); err != nil {
 		logrus.Warnf("Could not update internal docker sock config")
-		return err
-	}
-
-	args = []string{"sudo", "systemd-tmpfiles", "--create", "--prefix=/run/docker.sock"}
-	if err := LocalhostSSH(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port, args); err != nil {
-		logrus.Warnf("Could not create internal docker sock")
 		return err
 	}
 


### PR DESCRIPTION
Each ssh.Dial to localhost costs ~77ms. I counted 6 SSH calls during a machine start, ~464ms is spent on connection init. Some more time can be saved by incorporating bash commands in one.

- Merge the two separate SSH calls (write tmpfiles config + run systemd-tmpfiles) into a single bash -c command joined with &&.

- MountVolumesToVM now opens a single SSHSession for all volumes

- Combine mkdir and mount steps into a single bash -c command per volume, further halving the number of SSH round-trips.

Time measurements are done by running
`bin/podman machine start --log-level=debug`
and checking the time in the logs (this and the table were done by Claude):

  Init (unchanged, not optimized):
  +---+--------+--------+---------+------------------------------+
  | # |  Dial  |  Run   |  Total  | Purpose                      |
  +---+--------+--------+---------+------------------------------+
  | 1 |  95ms  | 2156ms | 2251ms  | SSH readiness probe          |
  | 2 |  85ms  |  738ms |  823ms  | inject proxy env             |
  +---+--------+--------+---------+------------------------------+

  Volume mounts — before (4 connections, 4 dials):
  +---+--------+--------+---------+------------------------------+
  | # |  Dial  |  Run   |  Total  | Purpose                      |
  +---+--------+--------+---------+------------------------------+
  | 1 |  66ms  |  341ms |  408ms  | vol 1: mkdir                 |
  | 2 |  70ms  |  329ms |  400ms  | vol 1: mount                 |
  | 3 |  76ms  |  423ms |  499ms  | vol 2: chattr + mkdir        |
  | 4 |  72ms  |  270ms |  342ms  | vol 2: mount                 |
  +---+--------+--------+---------+------------------------------+
      |  284ms | 1363ms | 1649ms  |
      +--------+--------+---------+

  Volume mounts — after (1 dial, shared session):
  +---+--------+--------+---------+------------------------------+
  | # |  Dial  |  Run   |  Total  | Purpose                      |
  +---+--------+--------+---------+------------------------------+
  | 1 |  64ms  |    --  |    --   | open shared session          |
  | 2 |   0ms  |  586ms |  586ms  | vol 1: mkdir + mount         |
  | 3 |   0ms  |  527ms |  527ms  | vol 2: chattr + mkdir + mount|
  +---+--------+--------+---------+------------------------------+
      |  64ms  | 1113ms | 1113ms  |
      +--------+--------+---------+
  Saved: ~220ms dial, ~250ms total (3 fewer connections)

Fixes: https://redhat.atlassian.net/browse/RUN-4470

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
