### PR TITLE
Remove unused nolint annotations

### DIFF
--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -171,7 +171,7 @@ func printJSON(data []*dfSummary) error {
 	return nil
 }
 
-func printVerbose(cmd *cobra.Command, reports *entities.SystemDfReport) error { //nolint:interfacer
+func printVerbose(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 	rpt := report.New(os.Stdout, cmd.Name())
 	defer rpt.Flush()
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1080,7 +1080,7 @@ func (c *Container) StartupHCPassed() (bool, error) {
 
 // NamespacePath returns the path of one of the container's namespaces
 // If the container is not running, an error will be returned
-func (c *Container) NamespacePath(linuxNS LinuxNS) (string, error) { //nolint:interfacer
+func (c *Container) NamespacePath(linuxNS LinuxNS) (string, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -1094,7 +1094,7 @@ func (c *Container) NamespacePath(linuxNS LinuxNS) (string, error) { //nolint:in
 
 // namespacePath returns the path of one of the container's namespaces
 // If the container is not running, an error will be returned
-func (c *Container) namespacePath(linuxNS LinuxNS) (string, error) { //nolint:interfacer
+func (c *Container) namespacePath(linuxNS LinuxNS) (string, error) {
 	if c.state.State != define.ContainerStateRunning && c.state.State != define.ContainerStatePaused {
 		return "", fmt.Errorf("cannot get namespace path unless container %s is running: %w", c.ID(), define.ErrCtrStopped)
 	}

--- a/pkg/domain/infra/abi/terminal/terminal_common.go
+++ b/pkg/domain/infra/abi/terminal/terminal_common.go
@@ -41,7 +41,7 @@ func ExecAttachCtr(ctx context.Context, ctr *libpod.Container, execConfig *libpo
 // StartAttachCtr starts and (if required) attaches to a container
 // if you change the signature of this function from os.File to io.Writer, it will trigger a downstream
 // error. we may need to just lint disable this one.
-func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool, startContainer bool) error { //nolint: interfacer
+func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool, startContainer bool) error {
 	resize := make(chan resize.TerminalSize)
 
 	haveTerminal := term.IsTerminal(int(os.Stdin.Fd()))


### PR DESCRIPTION
The interfacer linter was removed a few years ago. Remove the annotations as well.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
