### PR TITLE
.editorconfig: add indentation rule for shell files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# See https://EditorConfig.org
+
+# This is a top-most EditorConfig file.
+root = true
+
+# Ignore any "vendor" directories.
+[**/vendor/**]
+ignore = true
+
+# Bash, bats, and sh files use 4 spaces for indentation.
+[*.{bash,bats,sh}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
_This is a useful commit from the abandoned #26340._

EditorConfig is a way to specify some basic code formatting rules independently of an $EDITOR being used.

Add rules for bats/bash/sh files:
 - use 4 spaces for indentation (which appears to be a de-facto standard in this repository, see e.g. commit 86e55d0ec1acd79f7);
 - ignore everything in vendor directories.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
