### PR TITLE
Improvements for hack/golangci-lint.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,9 @@ endif
 .PHONY: golangci-lint
 golangci-lint: .install.golangci-lint
 	hack/golangci-lint.sh
+	CGO_ENABLED=0 GOOS=windows hack/golangci-lint.sh
+	CGO_ENABLED=0 GOOS=freebsd hack/golangci-lint.sh
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 hack/golangci-lint.sh
 
 .PHONY: test/checkseccomp/checkseccomp
 test/checkseccomp/checkseccomp: $(wildcard test/checkseccomp/*.go)

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -10,6 +10,9 @@ set -e
 
 declare -a EXTRA_TAGS
 
+# Prefer the one from $PATH, if available.
+BIN="$(command -v golangci-lint || echo ./bin/golangci-lint)"
+
 echo "Linting for GOOS=$GOOS"
 case "$GOOS" in
   windows|darwin)
@@ -31,6 +34,6 @@ for EXTRA in "" "${EXTRA_TAGS[@]}"; do
   # the command-line to focus or debug a single, specific linting category.
   (
     set -x
-    ./bin/golangci-lint run --build-tags="${TAGS}${EXTRA}" "$@"
+    "$BIN" run --build-tags="${TAGS}${EXTRA}" "$@"
   )
 done

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -10,6 +10,10 @@ die() { echo "${1:-No error message given} (from $(basename "$0"))"; exit 1; }
 # Strip the leading v, if found.
 VERSION=${VERSION#v}
 
+# Local installation path.
+BINDIR="./bin"
+LBIN="$BINDIR/golangci-lint"
+
 function install() {
     local retry=$1
 
@@ -22,10 +26,20 @@ function install() {
     curl -sSfL --retry 5 https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $BINDIR "v$VERSION"
 }
 
-BINDIR="./bin"
-BIN="$BINDIR/golangci-lint"
-if [ -x "$BIN" ] && $BIN --version | grep "$VERSION"; then
+# Check if it's already installed globally.
+BIN=$(command -v golangci-lint)
+if [ -n "$BIN" ] && $BIN --version | grep "$VERSION"; then
     echo "Using existing $BIN"
+    # Remove the locally installed one, as it is:
+    #  - no longer needed;
+    #  - might be old/wrong version.
+    rm -f $LBIN
+    exit 0
+fi
+
+# Check the locally installed one.
+if [ -x "$LBIN" ] && $LBIN --version | grep "$VERSION"; then
+    echo "Using existing local $LBIN"
     exit 0
 fi
 


### PR DESCRIPTION
_(useful bits extracted from #28740)_

1. hack: reuse already installed golangci-lint
    
    When a specific version of golangci-lint is already available in $PATH,
    use it instead of installing one locally.

2. hack/golangci-lint.sh: default GOARCH=arm64 for darwin
    
    Since commit f87cefc262 (Remove Intel MacOS support), Mac builds are
    arm64-only and pkg/machine/libkrun is gated on darwin && arm64. When
    linting darwin from an amd64 host (e.g. an ubuntu-latest GitHub
    Actions runner), the default GOARCH=amd64 leaves libkrun with no
    files for the build constraints, which trips a typecheck error:
    
    `pkg/machine/provider/platform_darwin.go: could not import go.podman.io/podman/v6/pkg/machine/libkrun (-: build constraints exclude all Go files in pkg/machine/libkrun)`
    
    Cirrus's Mac task runs on actual arm64 hardware so GOARCH is
    implicitly arm64 there, masking the issue. To make the script work
    identically on any host, force GOARCH=arm64 when GOOS=darwin and
    the caller hasn't set GOARCH.

#### Does this PR introduce a user-facing change?

```release-note
None
```
