### PR TITLE
Skip pasta forwarder tests pending passt SELinux fix

### DIFF
--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1060,6 +1060,8 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	configurePortForwarder := func(forwarder string) {
 		GinkgoHelper()
 		if forwarder == "pasta" {
+			// TODO: enable after new passt release with SELinux fix for pasta.sock (pasta_t + ifconfig_var_run_t)
+			Skip("disabled: pasta SELinux policy denies pasta.sock creation (needs passt release with fix)")
 			if !isRootless() {
 				Skip("pasta port forwarding requires rootless")
 			}

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -433,7 +433,9 @@ EOCONF
 }
 
 # bats test_tags=ci:parallel
+# TODO: enable after new passt release with SELinux fix for pasta.sock (pasta_t + ifconfig_var_run_t)
 @test "podman network reload - pasta forwarder" {
+    skip "disabled: pasta SELinux policy denies pasta.sock creation (needs passt release with fix)"
     skip_if_remote "podman network reload does not have remote support"
     is_rootless || skip "pasta port forwarder requires rootless"
     type -P pesto >/dev/null || skip "pesto not available"
@@ -644,7 +646,9 @@ EOCONF
 }
 
 # bats test_tags=ci:parallel
+# TODO: enable after new passt release with SELinux fix for pasta.sock (pasta_t + ifconfig_var_run_t)
 @test "podman network connect/disconnect with port forwarding - pasta forwarder" {
+    skip "disabled: pasta SELinux policy denies pasta.sock creation (needs passt release with fix)"
     is_rootless || skip "pasta port forwarder requires rootless"
     type -P pesto >/dev/null || skip "pesto not available"
     _test_network_connect_disconnect pasta
@@ -756,7 +760,9 @@ EOCONF
 }
 
 # bats test_tags=ci:parallel
+# TODO: enable after new passt release with SELinux fix for pasta.sock (pasta_t + ifconfig_var_run_t)
 @test "podman network after restart - pasta forwarder" {
+    skip "disabled: pasta SELinux policy denies pasta.sock creation (needs passt release with fix)"
     is_rootless || skip "pasta port forwarder requires rootless"
     type -P pesto >/dev/null || skip "pesto not available"
     _test_network_after_restart pasta


### PR DESCRIPTION
The pasta_t SELinux domain is denied { create } for pasta.sock on ifconfig_var_run_t directories. Disable all pasta forwarder tests (BATS + e2e) until a new passt release ships the fix.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
