### PR TITLE
ci: restrict specific workflows to the upstream repository

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   assign:
     # Only run on issue comments (not PR comments)
-    if: "!github.event.issue.pull_request && contains(github.event.comment.body, '/assign')"
+    if: |
+      !github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/assign') &&
+      github.repository == 'containers/podman'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -41,6 +41,7 @@ permissions:
 
 jobs:
     cron_failures:
+        if: github.repository == 'containers/podman'
         runs-on: ubuntu-latest
         steps:
             # This is where the scripts live

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -11,7 +11,8 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/cherry-pick ')
+      contains(github.event.comment.body, '/cherry-pick ') &&
+      github.repository == 'containers/podman'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -194,7 +195,8 @@ jobs:
   cherry-pick-on-merge:
     if: |
       github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true
+      github.event.pull_request.merged == true &&
+      github.repository == 'containers/podman'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dev-bump.yml
+++ b/.github/workflows/dev-bump.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   bump:
+    if: github.repository == 'containers/podman'
     name: Bump to -dev
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/first_contrib_cert_generator.yml
+++ b/.github/workflows/first_contrib_cert_generator.yml
@@ -22,7 +22,12 @@ jobs:
   screenshot_and_comment:
     # This job runs if the PR was merged or if it's a manual trigger.
     # The logic for first-time contributors is handled in a dedicated step below.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: |
+     (
+       github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.merged == true
+     ) &&
+     github.repository == 'containers/podman'
     runs-on: ubuntu-latest
     permissions:
       contents: read  # Write access for certificate storage

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   triage:
+    if: github.repository == 'containers/podman'
     permissions:
       contents: read  # for github/issue-labeler to get repo contents
       issues: write  # for github/issue-labeler to create or remove labels

--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -45,6 +45,7 @@ env:
 
 jobs:
   manage_locking:
+    if: github.repository == 'containers/podman'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 jobs:
   triage:
+    if: github.repository == 'containers/podman'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/mac-pkg.yml
+++ b/.github/workflows/mac-pkg.yml
@@ -19,6 +19,7 @@ permissions: {}
 
 jobs:
   build:
+    if: github.repository == 'containers/podman'
     runs-on: macos-latest
     permissions:
       contents: write

--- a/.github/workflows/machine-os-pr.yml
+++ b/.github/workflows/machine-os-pr.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   podman-image-build-pr:
+    if: github.repository == 'containers/podman'
     name: Open PR on podman-machine-os
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/needs-info-labeler.yaml
+++ b/.github/workflows/needs-info-labeler.yaml
@@ -8,7 +8,9 @@ permissions: {}
 
 jobs:
   add-comment:
-    if: github.event.label.name == 'needs-info'
+    if: |
+      github.event.label.name == 'needs-info' && 
+      github.repository == 'containers/podman'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -19,6 +19,7 @@ permissions: {}
 
 jobs:
   build:
+    if: github.repository == 'containers/podman'
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   check:
+    if: github.repository == 'containers/podman'
     name: Check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   stale:
-
+    if: github.repository == 'containers/podman'
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs

--- a/.github/workflows/update-podmanio.yml
+++ b/.github/workflows/update-podmanio.yml
@@ -22,6 +22,7 @@ permissions: {}
 
 jobs:
   bump:
+    if: github.repository == 'containers/podman'
     name: Bump
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
#### What does this PR do?
Fixed #28757 

All GitHub workflows fail because they require secrets. The only exception is `zizmor.yaml`, which runs a static analysis security check on GitHub Actions.

Here is the corrected list of workflows that should be restricted to upstream(`containers/podman`), categorized by why they will fail or act improperly in a fork:

1. Require Custom Upstream Secrets
They rely on secrets that are only available in the upstream repository:
* `check_cirrus_cron.yml`: Uses `ACTION_MAIL_*` secrets for alerting.
* `cherry-pick.yml`: Uses `CHERRY_PICK_TOKEN` to automate pushing to release branches.
* `dev-bump.yml`: Uses `PODMANBOT_TOKEN` to push version bumps.
* `first_contrib_cert_generator.yml`: Uses `CERTIFICATES_REPO_TOKEN` to commit to the external contributor certificates repo.
* `issue_pr_lock.yml`: Uses `STALE_LOCKING_APP_PRIVATE_KEY` and `ACTION_MAIL_*` secrets.
* `mac-pkg.yml`: Uses Apple Developer signing and notarization secrets (`MACOS_*`).
* `machine-os-pr.yml`: Uses `PODMANBOT_TOKEN` to push updates.
* `release-artifacts.yml`: Uses `ACTION_MAIL_*` secrets.
* `release.yml`: The primary release pipeline; requires Apple signing (`MACOS_*`), Azure signing (`AZ_*`), `ACTION_MAIL_*`, and `PODMANBOT_TOKEN`.
* `update-podmanio.yml`: Uses `PODMANBOT_TOKEN` to push updates to the `containers/podman.io` repository.

2. Manage Upstream Issue/PR Tracker State 
These workflows require write permissions to automatically manage issues, labels, and assignments. 
* `assign.yml`: Self-assigns issues.
* `issue-labeler.yml`: Automatically applies labels to new issues.
* `labeler.yml`: Automatically applies labels to PRs based on changed file paths.
* `needs-info-labeler.yaml`: Automates comments when the `needs-info` label is added.
* `stale.yml`: Marks older issues and PRs as stale and closes them.


➕  Additional Details
I refactored several complex `if` conditions using YAML multi-line strings (`|`) to improve readability and maintainability.

#### Does this PR introduce a user-facing change?

```release-note
None
```
