### PR TITLE
ci: restrict specific workflows to the upstream repository

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   assign:
     # Only run on issue comments (not PR comments)
-    if: "!github.event.issue.pull_request && contains(github.event.comment.body, '/assign')"
+    if: |
+      !github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/assign') &&
+      github.repository == 'podman-container-tools/podman'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -11,7 +11,8 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/cherry-pick ')
+      contains(github.event.comment.body, '/cherry-pick ') &&
+      github.repository == 'podman-container-tools/podman'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -194,7 +195,8 @@ jobs:
   cherry-pick-on-merge:
     if: |
       github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true
+      github.event.pull_request.merged == true &&
+      github.repository == 'podman-container-tools/podman'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   path-filter:
     runs-on: ubuntu-latest
+    if: github.repository == 'podman-container-tools/podman'
     outputs:
       all: ${{ steps.filter.outputs.all }}
       code: ${{ steps.filter.outputs.code }}
@@ -46,6 +47,7 @@ jobs:
   validate-source:
     name: Validate source code changes
     runs-on: cncf-ubuntu-8-32-x86
+    if: github.repository == 'podman-container-tools/podman'
     permissions:
       pull-requests: read # For hack/ci/pr-should-include-tests to query PR labels.
     env:
@@ -183,6 +185,7 @@ jobs:
   build-alt:
     name: Cross Build (Linux, FreeBSD)
     runs-on: cncf-ubuntu-16-64-x86
+    if: github.repository == 'podman-container-tools/podman'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -196,6 +199,7 @@ jobs:
 
   build:
     name: build ${{ matrix.distro }}
+    if: github.repository == 'podman-container-tools/podman'
     strategy:
       fail-fast: false
       matrix:
@@ -210,6 +214,7 @@ jobs:
   windows-installer:
     name: windows installer ${{ matrix.provider }}
     runs-on: windows-2025-vs2026
+    if: github.repository == 'podman-container-tools/podman'
     timeout-minutes: 20
     permissions:
       contents: read
@@ -285,6 +290,7 @@ jobs:
   macos-installer:
     name: macos installer
     runs-on: macos-26
+    if: github.repository == 'podman-container-tools/podman'
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/dev-bump.yml
+++ b/.github/workflows/dev-bump.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   bump:
+    if: github.repository == 'podman-container-tools/podman'
     name: Bump to -dev
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/first_contrib_cert_generator.yml
+++ b/.github/workflows/first_contrib_cert_generator.yml
@@ -22,7 +22,12 @@ jobs:
   screenshot_and_comment:
     # This job runs if the PR was merged or if it's a manual trigger.
     # The logic for first-time contributors is handled in a dedicated step below.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: |
+     (
+       github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.merged == true
+     ) &&
+     github.repository == 'podman-container-tools/podman'
     runs-on: ubuntu-latest
     permissions:
       contents: read  # Write access for certificate storage

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   triage:
+    if: github.repository == 'podman-container-tools/podman'
     permissions:
       contents: read  # for github/issue-labeler to get repo contents
       issues: write  # for github/issue-labeler to create or remove labels

--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -45,6 +45,7 @@ env:
 
 jobs:
   manage_locking:
+    if: github.repository == 'podman-container-tools/podman'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 jobs:
   triage:
+    if: github.repository == 'podman-container-tools/podman'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/machine-os-pr.yml
+++ b/.github/workflows/machine-os-pr.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   podman-image-build-pr:
+    if: github.repository == 'podman-container-tools/podman'
     name: Open PR on podman-machine-os
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/needs-info-labeler.yaml
+++ b/.github/workflows/needs-info-labeler.yaml
@@ -8,7 +8,9 @@ permissions: {}
 
 jobs:
   add-comment:
-    if: github.event.label.name == 'needs-info'
+    if: |
+      github.event.label.name == 'needs-info' &&
+      github.repository == 'podman-container-tools/podman'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/release-build-artifacts.yml
+++ b/.github/workflows/release-build-artifacts.yml
@@ -49,6 +49,7 @@ jobs:
   build-artifacts:
     name: Build Artifacts
     runs-on: ubuntu-latest
+    if: github.repository == 'podman-container-tools/podman'
     outputs:
       version_display: ${{ steps.set-version.outputs.version_display }}
     steps:
@@ -88,6 +89,7 @@ jobs:
   mac-pkg:
     name: Build MacOS pkginstaller
     runs-on: macos-latest
+    if: github.repository == 'podman-container-tools/podman'
     env:
       APPLICATION_CERTIFICATE: ${{ secrets.MACOS_APPLICATION_CERT }}
       CODESIGN_IDENTITY: ${{ secrets.MACOS_APPLICATION_IDENTITY }}

--- a/.github/workflows/release-pipeline-validation.yml
+++ b/.github/workflows/release-pipeline-validation.yml
@@ -17,7 +17,9 @@ jobs:
   get-latest-release:
     name: Get branch for latest release
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: |
+      github.event_name == 'schedule' &&
+      github.repository == 'podman-container-tools/podman'
     outputs:
       release_ref: ${{ steps.set.outputs.release_ref }}
     steps:
@@ -44,7 +46,9 @@ jobs:
   build-artifacts-main:
     name: Build Artifacts (main)
     uses: ./.github/workflows/release-build-artifacts.yml
-    if: github.event_name == 'schedule'
+    if: |
+      github.event_name == 'schedule' &&
+      github.repository == 'podman-container-tools/podman'
     with:
       version: 'main'
     secrets:
@@ -89,7 +93,9 @@ jobs:
   build-artifacts-single:
     name: Build Artifacts
     uses: ./.github/workflows/release-build-artifacts.yml
-    if: github.event_name == 'workflow_dispatch'
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      github.repository == 'podman-container-tools/podman'
     with:
       version: ${{ inputs.ref }}
     secrets:
@@ -110,6 +116,7 @@ jobs:
 
   validate-tokens:
     name: Validate GitHub tokens
+    if: github.repository == 'podman-container-tools/podman'
     runs-on: ubuntu-latest
     steps:
       - name: Validate PODMANBOT_TOKEN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   check:
+    if: github.repository == 'podman-container-tools/podman'
     name: Check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   stale:
-
+    if: github.repository == 'podman-container-tools/podman'
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs

--- a/.github/workflows/update-podmanio.yml
+++ b/.github/workflows/update-podmanio.yml
@@ -22,6 +22,7 @@ permissions: {}
 
 jobs:
   bump:
+    if: github.repository == 'podman-container-tools/podman'
     name: Bump
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
#### What does this PR do?
Fixed #28757 

All GitHub workflows fail because they require secrets. The only exception is `zizmor.yaml`, which runs a static analysis security check on GitHub Actions.

Here is the corrected list of workflows that should be restricted to upstream(`containers/podman`), categorized by why they will fail or act improperly in a fork:

1. Require Custom Upstream Secrets
They rely on secrets that are only available in the upstream repository:
* `check_cirrus_cron.yml`: Uses `ACTION_MAIL_*` secrets for alerting.
* `cherry-pick.yml`: Uses `CHERRY_PICK_TOKEN` to automate pushing to release branches.
* `dev-bump.yml`: Uses `PODMANBOT_TOKEN` to push version bumps.
* `first_contrib_cert_generator.yml`: Uses `CERTIFICATES_REPO_TOKEN` to commit to the external contributor certificates repo.
* `issue_pr_lock.yml`: Uses `STALE_LOCKING_APP_PRIVATE_KEY` and `ACTION_MAIL_*` secrets.
* `machine-os-pr.yml`: Uses `PODMANBOT_TOKEN` to push updates.
* `release.yml`: The primary release pipeline; requires Apple signing (`MACOS_*`), Azure signing (`AZ_*`), `ACTION_MAIL_*`, and `PODMANBOT_TOKEN`.
* `update-podmanio.yml`: Uses `PODMANBOT_TOKEN` to push updates to the `containers/podman.io` repository.

2. Manage Upstream Issue/PR Tracker State 
These workflows require write permissions to automatically manage issues, labels, and assignments. 
* `assign.yml`: Self-assigns issues.
* `issue-labeler.yml`: Automatically applies labels to new issues.
* `labeler.yml`: Automatically applies labels to PRs based on changed file paths.
* `needs-info-labeler.yaml`: Automates comments when the `needs-info` label is added.
* `stale.yml`: Marks older issues and PRs as stale and closes them.


➕  Additional Details
I refactored several complex `if` conditions using YAML multi-line strings (`|`) to improve readability and maintainability.

#### Does this PR introduce a user-facing change?

```release-note
None
```
