### PR TITLE
Use shfmt (for ./hack only)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,12 @@ ignore = true
 [*.{bash,bats,sh}]
 indent_style = space
 indent_size = 4
+space_redirects = true
+
+# This is for shell scripts with shebang but no extensions.
+# Not yes supported by editorconfig[1], only by shfmt.
+# https://github.com/editorconfig/editorconfig/issues/404
+[[shell]]
+indent_style = space
+indent_size = 4
+space_redirects = true

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ BUILDTAGS += ${EXTRA_BUILDTAGS}
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
 GOLANGCI_LINT_VERSION := 2.12.2
+SHFMT_VERSION := 3.13.1
 PYTHON ?= $(shell command -v python3 python|head -n1)
 PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems
@@ -295,6 +296,11 @@ golangci-lint: .install.golangci-lint
 	CGO_ENABLED=0 GOOS=freebsd hack/golangci-lint.sh
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 hack/golangci-lint.sh
 
+.PHONY: shfmt
+shfmt: .install.shfmt
+	./bin/shfmt --version
+	./bin/shfmt -d -w ./hack/
+
 .PHONY: test/checkseccomp/checkseccomp
 test/checkseccomp/checkseccomp: $(wildcard test/checkseccomp/*.go)
 	$(GOCMD) build $(BUILDFLAGS) $(GO_LDFLAGS) '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o $@ ./test/checkseccomp
@@ -323,7 +329,7 @@ codespell:
 
 # Code validation target that **DOES NOT** require building podman binaries
 .PHONY: validate-source
-validate-source: lint .commit-subject-check .check-ci-yaml swagger-check tests-expect-exit pr-removes-fixed-skips
+validate-source: lint shfmt .commit-subject-check .check-ci-yaml swagger-check tests-expect-exit pr-removes-fixed-skips
 
 # Code validation target that **DOES** require building podman binaries
 .PHONY: validate-binaries
@@ -1012,6 +1018,10 @@ install.tools: .install.golangci-lint ## Install needed tools
 .PHONY: .install.golangci-lint
 .install.golangci-lint:
 	VERSION=$(GOLANGCI_LINT_VERSION) ./hack/install_golangci.sh
+
+.PHONY: .install.shfmt
+.install.shfmt:
+	GOBIN=$(CURDIR)/bin $(GO) install mvdan.cc/sh/v3/cmd/shfmt@v$(SHFMT_VERSION)
 
 .PHONY: .install.swagger
 .install.swagger:

--- a/hack/apparmor_tag.sh
+++ b/hack/apparmor_tag.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-if pkg-config libapparmor 2> /dev/null ; then
-	echo apparmor
+if pkg-config libapparmor 2> /dev/null; then
+    echo apparmor
 fi

--- a/hack/bats
+++ b/hack/bats
@@ -67,35 +67,40 @@ declare -a bats_filter=()
 
 declare -a TESTS
 
-for i;do
-    value=`expr "$i" : '[^=]*=\(.*\)'`
+for i; do
+    value=$(expr "$i" : '[^=]*=\(.*\)')
     case "$i" in
-        -h|--help)  echo "$usage"; exit 0;;
-        --root)     TEST_ROOTLESS= ;;
-        --rootless) TEST_ROOT= ;;
-        --remote)   REMOTE=remote ;;
-        --tap|-t)   bats_opts+=("-t") ;;
-        --ts|-T)    bats_opts+=("-T") ;;
-        --tag=*)    bats_filter=("--filter-tags" "$value")
-                    if [[ "$value" = "ci:parallel" ]]; then
-                        bats_opts+=("--jobs" $(nproc))
-                    fi;;
-        */*.bats)   TESTS+=("$i") ;;
-        *)
-            if [[ $i =~ : ]]; then
-                tname=${i%:*}          # network:localhost -> network
-                filt=${i#*:}           # network:localhost ->   localhost
-                TESTS+=($(echo $TESTS_DIR/*$tname*.bats))
-                bats_filter=("--filter" "$filt")
-            else
-                TESTS+=($(echo $TESTS_DIR/*$i*.bats))
-            fi
-            ;;
+    -h | --help)
+        echo "$usage"
+        exit 0
+        ;;
+    --root) TEST_ROOTLESS= ;;
+    --rootless) TEST_ROOT= ;;
+    --remote) REMOTE=remote ;;
+    --tap | -t) bats_opts+=("-t") ;;
+    --ts | -T) bats_opts+=("-T") ;;
+    --tag=*)
+        bats_filter=("--filter-tags" "$value")
+        if [[ "$value" = "ci:parallel" ]]; then
+            bats_opts+=("--jobs" $(nproc))
+        fi
+        ;;
+    */*.bats) TESTS+=("$i") ;;
+    *)
+        if [[ $i =~ : ]]; then
+            tname=${i%:*} # network:localhost -> network
+            filt=${i#*:}  # network:localhost ->   localhost
+            TESTS+=($(echo $TESTS_DIR/*$tname*.bats))
+            bats_filter=("--filter" "$filt")
+        else
+            TESTS+=($(echo $TESTS_DIR/*$i*.bats))
+        fi
+        ;;
     esac
 done
 
-if [ ${#TESTS[@]} -eq 0 ] ; then
-        TESTS=("$TESTS_DIR")
+if [ ${#TESTS[@]} -eq 0 ]; then
+    TESTS=("$TESTS_DIR")
 fi
 
 # With --remote, use correct binary and make sure daem--I mean server--is live
@@ -125,12 +130,12 @@ export PODMAN_BATS_LEAK_CHECK=1
 # Root
 if [[ "$TEST_ROOT" ]]; then
     echo "# bats ${bats_opts[*]} ${bats_filter[*]} ${TESTS[*]}"
-    sudo    --preserve-env=PODMAN \
-            --preserve-env=QUADLET \
-            --preserve-env=PODMAN_TEST_DEBUG \
-            --preserve-env=CONTAINERS_HELPER_BINARY_DIR \
-            --preserve-env=PODMAN_ROOTLESS_USER \
-            bats "${bats_opts[@]}" "${bats_filter[@]}" "${TESTS[@]}"
+    sudo --preserve-env=PODMAN \
+        --preserve-env=QUADLET \
+        --preserve-env=PODMAN_TEST_DEBUG \
+        --preserve-env=CONTAINERS_HELPER_BINARY_DIR \
+        --preserve-env=PODMAN_ROOTLESS_USER \
+        bats "${bats_opts[@]}" "${bats_filter[@]}" "${TESTS[@]}"
     rc=$?
 fi
 

--- a/hack/btrfs_installed_tag.sh
+++ b/hack/btrfs_installed_tag.sh
@@ -2,6 +2,6 @@
 ${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <btrfs/ioctl.h>
 EOF
-if test $? -ne 0 ; then
-	echo exclude_graphdriver_btrfs
+if test $? -ne 0; then
+    echo exclude_graphdriver_btrfs
 fi

--- a/hack/check_root.sh
+++ b/hack/check_root.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 if ! [ $(id -u) = 0 ]; then
-   echo "Please run as root! '$*' requires root privileges."
-   exit 1
+    echo "Please run as root! '$*' requires root privileges."
+    exit 1
 fi

--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 
 source "$SCRIPT_DIR/lib.sh"
 
@@ -17,7 +17,6 @@ IMAGE="$DISTRO_NAME.x86_64.qcow2.zst"
 
 # IMAGE_URL="~/Downloads/fedora-rawhide.x86_64.qcow2.zst"
 IMAGE_URL="https://objectstorage.us-ashburn-1.oraclecloud.com/n/id0lmbbwgcdv/b/podman-ci-vm-images/o/releases/$AUTOMATION_RELEASE/$IMAGE"
-
 
 trap "limactl delete --force $LIMA_VM_NAME" EXIT
 

--- a/hack/ci/get-local-registry-script
+++ b/hack/ci/get-local-registry-script
@@ -48,14 +48,22 @@ Reasons for doing this:
 
 verbose=
 for i; do
-    value=`expr "$i" : '[^=]*=\(.*\)'`
+    value=$(expr "$i" : '[^=]*=\(.*\)')
     case "$i" in
-    -h*|--help)	echo "$usage"; exit 0;;
-    -v|--verbose)	verbose=$i; shift;;
-    -*)	echo "$ME: unrecognized option $i" >&2
-	echo "$usage" >&2
-	exit 1;;
-    *)	break;;
+    -h* | --help)
+        echo "$usage"
+        exit 0
+        ;;
+    -v | --verbose)
+        verbose=$i
+        shift
+        ;;
+    -*)
+        echo "$ME: unrecognized option $i" >&2
+        echo "$usage" >&2
+        exit 1
+        ;;
+    *) break ;;
     esac
 done
 
@@ -70,7 +78,7 @@ function die() {
 function get_imgsfx() {
     test -e .cirrus.yml || die ".cirrus.yml does not exist; please run me from top of repo"
 
-    imgsfx=$(sed -ne 's/^ *IMAGE_SUFFIX:.*"c\(202.*\)"/\1/p' <.cirrus.yml)
+    imgsfx=$(sed -ne 's/^ *IMAGE_SUFFIX:.*"c\(202.*\)"/\1/p' < .cirrus.yml)
     if [[ -z "$imgsfx" ]]; then
         die "Did not find 'IMAGE_SUFFIX:.*c202.*' in .cirrus.yml"
     fi
@@ -139,7 +147,7 @@ query="
 }
 "
 
-query_clean=$(tr -d \\012 <<<"$query")
+query_clean=$(tr -d \\012 <<< "$query")
 
 jsontmp=$(mktemp --tmpdir --suffix=.json $ME.graphql.XXXXXXX)
 

--- a/hack/ci/lib.sh
+++ b/hack/ci/lib.sh
@@ -1,9 +1,14 @@
 # This must be sourced from other scripts to work.
 
-OS_RELEASE_VER="$(source /etc/os-release; echo $VERSION_ID | tr -d '.')"
-OS_RELEASE_ID="$(source /etc/os-release; echo $ID)"
+OS_RELEASE_VER="$(
+    source /etc/os-release
+    echo $VERSION_ID | tr -d '.'
+)"
+OS_RELEASE_ID="$(
+    source /etc/os-release
+    echo $ID
+)"
 OS_REL_VER="$OS_RELEASE_ID-$OS_RELEASE_VER"
-
 
 function die() {
     echo "$1" >&2
@@ -20,24 +25,24 @@ function parse_args() {
     # root or rootless
     PRIV=rootless
     case "$#" in
-        2)
-            TEST=$1
-            DISTRO_NAME=$2
-            ;;
-        3)
-            TEST=$1
-            PRIV=$2
-            DISTRO_NAME=$3
-            ;;
-        4)
-            TEST=$1
-            MODE=$2
-            PRIV=$3
-            DISTRO_NAME=$4
-            ;;
-        *)
-            die "Invalid number of arguments $#, need 2-4"
-            ;;
+    2)
+        TEST=$1
+        DISTRO_NAME=$2
+        ;;
+    3)
+        TEST=$1
+        PRIV=$2
+        DISTRO_NAME=$3
+        ;;
+    4)
+        TEST=$1
+        MODE=$2
+        PRIV=$3
+        DISTRO_NAME=$4
+        ;;
+    *)
+        die "Invalid number of arguments $#, need 2-4"
+        ;;
     esac
 
     validate_distro "$DISTRO_NAME"
@@ -46,24 +51,24 @@ function parse_args() {
 
 function validate_distro() {
     case "$1" in
-        "fedora-current"|"fedora-prior"|"fedora-rawhide"|"debian-sid")
-            ;;
-        *)
-            die "Unknown DISTRO_NAME '$1' set"
-            ;;
+    "fedora-current" | "fedora-prior" | "fedora-rawhide" | "debian-sid")
+        ;;
+    *)
+        die "Unknown DISTRO_NAME '$1' set"
+        ;;
     esac
 }
 
 function validate_mode() {
     case "$1" in
-        "local"|"remote")
-            ;;
-        *)
-            # upgrade test uses mode to pass the upgrade version
-            if [[ "$TEST" != "upgrade" ]]; then
-                die "Unknown MODE '$1' set"
-            fi
-            ;;
+    "local" | "remote")
+        ;;
+    *)
+        # upgrade test uses mode to pass the upgrade version
+        if [[ "$TEST" != "upgrade" ]]; then
+            die "Unknown MODE '$1' set"
+        fi
+        ;;
     esac
 }
 
@@ -77,12 +82,9 @@ function remove_packaged_podman_files() {
     echo "Removing packaged podman files to prevent conflicts with source build and testing."
 
     # If any binaries are resident they could cause unexpected pollution
-    for unit in podman.socket podman-auto-update.timer
-    do
-        for state in enabled active
-        do
-            if sudo systemctl --quiet is-$state $unit
-            then
+    for unit in podman.socket podman-auto-update.timer; do
+        for state in enabled active; do
+            if sudo systemctl --quiet is-$state $unit; then
                 echo "Warning: $unit found $state prior to packaged-file removal"
                 sudo systemctl --quiet disable $unit || true
                 sudo systemctl --quiet stop $unit || true
@@ -92,8 +94,7 @@ function remove_packaged_podman_files() {
 
     # OS_RELEASE_ID is defined by automation-library
     # shellcheck disable=SC2154
-    if [[ "$OS_RELEASE_ID" =~ "debian" ]]
-    then
+    if [[ "$OS_RELEASE_ID" =~ "debian" ]]; then
         LISTING_CMD="dpkg-query -L podman"
     else
         LISTING_CMD="rpm -ql podman"
@@ -101,11 +102,10 @@ function remove_packaged_podman_files() {
 
     # delete the podman socket in case it has been created previously.
     # Do so without running podman, lest that invocation initialize unwanted state.
-    sudo rm -f /run/podman/podman.sock  /run/user/$(id -u)/podman/podman.sock || true
+    sudo rm -f /run/podman/podman.sock /run/user/$(id -u)/podman/podman.sock || true
 
     # yum/dnf/dpkg may list system directories, only remove files
-    $LISTING_CMD | while read fullpath
-    do
+    $LISTING_CMD | while read fullpath; do
         # Sub-directories may contain unrelated/valuable stuff
         if [[ -d "$fullpath" ]]; then continue; fi
         sudo rm -f "$fullpath"

--- a/hack/ci/logcollector.sh
+++ b/hack/ci/logcollector.sh
@@ -14,7 +14,7 @@ showrun() {
     echo '------------------------------------------------------------'
     "$@"
     local status=$?
-    [[ $status -eq 0 ]] || \
+    [[ $status -eq 0 ]] ||
         echo "[ rc = $status -- proceeding anyway ]"
     echo '------------------------------------------------------------'
     set -e
@@ -24,58 +24,57 @@ bad_os_id_ver() {
     die "Unknown OS '$OS_RELEASE_ID'"
 }
 
-
 case $1 in
-    audit)
-        case $OS_RELEASE_ID in
-            debian) showrun cat /var/log/kern.log ;;
-            fedora) showrun cat /var/log/audit/audit.log ;;
-            *) bad_os_id_ver ;;
-        esac
-        ;;
-    df) showrun df -lhTx tmpfs ;;
-    journal) showrun journalctl -b ;;
-    podman) showrun ./bin/podman system info ;;
-    packages)
-        # These names are common to Fedora and Debian
-        PKG_NAMES=(\
-                    aardvark-dns
-                    buildah
-                    conmon
-                    containernetworking-plugins
-                    criu
-                    crun
-                    golang
-                    netavark
-                    passt
-                    podman
-                    skopeo
+audit)
+    case $OS_RELEASE_ID in
+    debian) showrun cat /var/log/kern.log ;;
+    fedora) showrun cat /var/log/audit/audit.log ;;
+    *) bad_os_id_ver ;;
+    esac
+    ;;
+df) showrun df -lhTx tmpfs ;;
+journal) showrun journalctl -b ;;
+podman) showrun ./bin/podman system info ;;
+packages)
+    # These names are common to Fedora and Debian
+    PKG_NAMES=(
+        aardvark-dns
+        buildah
+        conmon
+        containernetworking-plugins
+        criu
+        crun
+        golang
+        netavark
+        passt
+        podman
+        skopeo
+    )
+    case $OS_RELEASE_ID in
+    fedora)
+        cat /etc/fedora-release
+        PKG_LST_CMD='rpm -q --qf=%{N}-%{V}-%{R}-%{ARCH}\n'
+        PKG_NAMES+=(
+            container-selinux
+            containers-common
+            libseccomp
         )
-        case $OS_RELEASE_ID in
-            fedora)
-                cat /etc/fedora-release
-                PKG_LST_CMD='rpm -q --qf=%{N}-%{V}-%{R}-%{ARCH}\n'
-                PKG_NAMES+=(\
-                    container-selinux
-                    containers-common
-                    libseccomp
-                )
-                ;;
-            debian)
-                cat /etc/issue
-                PKG_LST_CMD='dpkg-query --show --showformat=${Package}-${Version}-${Architecture}\n'
-                PKG_NAMES+=(\
-                    golang-github-containers-common
-                    golang-github-containers-image
-                    libseccomp2
-                )
-                ;;
-            *) bad_os_id_ver ;;
-        esac
-        echo "Kernel: " $(uname -r)
-        echo "Cgroups: " $(stat -f -c %T /sys/fs/cgroup)
-        # Any not-present packages will be listed as such
-        $PKG_LST_CMD "${PKG_NAMES[@]}" | sort -u
         ;;
-    ip) showrun sh -c "ip addr && ip route && ip -6 route" ;;
+    debian)
+        cat /etc/issue
+        PKG_LST_CMD='dpkg-query --show --showformat=${Package}-${Version}-${Architecture}\n'
+        PKG_NAMES+=(
+            golang-github-containers-common
+            golang-github-containers-image
+            libseccomp2
+        )
+        ;;
+    *) bad_os_id_ver ;;
+    esac
+    echo "Kernel: " $(uname -r)
+    echo "Cgroups: " $(stat -f -c %T /sys/fs/cgroup)
+    # Any not-present packages will be listed as such
+    $PKG_LST_CMD "${PKG_NAMES[@]}" | sort -u
+    ;;
+ip) showrun sh -c "ip addr && ip route && ip -6 route" ;;
 esac

--- a/hack/ci/make-and-check-size.sh
+++ b/hack/ci/make-and-check-size.sh
@@ -90,21 +90,21 @@ make
 # Determine size of each built file.
 # - If this is our first time through, preserve that size in a tmpfile
 # - On all subsequent runs, compare built size to initial size
-for bin in bin/*;do
+for bin in bin/*; do
     size=$(stat -c %s $bin)
 
     saved_size_file=$context_dir/$(basename $bin)
     if [[ -e $saved_size_file ]]; then
         # Not the first time through: compare to original size
         size_orig=$(< $saved_size_file)
-        delta_size=$(( size - size_orig ))
+        delta_size=$((size - size_orig))
 
         printf "%-20s size=%9d  delta=%6d\n" $bin $size $delta_size
         if [[ "$bin" = bin/podman-testing ]]; then
             continue # We compute / list this for completeness, but size does not matter to users.
         fi
         if [[ $delta_size -gt $MAX_BIN_GROWTH ]]; then
-            separator=$(printf "%.0s*" {1..75})   # row of stars, for highlight
+            separator=$(printf "%.0s*" {1..75}) # row of stars, for highlight
             echo "$separator"
             echo "* $bin grew by $delta_size bytes; max allowed is $MAX_BIN_GROWTH."
             echo "*"
@@ -122,7 +122,7 @@ for bin in bin/*;do
         fi
     else
         # First time through: preserve original file size
-        echo $size >$saved_size_file
+        echo $size > $saved_size_file
         printf "%-20s size=%9d\n" $bin $size
     fi
 done

--- a/hack/ci/pr-should-include-tests
+++ b/hack/ci/pr-should-include-tests
@@ -24,24 +24,24 @@ fi
 # Nothing changed under test subdirectory.
 #
 # This is OK if the only files being touched are "safe" ones.
-filtered_changes=$(git diff --name-only $base $head        |
-                       grep -F -vx .cirrus.yml             |
-                       grep -F -vx .pre-commit-config.yaml |
-                       grep -F -vx .gitignore              |
-                       grep -F -vx go.mod                  |
-                       grep -F -vx go.sum                  |
-                       grep -F -vx podman.spec.rpkg        |
-                       grep -F -vx .golangci.yml           |
-                       grep -F -vx winmake.ps1             |
-                       grep -E -v  '/*Makefile$'           |
-                       grep -E -v  '^[^/]+\.md$'           |
-                       grep -E -v  '^.github'              |
-                       grep -E -v  '^contrib/'             |
-                       grep -E -v  '^docs/'                |
-                       grep -E -v  '^hack/'                |
-                       grep -E -v  '^nix/'                 |
-                       grep -E -v  '^vendor/'              |
-                       grep -E -v  '^version/')
+filtered_changes=$(git diff --name-only $base $head |
+    grep -F -vx .cirrus.yml |
+    grep -F -vx .pre-commit-config.yaml |
+    grep -F -vx .gitignore |
+    grep -F -vx go.mod |
+    grep -F -vx go.sum |
+    grep -F -vx podman.spec.rpkg |
+    grep -F -vx .golangci.yml |
+    grep -F -vx winmake.ps1 |
+    grep -E -v '/*Makefile$' |
+    grep -E -v '^[^/]+\.md$' |
+    grep -E -v '^.github' |
+    grep -E -v '^contrib/' |
+    grep -E -v '^docs/' |
+    grep -E -v '^hack/' |
+    grep -E -v '^nix/' |
+    grep -E -v '^vendor/' |
+    grep -E -v '^version/')
 if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi
@@ -70,7 +70,7 @@ fi
 
 # This PR touches non-test files but adds no tests, and
 # the '$OVERRIDE_LABEL' is not set. Fail loudly.
-cat <<EOF
+cat << EOF
 $ME: PR does not include changes in the 'tests' directory
 
 Please write a regression test for what you're fixing. Even if it

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -5,12 +5,11 @@
 
 set -eo pipefail
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 
 source "$SCRIPT_DIR/lib.sh"
 
 parse_args "$@"
-
 
 PRESERVE_ENVS="CI_USE_REGISTRY_CACHE,CI_DESIRED_COMPOSEFS,OCI_RUNTIME,CGROUP_MANAGER,STORAGE_FS,STORAGE_OPTIONS_OVERLAY,STORAGE_OPTIONS_VFS,PODMAN_UPGRADE_FROM"
 # run as root or or not
@@ -22,30 +21,27 @@ fi
 STORAGE_FS=overlay
 
 case "$DISTRO_NAME" in
-    fedora-current)
-        ;;
-    fedora-prior)
-        STORAGE_FS=vfs
-        ;;
-    fedora-rawhide)
-        # On rawhide enable composefs testing
-        CI_DESIRED_COMPOSEFS="composefs"
-        # Enable sequoia testing
-        TEST_BUILD_TAGS="containers_image_sequoia"
+fedora-current)
+    ;;
+fedora-prior)
+    STORAGE_FS=vfs
+    ;;
+fedora-rawhide)
+    # On rawhide enable composefs testing
+    CI_DESIRED_COMPOSEFS="composefs"
+    # Enable sequoia testing
+    TEST_BUILD_TAGS="containers_image_sequoia"
 
-        # mount a tmpfs for the container storage. This is a work around for the staging pull composefs flake.
-        # FIXME: https://github.com/containers/podman/issues/28813
-        sudo mount -t tmpfs -o size=75%,mode=0700 none /var/lib/containers
-        ;;
-    debian-sid)
-        ;;
-    *)
-        die "Unknown DISTRO_NAME passed $DISTRO_NAME"
-        ;;
+    # mount a tmpfs for the container storage. This is a work around for the staging pull composefs flake.
+    # FIXME: https://github.com/containers/podman/issues/28813
+    sudo mount -t tmpfs -o size=75%,mode=0700 none /var/lib/containers
+    ;;
+debian-sid)
+    ;;
+*)
+    die "Unknown DISTRO_NAME passed $DISTRO_NAME"
+    ;;
 esac
-
-
-
 
 # As of July 2024, CI VMs come built-in with a registry.
 LCR=/var/cache/local-registry/local-cache-registry
@@ -59,7 +55,6 @@ if [[ -x $LCR ]]; then
     done < <(grep '^[^#]' test/NEW-IMAGES || true)
 fi
 
-
 ## Used in tests so we need to export them
 export STORAGE_FS
 export CI_DESIRED_COMPOSEFS
@@ -71,7 +66,7 @@ conf=/etc/containers/storage.conf
 if [[ -e $conf ]]; then
     die "FATAL! INTERNAL ERROR! Cannot override $conf"
 fi
-sudo tee $conf <<EOF
+sudo tee $conf << EOF
 [storage]
 driver = "$STORAGE_FS"
 EOF
@@ -80,7 +75,7 @@ if [[ -n "$CI_DESIRED_COMPOSEFS" ]]; then
     # composefs only works as root so we must set it in the rootful config
     sudo mkdir /etc/containers/storage.rootful.conf.d/
     conf=/etc/containers/storage.rootful.conf.d/99-composefs.conf
-    sudo tee $conf <<EOF
+    sudo tee $conf << EOF
 
 # BEGIN CI-enabled composefs
 [storage.options]
@@ -101,20 +96,18 @@ EOF
     fi
 fi
 
-
 # Machine image is not cached by design.
-if [[ "$TEST" != machine  ]]; then
+if [[ "$TEST" != machine ]]; then
     # Install test registries.conf
     sudo install -v -D -m 644 ./test/registries-cached.conf /etc/containers/registries.conf
 fi
 
 # Add Root user namespace for --userns=auto support in tests
-for which in uid gid;do
+for which in uid gid; do
     if ! grep -qE '^containers:' /etc/sub$which; then
         echo 'containers:10000000:1048576' | sudo tee --append /etc/sub$which
     fi
 done
-
 
 # Load null_blk to use /dev/nullb0 for testing block
 # devices limits
@@ -122,7 +115,6 @@ sudo modprobe null_blk nr_devices=1 || :
 
 # Ensure our CI uses the cache registry
 export CI_USE_REGISTRY_CACHE=1
-
 
 if [[ "$TEST" != build && "$TEST" != unit ]]; then
     ## Remove packaged podman and install the compiled podman
@@ -219,7 +211,6 @@ function run_sys() {
 function run_machine() {
     $SUDO make ${MODE}machine
 }
-
 
 echo
 echo "#################"

--- a/hack/commit-subject-check.sh
+++ b/hack/commit-subject-check.sh
@@ -12,22 +12,22 @@ set -euo pipefail
 MAX=90
 
 if [[ $# -ne 1 ]]; then
-	echo "Usage: $0 <git-range>" >&2
-	exit 2
+    echo "Usage: $0 <git-range>" >&2
+    exit 2
 fi
 
 range=$1
 rc=0
 
 while IFS=$'\t' read -r sha subject; do
-	len=${#subject}
-	if [[ $len -eq 0 ]]; then
-		echo "$sha: empty commit subject" >&2
-		rc=1
-	elif [[ $len -ge $MAX ]]; then
-		echo "$sha: subject is $len chars (must be < $MAX): $subject" >&2
-		rc=1
-	fi
+    len=${#subject}
+    if [[ $len -eq 0 ]]; then
+        echo "$sha: empty commit subject" >&2
+        rc=1
+    elif [[ $len -ge $MAX ]]; then
+        echo "$sha: subject is $len chars (must be < $MAX): $subject" >&2
+        rc=1
+    fi
 done < <(git log --no-merges --format='%H%x09%s' "$range")
 
 exit $rc

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -18,7 +18,7 @@ REPO_DIRPATH=$(realpath "$SCRIPT_DIRPATH/../")
 # Help detect what get_ci_vm container called this script
 GET_CI_VM="${GET_CI_VM:-0}"
 in_get_ci_vm() {
-    if ((GET_CI_VM==0)); then
+    if ((GET_CI_VM == 0)); then
         echo "Error: $1 is not intended for use in this context"
         exit 2
     fi
@@ -27,10 +27,10 @@ in_get_ci_vm() {
 # get_ci_vm APIv1 container entrypoint calls into this script
 # to obtain required repo. specific configuration options.
 if [[ "$1" == "--config" ]]; then
-    in_get_ci_vm "$1"  # handles GET_CI_VM==0 case
+    in_get_ci_vm "$1" # handles GET_CI_VM==0 case
     case "$GET_CI_VM" in
-        1)
-            cat <<EOF
+    1)
+        cat << EOF
 DESTDIR="/var/tmp/go/src/github.com/containers/podman"
 UPSTREAM_REPO="https://github.com/containers/podman.git"
 CI_ENVFILE="/etc/ci_environment"
@@ -42,14 +42,14 @@ GCLOUD_CPUS="2"
 GCLOUD_MEMORY="4Gb"
 GCLOUD_DISK="200"
 EOF
-            ;;
-        2)
-            # get_ci_vm APIv2 configuration details
-            echo "AWS_PROFILE=containers"
-            ;;
-        *)
-            echo "Error: Your get_ci_vm container image is too old."
-            ;;
+        ;;
+    2)
+        # get_ci_vm APIv2 configuration details
+        echo "AWS_PROFILE=containers"
+        ;;
+    *)
+        echo "Error: Your get_ci_vm container image is too old."
+        ;;
     esac
 elif [[ "$1" == "--setup" ]]; then
     in_get_ci_vm "$1"

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -16,25 +16,26 @@ BIN="$(command -v ./bin/golangci-lint golangci-lint | head -1)"
 
 echo "Linting for GOOS=$GOOS"
 case "$GOOS" in
-  windows|darwin)
+windows | darwin)
     # For Darwin and Windows, only "remote" linting is possible and required.
     TAGS="remote,containers_image_openpgp"
     ;;
-  freebsd)
+freebsd)
     TAGS="containers_image_openpgp"
     EXTRA_TAGS=(",remote")
     ;;
-  *)
+*)
     # Assume Linux: run linter for various sets of build tags.
     TAGS="apparmor,seccomp,selinux"
     EXTRA_TAGS=(",systemd" ",remote")
+    ;;
 esac
 
 for EXTRA in "" "${EXTRA_TAGS[@]}"; do
-  # Use set -x in a subshell to make it easy for a developer to copy-paste
-  # the command-line to focus or debug a single, specific linting category.
-  (
-    set -x
-    "$BIN" run --build-tags="${TAGS}${EXTRA}" "$@"
-  )
+    # Use set -x in a subshell to make it easy for a developer to copy-paste
+    # the command-line to focus or debug a single, specific linting category.
+    (
+        set -x
+        "$BIN" run --build-tags="${TAGS}${EXTRA}" "$@"
+    )
 done

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -3,7 +3,10 @@
 # This script is intended to be a convenience, to be called from the
 # Makefile `.install.golangci-lint` target.  Any other usage is not recommended.
 
-die() { echo "${1:-No error message given} (from $(basename "$0"))"; exit 1; }
+die() {
+    echo "${1:-No error message given} (from $(basename "$0"))"
+    exit 1
+}
 
 [ -n "$VERSION" ] || die "\$VERSION is empty or undefined"
 

--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-if test $(${GO:-go} env GOOS) != "linux" ; then
-	exit 0
+if test $(${GO:-go} env GOOS) != "linux"; then
+    exit 0
 fi
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
@@ -24,6 +24,6 @@ int main() {
 	return 0;
 }
 EOF
-if test $? -eq 0 ; then
-	echo libsubid
+if test $? -eq 0; then
+    echo libsubid
 fi

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -6,10 +6,9 @@
 verbose=
 for i; do
     case "$i" in
-        -v|--verbose)   verbose=verbose ;;
+    -v | --verbose) verbose=verbose ;;
     esac
 done
-
 
 die() {
     echo "$(basename $0): $*" >&2
@@ -20,13 +19,13 @@ cd $(dirname $0)/../docs/source/markdown || die "Please run me from top-level li
 
 rc=0
 
-for md in *.1.md;do
+for md in *.1.md; do
     # Read the first line after '# NAME' (or '## NAME'). (FIXME: # and ##
     #               are not the same; should we stick to one convention?)
     # There may be more than one name, e.g. podman-info.1.md has
     # podman-system-info then another line with podman-info. We
     # care only about the first.
-    name=$(grep -E -A1 '^#* NAME' $md|tail -1|awk '{print $1}' | tr -d \\\\)
+    name=$(grep -E -A1 '^#* NAME' $md | tail -1 | awk '{print $1}' | tr -d \\\\)
 
     expect=$(basename $md .1.md)
     if [ "$name" != "$expect" ]; then
@@ -42,8 +41,8 @@ done
 # Make sure the descriptive text in podman-foo.1.md matches the one
 # in the table in podman.1.md. podman-remote is not a podman subcommand,
 # so it is excluded here.
-for md in $(ls -1 *-*.1.md | grep -v remote);do
-    desc=$(grep -E -A1 '^#* NAME' $md|tail -1|sed -e 's/^podman[^ ]\+ - //')
+for md in $(ls -1 *-*.1.md | grep -v remote); do
+    desc=$(grep -E -A1 '^#* NAME' $md | tail -1 | sed -e 's/^podman[^ ]\+ - //')
 
     # podman.1.md has a two-column table; podman-*.1.md all have three.
     parent=$(echo $md | sed -e 's/^\(.*\)-.*$/\1.1.md/')
@@ -59,7 +58,7 @@ for md in $(ls -1 *-*.1.md | grep -v remote);do
         parent="podman-system.1.md"
     fi
     x=3
-    if expr -- "$parent" : ".*-" >/dev/null; then
+    if expr -- "$parent" : ".*-" > /dev/null; then
         x=4
     fi
 
@@ -97,36 +96,36 @@ function compare_usage() {
     local from_help=$(echo "$help_output" | grep -A1 '^Usage:' | tail -1)
 
     # strip off command name from both
-    from_man=$(sed -e "s/\*\*$cmd\*\*[[:space:]]*//" <<<"$from_man")
-    from_help=$(sed -e "s/^[[:space:]]*${cmd}[[:space:]]*//" <<<"$from_help")
+    from_man=$(sed -e "s/\*\*$cmd\*\*[[:space:]]*//" <<< "$from_man")
+    from_help=$(sed -e "s/^[[:space:]]*${cmd}[[:space:]]*//" <<< "$from_help")
 
     # man page lists 'foo [*options*]', help msg shows 'foo [flags]'.
     # Make sure if one has it, the other does too.
-    if expr "$from_man" : "\[\*options\*\]" >/dev/null; then
-        if expr "$from_help" : "\[options\]" >/dev/null; then
+    if expr "$from_man" : "\[\*options\*\]" > /dev/null; then
+        if expr "$from_help" : "\[options\]" > /dev/null; then
             :
         else
             echo "WARNING: $cmd: man page shows '[*options*]', help does not show [options]"
             rc=1
-       fi
-    elif expr "$from_help" : "\[flags\]" >/dev/null; then
+        fi
+    elif expr "$from_help" : "\[flags\]" > /dev/null; then
         echo "WARNING: $cmd: --help shows [flags], man page does not show [*options*]"
         rc=1
     fi
 
     # Strip off options and flags; start comparing arguments
-    from_man=$(sed  -e 's/^\[\*options\*\][[:space:]]*//' <<<"$from_man")
-    from_help=$(sed -e 's/^\[flags\][[:space:]]*//'      <<<"$from_help")
+    from_man=$(sed -e 's/^\[\*options\*\][[:space:]]*//' <<< "$from_man")
+    from_help=$(sed -e 's/^\[flags\][[:space:]]*//' <<< "$from_help")
 
     # Args in man page are '*foo*', in --help are 'FOO'. Convert all to
     # UPCASE simply because it stands out better to the eye.
-    from_man=$(sed -e 's/\*\([a-z-]\+\)\*/\U\1/g' <<<"$from_man")
+    from_man=$(sed -e 's/\*\([a-z-]\+\)\*/\U\1/g' <<< "$from_man")
 
     # FIXME: one of the common patterns is for --help to show 'POD [POD...]'
     # but man page show 'pod ...'. This conversion may help one day, but
     # not yet: there are too many inconsistencies such as '[pod ...]'
     # (brackets) and 'pod...' (no space between).
-#    from_help=$(sed -e 's/\([A-Z]\+\)[[:space:]]\+\[\1[[:space:]]*\.\.\.\]/\1 .../' <<<"$from_help")
+    #    from_help=$(sed -e 's/\([A-Z]\+\)[[:space:]]\+\[\1[[:space:]]*\.\.\.\]/\1 .../' <<<"$from_help")
 
     # Compare man-page and --help usage strings. For now, do so only
     # when run with --verbose.
@@ -142,7 +141,7 @@ function compare_usage() {
 # Pass 3: compare synopses.
 #
 # Make sure the SYNOPSIS line in podman-foo.1.md reads '**podman foo** ...'
-for md in *.1.md;do
+for md in *.1.md; do
     # FIXME: several pages have a multi-line form of SYNOPSIS in which
     #        many or all flags are enumerated. Some of these are trivial
     #        and really should be made into one line (podman-container-exists,
@@ -152,7 +151,7 @@ for md in *.1.md;do
     #        To view those:
     #           $ less $(for i in docs/*.1.md;do x=$(grep -A2 '^#* SYNOPSIS' $i|tail -1); if [ -n "$x" ]; then echo $i;fi;done)
     #
-    synopsis=$(grep -E -A1 '^#* SYNOPSIS' $md|tail -1)
+    synopsis=$(grep -E -A1 '^#* SYNOPSIS' $md | tail -1)
 
     # Command name must be bracketed by double asterisks; options and
     # arguments are bracketed by single ones.
@@ -177,7 +176,7 @@ for md in *.1.md;do
 
     # The convention is to use UPPER CASE in 'podman foo --help',
     # but *lower case bracketed by asterisks* in the man page
-    if expr "$synopsis" : ".*[A-Z]" >/dev/null; then
+    if expr "$synopsis" : ".*[A-Z]" > /dev/null; then
         echo
         printf "Inconsistent capitalization in SYNOPSIS in %s\n" $md
         printf "  '%s' should not contain upper-case characters\n" "$synopsis"
@@ -191,6 +190,5 @@ for md in *.1.md;do
     # messages. This is complicated, so do it in a helper function.
     compare_usage "$md_nodash" "$synopsis"
 done
-
 
 exit $rc

--- a/hack/perf/bz-2162111.sh
+++ b/hack/perf/bz-2162111.sh
@@ -32,7 +32,7 @@ container_cmd="--name $container_name \
 
 # Script to clean up before each benchmark below
 prepare_sh=$(mktemp -p $tmp --suffix '.prepare.sh')
-cat >$prepare_sh <<EOF
+cat > $prepare_sh << EOF
 \$ENGINE rm -f \$(\$ENGINE ps -aq)
 \$ENGINE volume prune -f
 \$ENGINE volume create $volume_name
@@ -41,14 +41,14 @@ echo_bold "Prepare script: $prepare_sh"
 
 # Script to create container below
 create_sh=$(mktemp -p $tmp --suffix '.create.sh')
-cat >$create_sh <<EOF
+cat > $create_sh << EOF
 \$ENGINE create $container_cmd true
 EOF
 echo_bold "Create script: $create_sh"
 
 # Script to run container below
 run_sh=$(mktemp -p $tmp --suffix '.run.sh')
-cat >$run_sh <<EOF
+cat > $run_sh << EOF
 # Make sure to remove the container from a previous run
 \$ENGINE rm -f $container_name || true
 # Run the container
@@ -61,40 +61,40 @@ echo "----------------------------------------------------"
 echo
 echo_bold "Create $NUM_CONTAINERS containers"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "ENGINE=$ENGINE_A sh $prepare_sh" \
-	--prepare "ENGINE=$ENGINE_B sh $prepare_sh" \
-	"$ENGINE_A create $container_cmd true" \
-	"$ENGINE_B create $container_cmd true"
+    --prepare "ENGINE=$ENGINE_A sh $prepare_sh" \
+    --prepare "ENGINE=$ENGINE_B sh $prepare_sh" \
+    "$ENGINE_A create $container_cmd true" \
+    "$ENGINE_B create $container_cmd true"
 
 echo ""
 echo "----------------------------------------------------"
 echo
 echo_bold "Start $NUM_CONTAINERS containers"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "ENGINE=$ENGINE_A sh $prepare_sh; ENGINE=$ENGINE_A sh $create_sh" \
-	--prepare "ENGINE=$ENGINE_B sh $prepare_sh; ENGINE=$ENGINE_B sh $create_sh" \
-	"$ENGINE_A start $container_name" \
-	"$ENGINE_B start $container_name"
+    --prepare "ENGINE=$ENGINE_A sh $prepare_sh; ENGINE=$ENGINE_A sh $create_sh" \
+    --prepare "ENGINE=$ENGINE_B sh $prepare_sh; ENGINE=$ENGINE_B sh $create_sh" \
+    "$ENGINE_A start $container_name" \
+    "$ENGINE_B start $container_name"
 
 echo ""
 echo "----------------------------------------------------"
 echo
 echo_bold "Stop $NUM_CONTAINERS containers"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "ENGINE=$ENGINE_A sh $run_sh" \
-	--prepare "ENGINE=$ENGINE_B sh $run_sh" \
-	"$ENGINE_A stop $container_name" \
-	"$ENGINE_B stop $container_name"
+    --prepare "ENGINE=$ENGINE_A sh $run_sh" \
+    --prepare "ENGINE=$ENGINE_B sh $run_sh" \
+    "$ENGINE_A stop $container_name" \
+    "$ENGINE_B stop $container_name"
 
 echo ""
 echo "----------------------------------------------------"
 echo
 echo_bold "Remove $NUM_CONTAINERS containers"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "ENGINE=$ENGINE_A sh $prepare_sh; ENGINE=$ENGINE_A sh $create_sh" \
-	--prepare "ENGINE=$ENGINE_B sh $prepare_sh; ENGINE=$ENGINE_B sh $create_sh" \
-	"$ENGINE_A rm -f $container_name" \
-	"$ENGINE_B rm -f $container_name"
+    --prepare "ENGINE=$ENGINE_A sh $prepare_sh; ENGINE=$ENGINE_A sh $create_sh" \
+    --prepare "ENGINE=$ENGINE_B sh $prepare_sh; ENGINE=$ENGINE_B sh $create_sh" \
+    "$ENGINE_A rm -f $container_name" \
+    "$ENGINE_B rm -f $container_name"
 
 # Clean up
 $ENGINE_A system prune -f >> /dev/null

--- a/hack/perf/create.sh
+++ b/hack/perf/create.sh
@@ -4,8 +4,8 @@ source ./helpers.bash
 setup
 echo_bold "Create $RUNS containers"
 hyperfine --warmup 10 --runs $RUNS \
-	"$ENGINE_A create $IMAGE" \
-	"$ENGINE_B create $IMAGE"
+    "$ENGINE_A create $IMAGE" \
+    "$ENGINE_B create $IMAGE"
 
 # Clean up
 $ENGINE_A system prune -f >> /dev/null

--- a/hack/perf/helpers.bash
+++ b/hack/perf/helpers.bash
@@ -12,25 +12,25 @@ function echo_bold() {
 }
 
 function pull_image() {
-	echo_bold "... pulling $IMAGE"
-	$ENGINE_A pull $IMAGE -q > /dev/null
-	$ENGINE_B pull $IMAGE -q > /dev/null
+    echo_bold "... pulling $IMAGE"
+    $ENGINE_A pull $IMAGE -q > /dev/null
+    $ENGINE_B pull $IMAGE -q > /dev/null
 }
 
 function setup() {
-	echo_bold "---------------------------------------------------"
-	echo_bold "... comparing $ENGINE_A with $ENGINE_B"
-	echo_bold "... cleaning up previous containers and images"
-	$ENGINE_A system prune -f > /dev/null
-	$ENGINE_B system prune -f > /dev/null
-	pull_image
-	echo ""
+    echo_bold "---------------------------------------------------"
+    echo_bold "... comparing $ENGINE_A with $ENGINE_B"
+    echo_bold "... cleaning up previous containers and images"
+    $ENGINE_A system prune -f > /dev/null
+    $ENGINE_B system prune -f > /dev/null
+    pull_image
+    echo ""
 }
 
 function create_containers() {
-	echo_bold "... creating $NUM_CONTAINERS containers"
-	for i in $(eval echo "{0..$NUM_CONTAINERS}"); do
-		$ENGINE_A create $IMAGE >> /dev/null
-		$ENGINE_B create $IMAGE >> /dev/null
-	done
+    echo_bold "... creating $NUM_CONTAINERS containers"
+    for i in $(eval echo "{0..$NUM_CONTAINERS}"); do
+        $ENGINE_A create $IMAGE >> /dev/null
+        $ENGINE_B create $IMAGE >> /dev/null
+    done
 }

--- a/hack/perf/ps.sh
+++ b/hack/perf/ps.sh
@@ -5,8 +5,8 @@ setup
 echo_bold "List $NUM_CONTAINERS created containers"
 create_containers
 hyperfine --warmup 10 --runs $RUNS \
-	"$ENGINE_A ps -a" \
-	"$ENGINE_B ps -a"
+    "$ENGINE_A ps -a" \
+    "$ENGINE_B ps -a"
 
 # Clean up
 $ENGINE_A system prune -f >> /dev/null

--- a/hack/perf/rm.sh
+++ b/hack/perf/rm.sh
@@ -4,10 +4,10 @@ source ./helpers.bash
 setup
 echo_bold "Remove $RUNS containers in a row"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "$ENGINE_A create --name=123 $IMAGE" \
-	--prepare "$ENGINE_B create --name=123 $IMAGE" \
-	"$ENGINE_A rm 123" \
-	"$ENGINE_B rm 123"
+    --prepare "$ENGINE_A create --name=123 $IMAGE" \
+    --prepare "$ENGINE_B create --name=123 $IMAGE" \
+    "$ENGINE_A rm 123" \
+    "$ENGINE_B rm 123"
 
 # Clean up
 $ENGINE_A system prune -f >> /dev/null

--- a/hack/perf/run.sh
+++ b/hack/perf/run.sh
@@ -4,18 +4,18 @@ source ./helpers.bash
 setup
 echo_bold "Run $RUNS containers in a row"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "$ENGINE_A rm -f 123 || true" \
-	--prepare "$ENGINE_B rm -f 123 || true" \
-	"$ENGINE_A run --name=123 $IMAGE true" \
-	"$ENGINE_B run --name=123 $IMAGE true"
+    --prepare "$ENGINE_A rm -f 123 || true" \
+    --prepare "$ENGINE_B rm -f 123 || true" \
+    "$ENGINE_A run --name=123 $IMAGE true" \
+    "$ENGINE_B run --name=123 $IMAGE true"
 
 setup
 echo_bold "Run and remove $RUNS containers in a row"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "$ENGINE_A rm -f 123 || true" \
-	--prepare "$ENGINE_B rm -f 123 || true" \
-	"$ENGINE_A run --rm --name=123 $IMAGE true" \
-	"$ENGINE_B run --rm --name=123 $IMAGE true"
+    --prepare "$ENGINE_A rm -f 123 || true" \
+    --prepare "$ENGINE_B rm -f 123 || true" \
+    "$ENGINE_A run --rm --name=123 $IMAGE true" \
+    "$ENGINE_B run --rm --name=123 $IMAGE true"
 
 # Clean up
 $ENGINE_A system prune -f >> /dev/null

--- a/hack/perf/start.sh
+++ b/hack/perf/start.sh
@@ -4,10 +4,10 @@ source ./helpers.bash
 setup
 echo_bold "Start $RUNS containers in a row"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "$ENGINE_A rm -f 123 || true; $ENGINE_A create --name=123 $IMAGE true" \
-	--prepare "$ENGINE_B rm -f 123 || true; $ENGINE_B create --name=123 $IMAGE true" \
-	"$ENGINE_A start 123" \
-	"$ENGINE_B start 123"
+    --prepare "$ENGINE_A rm -f 123 || true; $ENGINE_A create --name=123 $IMAGE true" \
+    --prepare "$ENGINE_B rm -f 123 || true; $ENGINE_B create --name=123 $IMAGE true" \
+    "$ENGINE_A start 123" \
+    "$ENGINE_B start 123"
 
 # Clean up
 $ENGINE_A system prune -f >> /dev/null

--- a/hack/perf/stop.sh
+++ b/hack/perf/stop.sh
@@ -4,10 +4,10 @@ source ./helpers.bash
 setup
 echo_bold "Stop $RUNS containers in a row"
 hyperfine --warmup 10 --runs $RUNS \
-	--prepare "$ENGINE_A rm -f 123 || true; $ENGINE_A run -d --name=123 $IMAGE top" \
-	--prepare "$ENGINE_B rm -f 123 || true; $ENGINE_B run -d --name=123 $IMAGE top" \
-	"$ENGINE_A stop 123" \
-	"$ENGINE_B stop 123"
+    --prepare "$ENGINE_A rm -f 123 || true; $ENGINE_A run -d --name=123 $IMAGE top" \
+    --prepare "$ENGINE_B rm -f 123 || true; $ENGINE_B run -d --name=123 $IMAGE top" \
+    "$ENGINE_A stop 123" \
+    "$ENGINE_B stop 123"
 
 # Clean up
 $ENGINE_A system prune -f >> /dev/null

--- a/hack/perf/system-df.sh
+++ b/hack/perf/system-df.sh
@@ -5,8 +5,8 @@ setup
 echo_bold "List $NUM_CONTAINERS created containers"
 create_containers
 hyperfine --warmup 10 --runs $RUNS \
-	"$ENGINE_A system df" \
-	"$ENGINE_B system df"
+    "$ENGINE_A system df" \
+    "$ENGINE_B system df"
 
 # Clean up
 $ENGINE_A system prune -f >> /dev/null

--- a/hack/podman-commands.sh
+++ b/hack/podman-commands.sh
@@ -17,13 +17,12 @@ function die() {
     exit 1
 }
 
-
 # Run 'podman help' (possibly against a subcommand, e.g. 'podman help image')
 # and return a list of each first word under 'Available Commands', that is,
 # the command name but not its description.
 function podman_commands() {
-    $PODMAN help "$@" |\
-        awk '/^Available Commands:/{ok=1;next}/^Options:/{ok=0}ok { print $1 }' |\
+    $PODMAN help "$@" |
+        awk '/^Available Commands:/{ok=1;next}/^Options:/{ok=0}ok { print $1 }' |
         grep .
 
     # Special case: podman-completion is a hidden command
@@ -40,7 +39,7 @@ function podman_man() {
         # This md file has a table of the form:
         #   | [podman-cmd(1)\[(podman-cmd.1.md)   | Description ... |
         # For all such, print the 'cmd' portion (the one in brackets).
-        sed -ne 's/^|\s\+\[podman-\([a-z]\+\)(1.*/\1/p' <docs/source/markdown/$1.1.md
+        sed -ne 's/^|\s\+\[podman-\([a-z]\+\)(1.*/\1/p' < docs/source/markdown/$1.1.md
 
         # Special case: there is no podman-help man page, nor need for such.
         echo "help"
@@ -80,7 +79,7 @@ function compare_help_and_man() {
         usage=$($PODMAN "$@" $cmd --help | grep -A1 '^Usage:' | tail -1)
 
         # if string ends in '[command]', recurse into its subcommands
-        if expr "$usage" : '.*\[command\]$' >/dev/null; then
+        if expr "$usage" : '.*\[command\]$' > /dev/null; then
             compare_help_and_man "$@" $cmd
         fi
     done
@@ -88,11 +87,10 @@ function compare_help_and_man() {
     rm -f /tmp/${basename}_{help,man}.txt
 }
 
-
 compare_help_and_man
 
 if [ $rc -ne 0 ]; then
-    cat <<EOF
+    cat << EOF
 
 **************************
 ** INTERPRETING RESULTS **

--- a/hack/podman-registry
+++ b/hack/podman-registry
@@ -55,7 +55,7 @@ Other options:
   -h            display usage message
 "
 
-die () {
+die() {
     echo "$ME: $*" >&2
     exit 1
 }
@@ -66,16 +66,22 @@ die () {
 
 while getopts "i:u:p:P:hv" opt; do
     case "$opt" in
-        i)         PODMAN_REGISTRY_IMAGE=$OPTARG ;;
-        u)         PODMAN_REGISTRY_USER=$OPTARG  ;;
-        p)         PODMAN_REGISTRY_PASS=$OPTARG  ;;
-        P)         PODMAN_REGISTRY_PORT=$OPTARG  ;;
-        h)         echo "$usage"; exit 0;;
-        v)         verbose=1 ;;
-        \?)        echo "Run '$ME -h' for help" >&2; exit 1;;
+    i) PODMAN_REGISTRY_IMAGE=$OPTARG ;;
+    u) PODMAN_REGISTRY_USER=$OPTARG ;;
+    p) PODMAN_REGISTRY_PASS=$OPTARG ;;
+    P) PODMAN_REGISTRY_PORT=$OPTARG ;;
+    h)
+        echo "$usage"
+        exit 0
+        ;;
+    v) verbose=1 ;;
+    \?)
+        echo "Run '$ME -h' for help" >&2
+        exit 1
+        ;;
     esac
 done
-shift $((OPTIND-1))
+shift $((OPTIND - 1))
 
 # END   option processing
 ###############################################################################
@@ -100,11 +106,11 @@ function podman() {
     fi
 
     # Reset $PODMAN, so ps/logs/stop use same args as the initial start
-    PODMAN="$(<${PODMAN_REGISTRY_WORKDIR}/PODMAN)"
+    PODMAN="$(< ${PODMAN_REGISTRY_WORKDIR}/PODMAN)"
 
-    ${PODMAN} --root    ${PODMAN_REGISTRY_WORKDIR}/root        \
-              --runroot ${PODMAN_REGISTRY_WORKDIR}/runroot     \
-              "$@"
+    ${PODMAN} --root ${PODMAN_REGISTRY_WORKDIR}/root \
+        --runroot ${PODMAN_REGISTRY_WORKDIR}/runroot \
+        "$@"
 }
 
 ###############
@@ -116,7 +122,7 @@ function must_pass() {
     "$@" &> $log
     if [ $? -ne 0 ]; then
         echo "$ME: Command failed: $*" >&2
-        cat $log                       >&2
+        cat $log >&2
 
         # If we ever get here, it's a given that the registry is not running.
         # Clean up after ourselves.
@@ -129,16 +135,16 @@ function must_pass() {
 #  wait_for_port  #  Returns once port is available on localhost
 ###################
 function wait_for_port() {
-    local port=$1                      # Numeric port
+    local port=$1 # Numeric port
 
     local host=127.0.0.1
     local _timeout=5
 
     # Wait
     while [ $_timeout -gt 0 ]; do
-        { exec {unused_fd}<> /dev/tcp/$host/$port; } &>/dev/null && return
+        { exec {unused_fd}<> /dev/tcp/$host/$port; } &> /dev/null && return
         sleep 1
-        _timeout=$(( $_timeout - 1 ))
+        _timeout=$(($_timeout - 1))
     done
 
     die "Timed out waiting for port $port"
@@ -151,8 +157,8 @@ function wait_for_port() {
 function do_start() {
     # If called without a port, assign a random one in the 5xxx range
     if [ -z "${PODMAN_REGISTRY_PORT}" ]; then
-        for port in $(shuf -i 5000-5999);do
-            if ! { exec {unused_fd}<> /dev/tcp/127.0.0.1/$port; } &>/dev/null; then
+        for port in $(shuf -i 5000-5999); do
+            if ! { exec {unused_fd}<> /dev/tcp/127.0.0.1/$port; } &> /dev/null; then
                 PODMAN_REGISTRY_PORT=$port
                 break
             fi
@@ -179,7 +185,7 @@ function do_start() {
 
     # Preserve initial podman path & args, so all subsequent invocations
     # of this script are consistent with the first one.
-    echo "$PODMAN" >${PODMAN_REGISTRY_WORKDIR}/PODMAN
+    echo "$PODMAN" > ${PODMAN_REGISTRY_WORKDIR}/PODMAN
 
     local AUTHDIR=${PODMAN_REGISTRY_WORKDIR}/auth
     mkdir -p $AUTHDIR
@@ -191,21 +197,21 @@ function do_start() {
     set +e
 
     # Give it three tries, to compensate for flakes
-    podman pull ${PODMAN_REGISTRY_IMAGE}      &>/dev/null ||
-        podman pull ${PODMAN_REGISTRY_IMAGE}  &>/dev/null ||
+    podman pull ${PODMAN_REGISTRY_IMAGE} &> /dev/null ||
+        podman pull ${PODMAN_REGISTRY_IMAGE} &> /dev/null ||
         must_pass podman pull ${PODMAN_REGISTRY_IMAGE}
 
     # Registry image needs a cert. Self-signed is good enough.
     local CERT=$AUTHDIR/domain.crt
-    must_pass openssl req -newkey rsa:4096 -nodes -sha256              \
-              -keyout ${AUTHDIR}/domain.key -x509 -days 2              \
-              -out ${AUTHDIR}/domain.crt                               \
-              -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=localhost"
+    must_pass openssl req -newkey rsa:4096 -nodes -sha256 \
+        -keyout ${AUTHDIR}/domain.key -x509 -days 2 \
+        -out ${AUTHDIR}/domain.crt \
+        -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=localhost"
 
     # Store credentials where container will see them. We can't run
     # this one via must_pass because we need its stdout.
-    htpasswd -Bbn ${PODMAN_REGISTRY_USER} ${PODMAN_REGISTRY_PASS}   \
-           > $AUTHDIR/htpasswd
+    htpasswd -Bbn ${PODMAN_REGISTRY_USER} ${PODMAN_REGISTRY_PASS} \
+        > $AUTHDIR/htpasswd
     if [ $? -ne 0 ]; then
         rm -rf ${PODMAN_REGISTRY_WORKDIR}
         die "Command failed: htpasswd"
@@ -213,19 +219,19 @@ function do_start() {
 
     # In case someone needs to debug
     echo "${PODMAN_REGISTRY_USER}:${PODMAN_REGISTRY_PASS}" \
-         > $AUTHDIR/htpasswd-plaintext
+        > $AUTHDIR/htpasswd-plaintext
 
     # Run the registry container.
-    must_pass podman run --quiet -d                                     \
-              -p ${PODMAN_REGISTRY_PORT}:5000                           \
-              --name registry                                           \
-              -v $AUTHDIR:/auth:Z                                       \
-              -e "REGISTRY_AUTH=htpasswd"                               \
-              -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm"          \
-              -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd"           \
-              -e "REGISTRY_HTTP_TLS_CERTIFICATE=/auth/domain.crt"       \
-              -e "REGISTRY_HTTP_TLS_KEY=/auth/domain.key"               \
-              ${PODMAN_REGISTRY_IMAGE}
+    must_pass podman run --quiet -d \
+        -p ${PODMAN_REGISTRY_PORT}:5000 \
+        --name registry \
+        -v $AUTHDIR:/auth:Z \
+        -e "REGISTRY_AUTH=htpasswd" \
+        -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
+        -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd" \
+        -e "REGISTRY_HTTP_TLS_CERTIFICATE=/auth/domain.crt" \
+        -e "REGISTRY_HTTP_TLS_KEY=/auth/domain.key" \
+        ${PODMAN_REGISTRY_IMAGE}
 
     # Confirm that registry started and port is active
     wait_for_port $PODMAN_REGISTRY_PORT
@@ -235,7 +241,6 @@ function do_start() {
         echo "PODMAN_REGISTRY_${v}=\"$(eval echo \$PODMAN_REGISTRY_${v})\""
     done
 }
-
 
 function do_stop() {
     podman stop registry
@@ -250,11 +255,9 @@ function do_stop() {
     fi
 }
 
-
 function do_ps() {
     podman ps -a
 }
-
 
 function do_logs() {
     podman logs registry
@@ -269,11 +272,11 @@ action=${1?ACTION$missing}
 shift
 
 case "$action" in
-    start)  do_start  ;;
-    stop)   do_stop   ;;
-    ps)     do_ps     ;;
-    logs)   do_logs   ;;
-    *)      die "Unknown action '$action'; must be start / stop / ps / logs" ;;
+start) do_start ;;
+stop) do_stop ;;
+ps) do_ps ;;
+logs) do_logs ;;
+*) die "Unknown action '$action'; must be start / stop / ps / logs" ;;
 esac
 
 # END   command-line processing

--- a/hack/podman-socat
+++ b/hack/podman-socat
@@ -8,12 +8,12 @@ if [[ $(id -u) != 0 ]]; then
     exit 2
 fi
 
-if ! command -v socat >/dev/null 2>&1; then
+if ! command -v socat > /dev/null 2>&1; then
     echo 1>&2 "socat not found on PATH"
 fi
 
 PODMAN=${PODMAN:-podman}
-if ! command -v "$PODMAN" >/dev/null 2>&1; then
+if ! command -v "$PODMAN" > /dev/null 2>&1; then
     echo 1>&2 "$PODMAN not found on PATH"
 fi
 
@@ -55,7 +55,7 @@ trap "cleanup $TMPDIR" EXIT
 mkdir -p "${TMPDIR}"/{podman,crio,crio-run,cni/net.d,ctnr,tunnel}
 
 export CNI_CONFIG_PATH=${TMPDIR}/cni/net.d
-cat >"$CNI_CONFIG_PATH"/87-podman-bridge.conflist <<-EOT
+cat > "$CNI_CONFIG_PATH"/87-podman-bridge.conflist <<- EOT
 {
   "cniVersion": "0.3.0",
   "name": "podman",
@@ -96,7 +96,7 @@ PODMAN="$PODMAN $PODMAN_ARGS"
 PODMAN_HOST="${TMPDIR}/podman/podman-socat.sock"
 SOCAT_HOST="${TMPDIR}/podman/podman.sock"
 
-cat <<-EOT
+cat <<- EOT
 Podman service running at unix://$SOCAT_HOST
 See /tmp/podman-socat.log for API stream capture
 See /tmp/podman-service.log for service logging
@@ -106,7 +106,7 @@ usage: sudo bin/podman-remote --url unix://$SOCAT_HOST images
 ^C to exit
 EOT
 
-$PODMAN system service --timeout=0 "unix://$PODMAN_HOST" >/tmp/podman-service.log 2>&1 &
+$PODMAN system service --timeout=0 "unix://$PODMAN_HOST" > /tmp/podman-service.log 2>&1 &
 REAP_PIDS=$!
 
-socat -v "UNIX-LISTEN:$SOCAT_HOST",fork,reuseaddr,unlink-early "UNIX-CONNECT:$PODMAN_HOST" >/tmp/podman-socat.log 2>&1
+socat -v "UNIX-LISTEN:$SOCAT_HOST",fork,reuseaddr,unlink-early "UNIX-CONNECT:$PODMAN_HOST" > /tmp/podman-socat.log 2>&1

--- a/hack/podmanv2-retry
+++ b/hack/podmanv2-retry
@@ -19,9 +19,8 @@ die() {
     exit 1
 }
 
-test -n "$PODMAN_V2"       || die "Please set \$PODMAN_V2 (path to podman v2)"
+test -n "$PODMAN_V2" || die "Please set \$PODMAN_V2 (path to podman v2)"
 test -n "$PODMAN_FALLBACK" || die "Please set \$PODMAN_FALLBACK (path to podman)"
-
 
 result=$(${PODMAN_V2} "$@" 2>&1)
 rc=$?

--- a/hack/sqlite_tag.sh
+++ b/hack/sqlite_tag.sh
@@ -2,6 +2,6 @@
 ${CPP:-${CC:-cc} -E} ${CPPFLAGS} - &> /dev/null << EOF
 #include <sqlite3.h>
 EOF
-if test $? -eq 0 ; then
-	echo libsqlite3
+if test $? -eq 0; then
+    echo libsqlite3
 fi

--- a/hack/systemd_tag.sh
+++ b/hack/systemd_tag.sh
@@ -2,6 +2,6 @@
 ${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <systemd/sd-daemon.h>
 EOF
-if test $? -eq 0 ; then
-	echo systemd
+if test $? -eq 0; then
+    echo systemd
 fi

--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -4,16 +4,15 @@ set -e
 SUGGESTION="${SUGGESTION:-run \"make vendor\" and commit all changes.}"
 
 STATUS=$(git status --porcelain)
-if [[ -z $STATUS ]]
-then
-	echo "tree is clean"
+if [[ -z $STATUS ]]; then
+    echo "tree is clean"
 else
-	echo "tree is dirty, please $SUGGESTION"
-	echo ""
-	echo "$STATUS"
-	echo ""
-	echo "---------------------- Diff below ----------------------"
-	echo ""
-	git --no-pager diff
-	exit 1
+    echo "tree is dirty, please $SUGGESTION"
+    echo ""
+    echo "$STATUS"
+    echo ""
+    echo "---------------------- Diff below ----------------------"
+    echo ""
+    git --no-pager diff
+    exit 1
 fi

--- a/hack/xref-docker-options
+++ b/hack/xref-docker-options
@@ -7,21 +7,21 @@
 # implemented in podman but hidden (so of course not in man pages);
 # some are not implemented and never will be (swarm).
 declare -a hidden=(
-    "docker --config"                    # Hidden
-    "docker --context"                   # Hidden
-    "docker --debug"                     # Hidden
-    "docker --host"                      # Hidden
-    "docker -D"                          # Hidden
-    "docker -H"                          # Hidden
+    "docker --config"  # Hidden
+    "docker --context" # Hidden
+    "docker --debug"   # Hidden
+    "docker --host"    # Hidden
+    "docker -D"        # Hidden
+    "docker -H"        # Hidden
 
-    "docker .* --isolation"              # Only for Windows containers
-    "docker .* --kernel-memory"          # CGroupsV1 only, present but hidden
-    "docker .* --link"                   # Deprecated in docker
-    "docker .* --runtime"                # Global option under podman
-    "docker .* --storage-opt"            # Global option under podman
+    "docker .* --isolation"     # Only for Windows containers
+    "docker .* --kernel-memory" # CGroupsV1 only, present but hidden
+    "docker .* --link"          # Deprecated in docker
+    "docker .* --runtime"       # Global option under podman
+    "docker .* --storage-opt"   # Global option under podman
 
-    "docker (container|image) ls"        # Hidden alias to list
-    "docker context"                     # Hidden
+    "docker (container|image) ls" # Hidden alias to list
+    "docker context"              # Hidden
 
     # Hidden
     "docker (container |)logs --details"
@@ -58,15 +58,15 @@ index de9ef8630..b9e4bd0ef 100755
              \$section = lc \$1;
 "
 
-patch --quiet -p1 <<<"$DIFF"
+patch --quiet -p1 <<< "$DIFF"
 
 # Sometimes this produces no output at all. Likely cause is that you
 # have inconsistent .md files, solution is 'make docs'. If that doesn't
 # work, remove the '2>&1 \' from the line below and rerun. I don't feel
 # it's worth the time to improve the error handling here.
-PODMAN=/usr/bin/docker $TMP_SCRIPT 2>&1 \
-    | sed -ne 's/^.*podman \+\(.*\) --help. lists .\(.*\)., which is not.*/- [ ] docker \1 \2/p' \
-    | sed -e 's/ \+/ /g' \
-    | grep -vE "($hidden_re)\$"
+PODMAN=/usr/bin/docker $TMP_SCRIPT 2>&1 |
+    sed -ne 's/^.*podman \+\(.*\) --help. lists .\(.*\)., which is not.*/- [ ] docker \1 \2/p' |
+    sed -e 's/ \+/ /g' |
+    grep -vE "($hidden_re)\$"
 
 rm -f $TMP_SCRIPT


### PR DESCRIPTION
As suggested in https://github.com/containers/podman/pull/28760#discussion_r3296435987, let's try to use shfmt for shell scripts under ./hack/ only. For the previous (rejected) attempt, see https://github.com/containers/podman/pull/26340. To reiterate the discussion in there, the main reasons to reject were:
 - we only gain readability (and even that is questionable);
 - it raises barrier for contribution.
 
The second point is probably of less concern for `./hack` (as it is rarely modified). Also, `make validate-source` (or `make validatepr`, or `make shfmt`) automatically fixes all the formatting issues, so the barrier is probably not that high.

shfmt configuration is intentionally kept minimal. Yet the diff is big, mostly because of indentation differences (previously we only enforced the use of spaces instead of tabs, but how many spaces was used was not in any way enforced or suggested).

Feel free to close w/o further discussion if you don't like it; this is not a hill I will die on.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
