### PR TITLE
.cirrus.yml: do not run golangci-lint for freebsd and mac

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -297,8 +297,6 @@ osx_alt_build_task:
     # This host is/was shared with potentially many other CI tasks.
     # The previous task may have been canceled or aborted.
     prep_script: &mac_cleanup "contrib/cirrus/mac_cleanup.sh"
-    lint_script:
-        - make golangci-lint
     basic_build_script:
         - make .install.ginkgo
         - make podman-remote
@@ -338,17 +336,11 @@ freebsd_alt_build_task:
         ALT_NAME: 'FreeBSD Cross'
     freebsd_instance:
         image_family: freebsd-14-3
-        # golangci-lint is a very, very hungry beast.
         cpu: 4
         memory: 8Gb
     setup_script:
         - pkg install -y gpgme bash go-md2man gmake gsed gnugrep go pkgconf zstd
         - go version # Downloads a new go version based on go.mod's go directive.
-    golint_cache:
-        folder: ~/.cache/golangci-lint
-        fingerprint_script: *golangci_cache_fingerprint
-    lint_script:
-        - gmake golangci-lint
     build_amd64_script:
         - gmake podman-release
     # This task cannot make use of the shared repo.tar.zst artifact and must


### PR DESCRIPTION
Since PR #28760 linting is done for all OSes on linux, so there's no need to run golangci-lint on Mac and FreeBSD separately. This also fixes the issue of mixing up golangci-lint caches between different Mac OS X runs (saw [here](https://github.com/containers/podman/pull/28794#issuecomment-4549077220)).

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
