### PR TITLE
specgen: move log_path handling over to the server

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -331,6 +331,9 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	if len(s.LogConfiguration.Driver) < 1 {
 		s.LogConfiguration.Driver = rtc.Containers.LogDriver
 	}
+	if len(s.LogConfiguration.Path) < 1 {
+		s.LogConfiguration.Path = rtc.Containers.LogPath
+	}
 	if len(rtc.Containers.LogTag) > 0 {
 		if s.LogConfiguration.Options == nil {
 			s.LogConfiguration.Options = make(map[string]string)

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -242,10 +242,6 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 
 	s.ImageVolumes = opts.ImageVolumes
 
-	if rtc.Containers.LogPath != "" {
-		s.LogConfiguration.Path = rtc.Containers.LogPath
-	}
-
 	s.LogConfiguration.Options = make(map[string]string)
 	s.LogConfiguration.Labels = make(map[string]string)
 	for _, o := range opts.LogOptions {

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -845,10 +845,6 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		return err
 	}
 
-	if rtc.Containers.LogPath != "" {
-		s.LogConfiguration.Path = rtc.Containers.LogPath
-	}
-
 	logOpts := make(map[string]string)
 	logLabels := make(map[string]string)
 	for _, o := range c.LogOptions {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2435,6 +2435,11 @@ log_path = "%s"
 
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
+			// Server inherited CONTAINERS_CONF_OVERRIDE at restart; unset on
+			// the client so this forces the server to use its config and not rely on
+			// the client's. Without this the client would read log_path and
+			// pass it on to the client, masking server-side bugs.
+			os.Unsetenv("CONTAINERS_CONF_OVERRIDE")
 		}
 
 		containerName := "test-conf-log-container"


### PR DESCRIPTION
log_path is currently set at the client side and is ignored by the server in a remote session. This leads to either incorrect log_path being considered by the server or not honored at all. Move the handling from client to the server, in line with other flags such as log_driver.

Fixes #28792 