### PR TITLE
cmd/podman: don't warn on `podman run -ti -d` from not a tty

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -116,8 +116,8 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 		cliVals.Rm = true
 	}
-	// TODO: Breaking change should be made fatal in next major Release
-	if cliVals.TTY && cliVals.Interactive && !term.IsTerminal(int(os.Stdin.Fd())) {
+
+	if cliVals.TTY && cliVals.Interactive && !runOpts.Detach && !term.IsTerminal(int(os.Stdin.Fd())) {
 		logrus.Warnf("The input device is not a TTY. The --tty and --interactive flags might not work properly")
 	}
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -342,11 +342,12 @@ var _ = Describe("Podman exec", func() {
 
 	// #10927 ("no logs from conmon"), one of our nastiest flakes
 	It("podman exec terminal doesn't hang", FlakeAttempts(3), func() {
-		setup := podmanTest.Podman([]string{"run", "-dti", "--name", "test1", FEDORA_MINIMAL, "sleep", "+Inf"})
+		setup := podmanTest.Podman([]string{"run", "-ti", "--rm", "--name", "test1", FEDORA_MINIMAL, "true"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))
 		Expect(setup.ErrorToString()).To(ContainSubstring("The input device is not a TTY. The --tty and --interactive flags might not work properly"))
 
+		podmanTest.PodmanExitCleanly("run", "-dti", "--name", "test1", FEDORA_MINIMAL, "sleep", "+Inf")
 		for range 5 {
 			session := podmanTest.Podman([]string{"exec", "-ti", "test1", "true"})
 			session.WaitWithDefaultTimeout()


### PR DESCRIPTION
`podman run -ti` warns when stdin is not a tty, but if the container is run in detached state that warning does not make much sense: we just need the environment where podman attach will be run to be a tty.

Running with `-ti` even in detached state can make sense to avoid applications buffering their output (for realtime logs) or allowing later interaction and should not warn users.

-------------

This can be easily reproduced with `podman run --name foo -ti -d --rm docker.io/alpine /bin/sh </dev/null` or similar

-------------

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
  - ~~I've tested manually, I'm not sure this warrants a test? Happy to add one if you prefer~~ nm, that broke one of the e2e tests so I made sure the warning is displayed without detach and not displayed on detach
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
  - Doesn't run in my environment, I ran a subset fine but if I missed something I'll fix whatever CI reports. If CI doesn't check everything please let me know and I'll try to fix my sandboxing...
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```