### PR TITLE
Use GitHub token in Windows installer tests web request

### DIFF
--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -17,8 +17,8 @@ $ENV:PODMAN_ARCH = Get-Current-Architecture # on Cirrus CI this should always be
 
 # To get the a GitHub release ID run the following command:
 #  curl -s -H "Accept: application/vnd.github+json" \
-#    https://api.github.com/repos/containers/podman/releases/tags/v5.6.2 | jq '.id'
-$ENV:LATEST_GH_RELEASE_ID = "251232431" # v5.6.2
+#    https://api.github.com/repos/containers/podman/releases/tags/v5.8.2 | jq '.id'
+$ENV:LATEST_GH_RELEASE_ID = "308971529" # v5.8.2
 $NEXT_WIN_INST_VER="9.9.10"
 
 # Download the previous installer to test a major update

--- a/contrib/win-installer/utils.ps1
+++ b/contrib/win-installer/utils.ps1
@@ -17,7 +17,11 @@ function Get-Podman-Setup-From-GitHub {
 
     Write-Host "Downloading the $arch $version Podman windows setup from GitHub..."
     $apiUrl = "https://api.github.com/repos/containers/podman/releases/$version"
-    $response = Invoke-RestMethod -Uri $apiUrl -Headers @{"User-Agent"="PowerShell"} -ErrorAction Stop
+    $headers = @{"User-Agent"="PowerShell"}
+    if ($env:GITHUB_TOKEN) {
+        $headers["Authorization"] = "Bearer $env:GITHUB_TOKEN"
+    }
+    $response = Invoke-RestMethod -Uri $apiUrl -Headers $headers -ErrorAction Stop
     $latestTag = $response.tag_name
     Write-Host "Looking for an asset named ""podman-installer-windows-$arch.exe"""
     $downloadAsset = $response.assets | Where-Object { $_.name -eq "podman-installer-windows-$arch.exe" } | Select-Object -First 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

This is to avoid requests failing due to GitHub's non-authenticated request rate limit.

See [this PR check failure](https://github.com/podman-container-tools/podman-sandbox/actions/runs/26632208486/job/78483599334?pr=5) for an example of such a failure.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
