### PR TITLE
machine: escape % as %% in proxy values written to systemd unit conf

### DIFF
--- a/pkg/machine/proxyenv/env.go
+++ b/pkg/machine/proxyenv/env.go
@@ -26,8 +26,9 @@ rm -f $SYSTEMD_SYSTEM_CONF $SYSTEMD_USER_CONF $ENVD_CONF $PROFILE_CONF
 echo "[Manager]" >> $SYSTEMD_SYSTEM_CONF
 echo "[Manager]" >> $SYSTEMD_USER_CONF
 for proxy in %s; do
-	printf "DefaultEnvironment=\"%%s\"\n" "$proxy"  >> $SYSTEMD_SYSTEM_CONF
-	printf "DefaultEnvironment=\"%%s\"\n" "$proxy"  >> $SYSTEMD_USER_CONF
+	systemd_proxy="${proxy//%%/%%%%}"
+	printf "DefaultEnvironment=\"%%s\"\n" "$systemd_proxy"  >> $SYSTEMD_SYSTEM_CONF
+	printf "DefaultEnvironment=\"%%s\"\n" "$systemd_proxy"  >> $SYSTEMD_USER_CONF
 	printf "%%s\n" "$proxy"  >> $ENVD_CONF
 	printf "export %%s\n" "$proxy" >> $PROFILE_CONF
 done

--- a/pkg/machine/proxyenv/env_test.go
+++ b/pkg/machine/proxyenv/env_test.go
@@ -55,8 +55,43 @@ rm -f $SYSTEMD_SYSTEM_CONF $SYSTEMD_USER_CONF $ENVD_CONF $PROFILE_CONF
 echo "[Manager]" >> $SYSTEMD_SYSTEM_CONF
 echo "[Manager]" >> $SYSTEMD_USER_CONF
 for proxy in "http_proxy=proxy1" "https_proxy=sproxy1" "no_proxy=no1,no2"; do
-	printf "DefaultEnvironment=\"%s\"\n" "$proxy"  >> $SYSTEMD_SYSTEM_CONF
-	printf "DefaultEnvironment=\"%s\"\n" "$proxy"  >> $SYSTEMD_USER_CONF
+	systemd_proxy="${proxy//%/%%}"
+	printf "DefaultEnvironment=\"%s\"\n" "$systemd_proxy"  >> $SYSTEMD_SYSTEM_CONF
+	printf "DefaultEnvironment=\"%s\"\n" "$systemd_proxy"  >> $SYSTEMD_USER_CONF
+	printf "%s\n" "$proxy"  >> $ENVD_CONF
+	printf "export %s\n" "$proxy" >> $PROFILE_CONF
+done
+
+systemctl daemon-reload
+`,
+		},
+		{
+			name: "percent sign in proxy value is escaped for systemd",
+			args: args{
+				isWSL: false,
+				envs: []env{
+					{
+						name:  "http_proxy",
+						value: "http://user%40example.com@proxy:3128",
+					},
+				},
+			},
+			want: `#!/bin/bash
+
+SYSTEMD_SYSTEM_CONF=/etc/systemd/system.conf.d/default-env.conf
+SYSTEMD_USER_CONF=/etc/systemd/user.conf.d/default-env.conf
+ENVD_CONF=/etc/environment.d/default-env.conf
+PROFILE_CONF=/etc/profile.d/default-env.sh
+
+mkdir -p /etc/profile.d /etc/environment.d /etc/systemd/system.conf.d/ /etc/systemd/user.conf.d/
+rm -f $SYSTEMD_SYSTEM_CONF $SYSTEMD_USER_CONF $ENVD_CONF $PROFILE_CONF
+
+echo "[Manager]" >> $SYSTEMD_SYSTEM_CONF
+echo "[Manager]" >> $SYSTEMD_USER_CONF
+for proxy in "http_proxy=http://user%40example.com@proxy:3128"; do
+	systemd_proxy="${proxy//%/%%}"
+	printf "DefaultEnvironment=\"%s\"\n" "$systemd_proxy"  >> $SYSTEMD_SYSTEM_CONF
+	printf "DefaultEnvironment=\"%s\"\n" "$systemd_proxy"  >> $SYSTEMD_USER_CONF
 	printf "%s\n" "$proxy"  >> $ENVD_CONF
 	printf "export %s\n" "$proxy" >> $PROFILE_CONF
 done


### PR DESCRIPTION
## Problem

systemd treats `%` as a specifier character in unit configuration files
(e.g. `%H` → hostname, `%40` → `@` in percent-encoded strings).
When proxy environment variables contain URL-percent-encoded characters
(common in credentials: `http://user%40example.com@proxy:3128`), the
generated `/etc/systemd/system.conf.d/default-env.conf` contains
bare `%` sequences that systemd tries to expand as specifiers, leading to:

```
system.conf.d/default-env.conf:2: Failed to resolve specifiers in
HTTP_PROXY=http://user%40example.com@proxy:3128
```

## Fix

Introduce a bash variable substitution `${proxy//%/%%}` that doubles
every `%` to `%%` before writing to the systemd-specific conf files.
The `%%` is then decoded by systemd back to a literal `%`, preserving
the original value.

The `/etc/profile.d/default-env.sh` and `/etc/environment.d/default-env.conf`
destinations do not perform specifier expansion, so they continue to use the
original value without escaping.

A new test case covering a proxy value with a percent-encoded character
is added alongside the update to the existing expected output.

Fixes #28698