### PR TITLE
test/system: two more flake fixes

### DIFF
--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -131,7 +131,7 @@ load helpers
 @test "podman stop - can trap signal" {
     # Because the --time and --timeout options can be wonky, try three
     # different variations of this test.
-    for t_opt in '' '--time=5' '--timeout=5'; do
+    for t_opt in '' '--time=9' '--timeout=11'; do
         # Run a simple container that logs output on SIGTERM
         run_podman run -d $IMAGE sh -c \
                    "trap 'echo Received SIGTERM, finishing; exit' SIGTERM; echo READY; while :; do sleep 1; done"
@@ -155,7 +155,7 @@ load helpers
         local howlong=2
         # ...unless running parallel, due to high system load.
         if [[ -n "$PARALLEL_JOBSLOT" ]]; then
-            howlong=4
+            howlong=8
         fi
         delta_t=$(( $t1 - $t0 ))
         assert $delta_t -le $howlong "podman stop: took too long"

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1322,7 +1322,7 @@ spec:
 EOF
 
     # Bind the port to force a an error when starting the pod
-    timeout --foreground -v --kill=10 10 socat TCP-LISTEN:$port,bind=127.0.0.1,fork - &
+    timeout --foreground -v --kill=10 20 socat TCP-LISTEN:$port,bind=127.0.0.1,fork - &
     socat_pid=$!
 
     # Create the Quadlet file
@@ -1341,14 +1341,14 @@ EOF
     echo $output
     assert $status -eq 1 "systemctl start should report failure"
 
+    kill "$socat_pid"
+
     run -0 systemctl show --property=ActiveState $QUADLET_SERVICE_NAME
     assert "$output" == "ActiveState=failed" "unit must be in failed state"
 
     echo "$_LOG_PROMPT journalctl -u $QUADLET_SERVICE_NAME"
     run -0 journalctl -eu $QUADLET_SERVICE_NAME
     assert "$output" =~ "$port.*ddress already in use" "journal contains the real podman start error"
-
-    kill "$socat_pid"
 }
 
 # https://github.com/containers/podman/issues/25786


### PR DESCRIPTION
observed in the new CI

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
