### PR TITLE
ci: fix validate-source checks vs stale labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
   validate-source:
     name: Validate source code changes
     runs-on: cncf-ubuntu-8-32-x86
+    permissions:
+      pull-requests: read # For hack/ci/pr-should-include-tests to query PR labels.
     env:
       # Base commit of this PR; used by the Makefile and the helper scripts to
       # compute the commit range (git merge-base $DEST_BRANCH HEAD).
@@ -126,8 +128,9 @@ jobs:
         run: make swagger
 
       - name: Check that the PR includes tests
-        # The 'No New Tests' label lets maintainers override this check.
-        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'No New Tests') }}
+        env:
+          # For hack/ci/pr-should-include-tests to query PR labels.
+          GITHUB_TOKEN: ${{ github.token }}
         run: make tests-included
 
       - name: Validate renovate config
@@ -154,9 +157,8 @@ jobs:
         # limit enforced by hack/ci/make-and-check-size.sh.
         if: ${{ github.event_name == 'pull_request' }}
         env:
-          # The 'bloat_approved' label lets a repo admin override the binary
-          # size growth check in hack/ci/make-and-check-size.sh.
-          BLOAT_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'bloat_approved') }}
+          # For hack/ci/make-and-check-size.sh to query PR labels.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # git rebase rewrites commits, so it needs a committer identity.
           git config user.name "CI"

--- a/hack/ci/make-and-check-size.sh
+++ b/hack/ci/make-and-check-size.sh
@@ -53,9 +53,21 @@ function bloat_approved() {
     #        requiring a MAX_BIN_GROWTH=nnn statement in github comments.
     local actual_growth="$1"
 
-    # The validate-source GitHub Actions workflow sets BLOAT_APPROVED=true when
-    # the PR carries the '$OVERRIDE_LABEL' label.
-    [[ "$BLOAT_APPROVED" == "true" ]]
+    local var
+    for var in PR_NUMBER GITHUB_TOKEN GITHUB_REPOSITORY; do
+        if [[ -z "${!var}" ]]; then
+            echo "$ME: cannot query github: \$$var is undefined" >&2
+            return 1
+        fi
+    done
+
+    labels=$(curl --fail -s \
+        -H "Authorization: bearer $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER" |
+        jq -r '.labels[].name')
+
+    grep -F -x -q "$OVERRIDE_LABEL" <<< "$labels"
 }
 
 # ACTUAL CODE BEGINS HERE

--- a/hack/ci/pr-should-include-tests
+++ b/hack/ci/pr-should-include-tests
@@ -46,9 +46,30 @@ if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi
 
-# This PR touches non-test files but adds no tests. Fail loudly.
-# The '$OVERRIDE_LABEL' label can be used to override this check; that is
-# handled by the CI workflow, not here.
+# This PR touches non-test files but adds no tests. Only allow it if the
+# '$OVERRIDE_LABEL' github label is set.
+if [[ -n "$PR_NUMBER" ]]; then
+    for var in GITHUB_TOKEN GITHUB_REPOSITORY; do
+        if [[ -z "${!var}" ]]; then
+            echo "$ME: cannot query github: \$$var is undefined" >&2
+            return 1
+        fi
+    done
+
+    labels=$(curl --fail -s \
+        -H "Authorization: bearer $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER" |
+        jq -r '.labels[].name')
+
+    if grep -F -x -q "$OVERRIDE_LABEL" <<< "$labels"; then
+        echo "$ME: \"$OVERRIDE_LABEL\" label found, ignoring test requirements"
+        exit 0
+    fi
+fi
+
+# This PR touches non-test files but adds no tests, and
+# the '$OVERRIDE_LABEL' is not set. Fail loudly.
 cat <<EOF
 $ME: PR does not include changes in the 'tests' directory
 


### PR DESCRIPTION
When the validate-source job is re-run manually after adding a label,
it uses stale labels (from the "pull_request" event that originally
triggered it), and so the steps that check labels don't see new labels.

Fix by querying the labels live (similar to how it was done before
commits 6e597af6dc and 1da154117c).

Note the logic differs slightly between hack/ci/make-and-check-size.sh
and hack/ci/pr-should-include-tests. This is because
pr-should-include-tests is also executed locally as well as on non-PRs,
while make-and-check-size is run strictly in CI for PRs only.

Fixes: #28838

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
