### PR TITLE
fix: handle multiple networks in 'podman inspect --type=all'

### DIFF
--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -228,7 +228,7 @@ func (i *inspector) inspectAll(ctx context.Context, namesOrIDs []string) ([]any,
 			data = append(data, volumeData[0])
 			continue
 		}
-		networkData, errs, err := registry.ContainerEngine().NetworkInspect(ctx, namesOrIDs, i.options)
+		networkData, errs, err := registry.ContainerEngine().NetworkInspect(ctx, []string{name}, i.options)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -371,6 +371,17 @@ var _ = Describe("Podman inspect", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("bridge"))
 	})
 
+	It("podman inspect networks with --type=all ", func() {
+		name_0, path_0 := generateNetworkConfig(podmanTest)
+		defer removeConf(path_0)
+		name_1, path_1 := generateNetworkConfig(podmanTest)
+		defer removeConf(path_1)
+
+		session := podmanTest.PodmanExitCleanly("inspect", "--type", "all", name_0, name_1, "--format", "{{.Name}}")
+		Expect(session.OutputToString()).To(ContainSubstring(name_0))
+		Expect(session.OutputToString()).To(ContainSubstring(name_1))
+	})
+
 	It("podman inspect a volume", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

Steps to Reproduce：

1. Create multiple Podman networks:

```bash
podman network create net_1
podman network create net_2
```

2. Inspect with --type=all:

```bash
podman inspect --type=all net_1 net_2
```

3. Actual Result:
```json
[
     {
          "name": "net_1",
          "id": "82e01d194062d42f8a8353f598f03bf9cb527a61ade9f5672a7a63176ccc72b3",
          "driver": "bridge",
          "network_interface": "podman1",
          "created": "2026-06-03T16:53:39.49571197+08:00",
          "subnets": [
               {
                    "subnet": "10.89.0.0/24",
                    "gateway": "10.89.0.1"
               }
          ],
          "ipv6_enabled": false,
          "internal": false,
          "dns_enabled": true,
          "ipam_options": {
               "driver": "host-local"
          },
          "containers": {}
     },
     {
          "name": "net_1",
          "id": "82e01d194062d42f8a8353f598f03bf9cb527a61ade9f5672a7a63176ccc72b3",
          "driver": "bridge",
          "network_interface": "podman1",
          "created": "2026-06-03T16:53:39.49571197+08:00",
          "subnets": [
               {
                    "subnet": "10.89.0.0/24",
                    "gateway": "10.89.0.1"
               }
          ],
          "ipv6_enabled": false,
          "internal": false,
          "dns_enabled": true,
          "ipam_options": {
               "driver": "host-local"
          },
          "containers": {}
     }
]
```

4. Expected Result:

```json
[
    {
          "name": "net_1",
          "id": "82e01d194062d42f8a8353f598f03bf9cb527a61ade9f5672a7a63176ccc72b3",
          "driver": "bridge",
          "network_interface": "podman1",
          "created": "2026-06-03T16:53:39.49571197+08:00",
          "subnets": [
               {
                    "subnet": "10.89.0.0/24",
                    "gateway": "10.89.0.1"
               }
          ],
          "ipv6_enabled": false,
          "internal": false,
          "dns_enabled": true,
          "ipam_options": {
               "driver": "host-local"
          },
          "containers": {}
     },
     {
          "name": "net_2",
          "id": "249107cc06e598e2c3c27b0064d8acde5257d67a860f24e85d12512b9afa05ed",
          "driver": "bridge",
          "network_interface": "podman2",
          "created": "2026-06-03T16:53:40.983070804+08:00",
          "subnets": [
               {
                    "subnet": "10.89.1.0/24",
                    "gateway": "10.89.1.1"
               }
          ],
          "ipv6_enabled": false,
          "internal": false,
          "dns_enabled": true,
          "ipam_options": {
               "driver": "host-local"
          },
          "containers": {}
     }
]
```

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
