### PR TITLE
docs(podman-systemd.unit.5.md): fix a typo

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -87,7 +87,7 @@ If the administrator places a Quadlet file in the
 /etc/containers/systemd/users/${UID}/ or /usr/share/containers/users/${UID}
 directory, then only the user with the matching UID executes the Quadlet
 when the login session gets started. For unit files placed in subdirectories within
-/etc/containers/systemd/user/${UID}/, /usr/share/containers/users/${UID} and
+/etc/containers/systemd/users/${UID}/, /usr/share/containers/users/${UID} and
 the other user unit search paths, Quadlet will recursively search and run the
 unit files present in these subdirectories.
 


### PR DESCRIPTION
systemd container user path should be 'users'.  Not 'user'

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [X] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [X] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [X] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

None
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
