### PR TITLE
packit: Stop notifying martinpitt for Cockpit test failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -117,7 +117,7 @@ jobs:
     packages: [podman-fedora]
     notifications:
       failure_comment:
-        message: "Cockpit tests failed for commit {commit_sha}. @martinpitt, @jelly, @mvollmer please check."
+        message: "Cockpit tests failed for commit {commit_sha}. @jelly, @mvollmer please check."
     targets:
       - fedora-latest-stable
       - fedora-development

--- a/plans/cockpit-podman.fmf
+++ b/plans/cockpit-podman.fmf
@@ -1,6 +1,6 @@
 # reverse dependency test for https://github.com/cockpit-project/cockpit-podman/
 # packit should automatically notify the cockpit maintainers on failures.
-# For questions, please contact @martinpitt, @jelly, @mvollmer
+# For questions, please contact @jelly, @mvollmer
 enabled: false
 
 adjust+:


### PR DESCRIPTION
Martin left Red Hat and is no longer active in Cockpit development.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

None