### PR TITLE
Governance: update maintainer Admin exception rule

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -131,7 +131,10 @@ A Maintainer must meet the responsibilities and requirements of a Reviewer, plus
     * Represent the project in interactions with the CNCF
     * Have a voice, but not a vote, in Core Maintainer decision-making meetings
 	* For repositories hosted on GitHub, Maintainers receive Maintain privileges by default by being added to the `<repo-name>-maintainers` team and removed from the `<repo-name>-reviewers` teams.
-      If they have a legitimate reason to require Admin privileges (e.g. working on project CI systems), a Maintainer can petition a Core Maintainer to be granted these additional privileges in GitHub.
+
+If a Maintainer needs or wants to work on the CI/CD pipelines and requires elevated access to manage things like secrets or the github runners they
+can petition a Core Maintainer to be granted these additional privileges in GitHub. Depending on what kind of access is required they can be given
+the 'CI/CD Admin' *Organization* role which enables them access to organization-wide runner and secret configuration, or they can ask for the 'CI/CD Admin' *Repository* role (must be granted per repository) to access the repository level runners or secrets.
 
 #### Process of becoming a maintainer:
 1. A current reviewer must be sponsored by a Maintainer of the repository in question or a Core Maintainer. The Maintainer or Core Maintainer will open a PR against the repository and add the nominee as a Maintainer in the [MAINTAINERS.md](./MAINTAINERS.md) file. The need for a sponsor is removed for Emeritus Maintainers, who may open this pull request themselves.


### PR DESCRIPTION
Instead of granting people outright admin access we should limit the scope. Github offers us a org wide "CI/CD Admin" rule that can be used to manage all the import CI configs. In particular I assigned that role to Ashley as she requires that access to manage the macos worker pool.

Using the roles to limit access is better for security as we do not have to give out Admin or org wide Owner access then.



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
