### PR TITLE
fix ssh config parsing for HostName

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -217,7 +217,7 @@ func sshClient(_url *url.URL, uri string, identity string, machine bool) (Connec
 		}
 
 		if val := cfg.Get(alias, "Hostname"); val != "" {
-			uri = val
+			uri = "ssh://" + val
 			found = true
 		}
 


### PR DESCRIPTION
A later invocation to url.Parse() needs a preceding scheme, otherwise the hostname just gets discarded.

Fixes #25067

---

This is a re-submission of #27673 (authored by @Jannik2099)

The original PR is stalled due to the addition of tests.

The maintainers (@mheon, @giuseppe) agreed to merge without tests, but @mtrmac expressed concerns about the test content.

Since it was deemed acceptable to merge without tests, I removed them.

---

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fix podman-remote being unable to connect to any host with a custom HostName in the user's ~/.ssh/config
```
