### PR TITLE
events: include labels in pod and volume attributes Fixes: #26480

### DIFF
--- a/libpod/events.go
+++ b/libpod/events.go
@@ -126,12 +126,10 @@ func (c *Container) newExecDiedEvent(sessionID string, exitCode int) {
 	e.Type = events.Container
 	intExitCode := exitCode
 	e.ContainerExitCode = &intExitCode
-	e.Attributes = make(map[string]string)
-	e.Attributes["execID"] = sessionID
 
-	e.Details = events.Details{
-		Attributes: c.Labels(),
-	}
+	attrs := c.Labels()
+	attrs["execID"] = sessionID
+	e.Attributes = attrs
 
 	if err := c.runtime.eventer.Write(e); err != nil {
 		logrus.Errorf("Unable to write exec died event: %q", err)
@@ -169,6 +167,7 @@ func (p *Pod) newPodEvent(status events.Status) {
 	e.ID = p.ID()
 	e.Name = p.Name()
 	e.Type = events.Pod
+	e.Attributes = p.Labels()
 	if err := p.runtime.eventer.Write(e); err != nil {
 		logrus.Errorf("Unable to write pod event: %q", err)
 	}
@@ -189,6 +188,7 @@ func (v *Volume) newVolumeEvent(status events.Status) {
 	e := events.NewEvent(status)
 	e.Name = v.Name()
 	e.Type = events.Volume
+	e.Attributes = v.Labels()
 	if err := v.runtime.eventer.Write(e); err != nil {
 		logrus.Errorf("Unable to write volume event: %q", err)
 	}

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -77,6 +77,9 @@ func (e EventJournalD) Write(ee Event) error {
 		}
 	case Volume:
 		m["PODMAN_NAME"] = ee.Name
+		if err := addLabelsToJournal(m, ee.Details.Attributes); err != nil {
+			return err
+		}
 	}
 
 	// starting with commit 7e6e267329 we set LogLevel=notice for the systemd healthcheck unit
@@ -275,6 +278,10 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) {
 			}
 		}
 		newEvent.Details.ContainerInspectData = entry.Fields["PODMAN_CONTAINER_INSPECT_DATA"]
+	case Volume:
+		if err := getLabelsFromJournal(entry, &newEvent); err != nil {
+			return nil, err
+		}
 	case Network:
 		newEvent.ID = entry.Fields["PODMAN_ID"]
 		newEvent.Network = entry.Fields["PODMAN_NETWORK_NAME"]

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -443,7 +443,9 @@ EOF
 # bats test_tags=ci:parallel
 @test "events - volume events" {
     local vname=v-$(safename)
-    run_podman volume create $vname
+    local lname=label$(safename | tr -d -)
+    local lvalue="labelvalue-$(safename) $(random_string 5)"
+    run_podman volume create --label="$lname=$lvalue" $vname
     run_podman volume rm $vname
 
     run_podman events --since=1m --stream=false --filter volume=$vname
@@ -454,10 +456,28 @@ EOF
     # Prefix test
     run_podman events --since=1m --stream=false --filter volume=${vname:0:9}
     assert "$output" = "$notrunc_results"
+
+    # Labels test
+    run_podman events --since=1m --stream=false --filter volume=$vname --filter event=create --format "{{.Attributes}}"
+    assert "$output" =~ "${lname}:${lvalue}" "podman-events output includes volume label"
 }
 
 # bats test_tags=ci:parallel
 @test "events - invalid filter" {
     run_podman 125 events --since="the dawn of time...ish"
     assert "$output" =~ "failed to parse event filters"
+}
+
+# bats test_tags=ci:parallel
+@test "events - pod labels in event attributes" {
+    local pname=p-$(safename)
+    local lname=label$(safename | tr -d -)
+    local lvalue="labelvalue-$(safename) $(random_string 5)"
+
+    run_podman pod create --name $pname --label "$lname=$lvalue"
+
+    run_podman events --since=1m --stream=false --filter type=pod --filter event=create --format "{{.Name}} {{.Attributes}}"
+    assert "$output" =~ "$pname .*${lname}:${lvalue}" "podman-events output includes pod label"
+
+    run_podman pod rm -f $pname
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
 Pod and volume events now include labels in the JSON `Attributes` field, consistent with container events.
```
#### Description 

Volume events currently do not include labels in the event Attributes field, even though the labels are present in volume inspect output. Container events already include labels in Attributes, so this change aligns volume and pod events with that behavior.

For journald-backed volume events, labels also need to be explicitly written to and read from PODMAN_LABELS; otherwise, labels are lost when events are reconstructed from journald.

This also fixes exec_died event construction so the execID attribute is preserved together with container labels instead of being overwritten.

#### Related Issues 
Fixes #26480 


#### Changes 

- `libpod/events.go`: 
    - Adds volume labels to volume event Attributes.
    - Adds pod labels to pod event Attributes.
    -  Updates exec_died event construction to merge container labels with `execID` so `execID` is not overwritten.

- `libpod/events/journal_linux.go`: 
    - Writes volume event labels to PODMAN_LABELS when using the journald event backend.
    - Restores volume event labels from PODMAN_LABELS when reading events from journald.

- `test/system/090-events.bats`: 
    - Extends the volume events test to verify that volume labels are included in JSON event Attributes.
    - Adds a system test for pod labels in JSON event Attributes.
