### PR TITLE
manifest push: add --retry and --retry-delay flags

### DIFF
--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -96,6 +96,14 @@ func init() {
 	flags.Int(compressionLevel, 0, "compression level to use")
 	_ = pushCmd.RegisterFlagCompletionFunc(compressionLevel, completion.AutocompleteNone)
 
+	retryFlagName := "retry"
+	flags.Uint(retryFlagName, registry.RetryDefault(), "number of times to retry in case of failure when performing push")
+	_ = pushCmd.RegisterFlagCompletionFunc(retryFlagName, completion.AutocompleteNone)
+
+	retryDelayFlagName := "retry-delay"
+	flags.String(retryDelayFlagName, registry.RetryDelayDefault(), "delay between retries in case of push failures")
+	_ = pushCmd.RegisterFlagCompletionFunc(retryDelayFlagName, completion.AutocompleteNone)
+
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("cert-dir")
 	}
@@ -163,6 +171,22 @@ func push(cmd *cobra.Command, args []string) error {
 			// is selected then defaults to `true`.
 			manifestPushOpts.ForceCompressionFormat = true
 		}
+	}
+
+	if cmd.Flags().Changed("retry") {
+		retry, err := cmd.Flags().GetUint("retry")
+		if err != nil {
+			return err
+		}
+		manifestPushOpts.Retry = &retry
+	}
+
+	if cmd.Flags().Changed("retry-delay") {
+		val, err := cmd.Flags().GetString("retry-delay")
+		if err != nil {
+			return err
+		}
+		manifestPushOpts.RetryDelay = val
 	}
 
 	digest, err := registry.ImageEngine().ManifestPush(registry.Context(), listImageSpec, destSpec, manifestPushOpts.ImagePushOptions)

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -38,6 +38,10 @@ the list or index itself. (Default true)
 
 @@option compression-level
 
+@@option retry
+
+@@option retry-delay
+
 @@option creds
 
 @@option digestfile

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -297,6 +297,8 @@ func ManifestPushV3(w http.ResponseWriter, r *http.Request) {
 		All              bool   `schema:"all"`
 		Destination      string `schema:"destination"`
 		RemoveSignatures bool   `schema:"removeSignatures"`
+		Retry            uint   `schema:"retry"`
+		RetryDelay       string `schema:"retryDelay"`
 		TLSVerify        bool   `schema:"tlsVerify"`
 	}{
 		// Add defaults here once needed.
@@ -328,7 +330,11 @@ func ManifestPushV3(w http.ResponseWriter, r *http.Request) {
 		Authfile:         authfile,
 		Password:         password,
 		RemoveSignatures: query.RemoveSignatures,
+		RetryDelay:       query.RetryDelay,
 		Username:         username,
+	}
+	if _, found := r.URL.Query()["retry"]; found {
+		options.Retry = &query.Retry
 	}
 	if sys := runtime.SystemContext(); sys != nil {
 		options.CertDir = sys.DockerCertPath
@@ -359,6 +365,8 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		ForceCompressionFormat bool     `schema:"forceCompressionFormat"`
 		Format                 string   `schema:"format"`
 		RemoveSignatures       bool     `schema:"removeSignatures"`
+		Retry                  uint     `schema:"retry"`
+		RetryDelay             string   `schema:"retryDelay"`
 		TLSVerify              bool     `schema:"tlsVerify"`
 		Quiet                  bool     `schema:"quiet"`
 		AddCompression         []string `schema:"addCompression"`
@@ -403,7 +411,11 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		Password:               password,
 		Quiet:                  true,
 		RemoveSignatures:       query.RemoveSignatures,
+		RetryDelay:             query.RetryDelay,
 		Username:               username,
+	}
+	if _, found := r.URL.Query()["retry"]; found {
+		options.Retry = &query.Retry
 	}
 	if _, found := r.URL.Query()["compressionFormat"]; found {
 		if _, foundForceCompression := r.URL.Query()["forceCompressionFormat"]; !foundForceCompression {

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -36,6 +36,14 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    name: all
 	//    description: push all images
 	//    type: boolean
+	//  - in: query
+	//    name: retry
+	//    type: integer
+	//    description: number of times to retry in case of failure when performing push
+	//  - in: query
+	//    name: retryDelay
+	//    type: string
+	//    description: delay between retries in case of push failures
 	// responses:
 	//   200:
 	//     schema:
@@ -94,6 +102,14 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    description: "silences extra stream data on push"
 	//    type: boolean
 	//    default: true
+	//  - in: query
+	//    name: retry
+	//    type: integer
+	//    description: number of times to retry in case of failure when performing push
+	//  - in: query
+	//    name: retryDelay
+	//    type: string
+	//    description: delay between retries in case of push failures
 	// responses:
 	//   200:
 	//     schema:

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -502,6 +503,14 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 	pushOptions.CompressionLevel = opts.CompressionLevel
 	pushOptions.AddCompression = opts.AddCompression
 	pushOptions.ForceCompressionFormat = opts.ForceCompressionFormat
+	pushOptions.MaxRetries = opts.Retry
+	if opts.RetryDelay != "" {
+		duration, err := time.ParseDuration(opts.RetryDelay)
+		if err != nil {
+			return "", err
+		}
+		pushOptions.RetryDelay = &duration
+	}
 
 	compressionFormat := opts.CompressionFormat
 	if compressionFormat == "" {

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -190,6 +190,12 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 
 	options := new(images.PushOptions)
 	options.WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithRemoveSignatures(opts.RemoveSignatures).WithAll(opts.All).WithFormat(opts.Format).WithCompressionFormat(opts.CompressionFormat).WithQuiet(opts.Quiet).WithProgressWriter(opts.Writer).WithAddCompression(opts.AddCompression).WithForceCompressionFormat(opts.ForceCompressionFormat)
+	if opts.Retry != nil {
+		options.WithRetry(*opts.Retry)
+	}
+	if opts.RetryDelay != "" {
+		options.WithRetryDelay(opts.RetryDelay)
+	}
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -614,6 +614,31 @@ RUN touch /file
 		Expect(push.ErrorToString()).To(MatchRegexp("Copying blob.*Failed, retrying in 1s \\.\\.\\. \\(1/3\\).*Copying blob.*Failed, retrying in 2s"))
 	})
 
+	It("push must retry with custom retry count", func() {
+		SkipIfRemote("warning is not relayed in remote setup")
+		session := podmanTest.Podman([]string{"manifest", "create", "foo", imageList})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		push := podmanTest.Podman([]string{"manifest", "push", "--all", "--tls-verify=false", "--remove-signatures", "--retry=2", "foo", "localhost:7000/bogus"})
+		push.WaitWithDefaultTimeout()
+		Expect(push).Should(ExitWithError(125, "Failed, retrying in 1s ... (1/2)"))
+		Expect(push.ErrorToString()).To(MatchRegexp("Copying blob.*Failed, retrying in 1s \\.\\.\\. \\(1/2\\).*Copying blob.*Failed, retrying in 2s"))
+		Expect(push.ErrorToString()).ToNot(MatchRegexp("\\(3/"))
+	})
+
+	It("push with retry=0 must not retry", func() {
+		SkipIfRemote("warning is not relayed in remote setup")
+		session := podmanTest.Podman([]string{"manifest", "create", "foo", imageList})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		push := podmanTest.Podman([]string{"manifest", "push", "--all", "--tls-verify=false", "--remove-signatures", "--retry=0", "foo", "localhost:7000/bogus"})
+		push.WaitWithDefaultTimeout()
+		Expect(push).Should(Exit(125))
+		Expect(push.ErrorToString()).ToNot(ContainSubstring("Failed, retrying"))
+	})
+
 	It("authenticated push", func() {
 		registryOptions := &podmanRegistry.Options{
 			PodmanPath: podmanTest.PodmanBinary,


### PR DESCRIPTION
Manifest push was missing the --retry and --retry-delay options
that podman push already supports. This wires them through so
both local and remote clients can configure retry behavior.

Closes #28590