### PR TITLE
[v5.8] Bump Buildah to v1.43.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/checkpoint-restore/checkpointctl v1.4.0
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.8.0
-	github.com/containers/buildah v1.43.1
+	github.com/containers/buildah v1.43.2
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.8
 	github.com/containers/libhvee v0.10.1-0.20250829163521-178d10e67860
@@ -50,7 +50,7 @@ require (
 	github.com/nxadm/tail v1.4.11
 	github.com/onsi/ginkgo/v2 v2.28.0
 	github.com/onsi/gomega v1.39.1
-	github.com/opencontainers/cgroups v0.0.5
+	github.com/opencontainers/cgroups v0.0.6
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEm
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.8.0 h1:WjGbV/0UQyo8A4qBsAh6GaDAtu1hevxVxsEuqtBqUFk=
 github.com/containernetworking/plugins v1.8.0/go.mod h1:JG3BxoJifxxHBhG3hFyxyhid7JgRVBu/wtooGEvWf1c=
-github.com/containers/buildah v1.43.1 h1:hZO/b0BxDTu38vVc3CaUhe1q3s+q2Y3goeY6QRqm4Qg=
-github.com/containers/buildah v1.43.1/go.mod h1:LSi6Syf+ntc1g0WcUa7yb5dT1W2KzA//+aW+TLgj1os=
+github.com/containers/buildah v1.43.2 h1:KbxgDNWtbMTQtbSElh4e/n8pJa9EDF+/jtIKPr1QtZI=
+github.com/containers/buildah v1.43.2/go.mod h1:dXSaAu+S9aiY0j1teX+7btxBKSZlLfWU5LXnXwPaxf8=
 github.com/containers/common v0.62.2 h1:xO45OOoeq17EZMIDZoSyRqg7GXGcRHa9sXlrr75zH+U=
 github.com/containers/common v0.62.2/go.mod h1:veFiR9iq2j3CHXtB4YnPHuOkSRdhIQ3bAY8AFMP/5bE=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
@@ -300,8 +300,8 @@ github.com/onsi/ginkgo/v2 v2.28.0 h1:Rrf+lVLmtlBIKv6KrIGJCjyY8N36vDVcutbGJkyqjJc
 github.com/onsi/ginkgo/v2 v2.28.0/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
 github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
-github.com/opencontainers/cgroups v0.0.5 h1:DRITAqcOnY0uSBzIpt1RYWLjh5DPDiqUs4fY6Y0ktls=
-github.com/opencontainers/cgroups v0.0.5/go.mod h1:oWVzJsKK0gG9SCRBfTpnn16WcGEqDI8PAcpMGbqWxcs=
+github.com/opencontainers/cgroups v0.0.6 h1:tfZFWTIIGaUUFImTyuTg+Mr5x8XRiSdZESgEBW7UxuI=
+github.com/opencontainers/cgroups v0.0.6/go.mod h1:oWVzJsKK0gG9SCRBfTpnn16WcGEqDI8PAcpMGbqWxcs=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -375,7 +375,7 @@ func GetLimits(resource *spec.LinuxResources) (runcconfig.Resources, error) {
 
 	// Pids
 	if resource.Pids != nil {
-		final.PidsLimit = resource.Pids.Limit
+		final.PidsLimit = &resource.Pids.Limit
 	}
 
 	// Networking

--- a/test/buildah-bud/buildah-tests.diff
+++ b/test/buildah-bud/buildah-tests.diff
@@ -1,19 +1,21 @@
-From 4c30f5e698bc1d4ca498347435174a6be7232876 Mon Sep 17 00:00:00 2001
+From 53c97f858285ff043b4121988433f2312482eba9 Mon Sep 17 00:00:00 2001
 From: Ed Santiago <santiago@redhat.com>
 Date: Thu, 6 Oct 2022 17:32:59 -0600
 Subject: [PATCH] tweaks for running buildah tests under podman
 
 Signed-off-by: Ed Santiago <santiago@redhat.com>
 Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+Signed-off-by: Danish Prakash <contact@danishpraka.sh>
+Signed-off-by: Lokesh Mandvekar <lsm5@redhat.com>
 ---
  tests/helpers.bash | 166 +++++++++++++++++++++++++++++++++++++++++++--
  1 file changed, 162 insertions(+), 4 deletions(-)
 
 diff --git a/tests/helpers.bash b/tests/helpers.bash
-index 5acd0a3c3..7a0721305 100644
+index 5ba4f5a..6a41f10 100644
 --- a/tests/helpers.bash
 +++ b/tests/helpers.bash
-@@ -85,6 +85,42 @@ EOF
+@@ -86,6 +86,42 @@ EOF
      BUILDAH_REGISTRY_OPTS="${regconfopt} ${regconfdir} --short-name-alias-conf ${TEST_SCRATCH_DIR}/cache/shortnames.conf"
      COPY_REGISTRY_OPTS="${BUILDAH_REGISTRY_OPTS}"
      PODMAN_REGISTRY_OPTS="${regconfopt}"
@@ -54,12 +56,12 @@ index 5acd0a3c3..7a0721305 100644
 +        die "podman server never came up: $PODMAN_SOCK_FILE"
 +    fi
  }
- 
- function starthttpd() { # directory [working-directory-or-"" [certfile, keyfile]]
-@@ -149,6 +185,22 @@ function teardown_tests() {
+
+ function starthttpd() { # directoryspecs [working-directory-or-"" [certfile, keyfile]]
+@@ -155,6 +191,22 @@ function teardown_tests() {
      stop_git_daemon
      stop_registry
- 
+
 +    if [[ -n "$PODMAN_SERVER_PID" ]]; then
 +        echo "teardown: stopping podman server $PODMAN_SERVER_PID"
 +        kill $PODMAN_SERVER_PID
@@ -79,9 +81,9 @@ index 5acd0a3c3..7a0721305 100644
      # Workaround for #1991 - buildah + overlayfs leaks mount points.
      # Many tests leave behind /var/tmp/.../root/overlay and sub-mounts;
      # let's find those and clean them up, otherwise 'rm -rf' fails.
-@@ -270,7 +322,12 @@ function copy() {
+@@ -276,7 +328,12 @@ function copy() {
  }
- 
+
  function podman() {
 -    command ${PODMAN_BINARY:-podman} ${PODMAN_REGISTRY_OPTS} ${ROOTDIR_OPTS} "$@"
 +    local cmd=${PODMAN_BINARY:-podman}
@@ -91,12 +93,12 @@ index 5acd0a3c3..7a0721305 100644
 +    fi
 +    command $cmd $opts "$@"
  }
- 
+
  # There are various scenarios where we would like to execute `tests` as rootless user, however certain commands like `buildah mount`
-@@ -377,8 +434,86 @@ function run_buildah() {
+@@ -383,8 +440,86 @@ function run_buildah() {
          --retry)         retry=3;        shift;;  # retry network flakes
      esac
- 
+
 +    local podman_or_buildah=${BUILDAH_BINARY}
 +    local _opts="${ROOTDIR_OPTS} ${BUILDAH_REGISTRY_OPTS}"
 +    local copydown=:
@@ -178,12 +180,12 @@ index 5acd0a3c3..7a0721305 100644
      # Remember command args, for possible use in later diagnostic messages
 -    MOST_RECENT_BUILDAH_COMMAND="buildah $*"
 +    MOST_RECENT_BUILDAH_COMMAND="$cmd_basename $*"
- 
+
      # If session is rootless and `buildah mount` is invoked, perform unshare,
      # since normal user cannot mount a filesystem unless they're in a user namespace along with its own mount namespace.
-@@ -392,8 +527,8 @@ function run_buildah() {
+@@ -398,8 +533,8 @@ function run_buildah() {
          retry=$(( retry - 1 ))
- 
+
          # stdout is only emitted upon error; this echo is to help a debugger
 -        echo "${_LOG_PROMPT} ${BUILDAH_BINARY} $*"
 -        run env CONTAINERS_CONF=${CONTAINERS_CONF:-$(dirname ${BASH_SOURCE})/containers.conf} timeout --foreground --kill=10 $BUILDAH_TIMEOUT ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${ROOTDIR_OPTS} "$@"
@@ -192,10 +194,10 @@ index 5acd0a3c3..7a0721305 100644
          # without "quotes", multiple lines are glommed together into one
          if [ -n "$output" ]; then
              echo "$output"
-@@ -420,6 +555,9 @@ function run_buildah() {
+@@ -426,6 +561,9 @@ function run_buildah() {
              false
          fi
- 
+
 +        if [[ "$status" -eq 0 ]] ; then
 +            eval ${copydown}
 +        fi
@@ -205,7 +207,7 @@ index 5acd0a3c3..7a0721305 100644
 @@ -757,6 +895,26 @@ function skip_if_no_unshare() {
    fi
  }
- 
+
 +####################
 +#  skip_if_remote  #  (only applicable for podman)
 +####################
@@ -230,5 +232,4 @@ index 5acd0a3c3..7a0721305 100644
  #  start_git_daemon  #
  ######################
 -- 
-2.51.0
-
+2.53.0

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 # Changelog
 
+## v1.43.2 (2026-05-29)
+
+    Bump opencontainers/cgroups to v0.0.6
+    bud with ADD with git repository source integration test: go local
+    Add changes to tests/serve/serve.go from 68b29e6
+    Add bare-podman-repo.tar.gz for testing
+    TEMPORARY: Skip a newly-added test
+    Revert urlsource changes in define/types.go
+    Restore the previous TempDirForURL API
+    TempDirForURL: return absolute context path instead of relative subdir
+    TempDirForURL: refactor if-chain into switch statement
+    Prevent symlink-based path traversal in build contexts
+    tests: remove dependencies on online apt repositories
+    Cite go module change
+
 ## v1.43.1 (2026-04-07)
 
     [release-1.43] Bump c/common v0.67.1, c/image v5.39.2

--- a/vendor/github.com/containers/buildah/add.go
+++ b/vendor/github.com/containers/buildah/add.go
@@ -604,6 +604,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				go func() {
 					defer wg.Done()
 					defer pipeWriter.Close()
+					// TODO: the returned cloneDir is never cleaned up, leaking disk space.
 					var cloneDir, subdir string
 					cloneDir, subdir, getErr = define.TempDirForURL(tmpdir.GetTempDir(), "", src)
 					if getErr != nil {

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,17 @@
+- Changelog for v1.43.2 (2026-05-29)
+  * Bump opencontainers/cgroups to v0.0.6
+  * bud with ADD with git repository source integration test: go local
+  * Add changes to tests/serve/serve.go from 68b29e6
+  * Add bare-podman-repo.tar.gz for testing
+  * TEMPORARY: Skip a newly-added test
+  * Revert urlsource changes in define/types.go
+  * Restore the previous TempDirForURL API
+  * TempDirForURL: return absolute context path instead of relative subdir
+  * TempDirForURL: refactor if-chain into switch statement
+  * Prevent symlink-based path traversal in build contexts
+  * tests: remove dependencies on online apt repositories
+  * Cite go module change
+
 - Changelog for v1.43.1 (2026-04-07)
   * [release-1.43] Bump c/common v0.67.1, c/image v5.39.2
   * update module github.com/go-jose/go-jose/v4 to v4.1.4 [security]

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -7,20 +7,20 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	urlpkg "net/url"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/image/v5/manifest"
 	"go.podman.io/storage/pkg/archive"
 	"go.podman.io/storage/pkg/chrootarchive"
-	"go.podman.io/storage/pkg/ioutils"
 	"go.podman.io/storage/types"
 )
 
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.43.1"
+	Version = "1.43.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"
@@ -171,12 +171,12 @@ type SBOMScanOptions struct {
 
 // TempDirForURL checks if the passed-in string looks like a URL or "-".  If it
 // is, TempDirForURL creates a temporary directory, arranges for its contents
-// to be the contents of that URL, and returns the temporary directory's path,
-// along with the relative name of a subdirectory which should be used as the
-// build context (which may be empty or ".").  Removal of the temporary
-// directory is the responsibility of the caller.  If the string doesn't look
-// like a URL or "-", TempDirForURL returns empty strings and a nil error code.
-func TempDirForURL(dir, prefix, url string) (name string, subdir string, err error) {
+// to be the contents of that URL, and returns the temporary directory's path
+// (for cleanup) and a relative subdirectory to the build context within it.
+// Removal of the temporary directory is the responsibility of the caller.
+// If the string doesn't look like a URL or "-", TempDirForURL returns empty
+// strings and a nil error code.
+func TempDirForURL(dir, prefix, url string) (tempDir string, relativeContextDir string, err error) {
 	if !strings.HasPrefix(url, "http://") &&
 		!strings.HasPrefix(url, "https://") &&
 		!strings.HasPrefix(url, "git://") &&
@@ -184,62 +184,67 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 		url != "-" {
 		return "", "", nil
 	}
-	name, err = os.MkdirTemp(dir, prefix)
+	tempDir, err = os.MkdirTemp(dir, prefix)
 	if err != nil {
 		return "", "", fmt.Errorf("creating temporary directory for %q: %w", url, err)
 	}
-	downloadDir := filepath.Join(name, "download")
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			if err2 := os.RemoveAll(tempDir); err2 != nil {
+				logrus.Errorf("error removing temporary directory %q: %v", tempDir, err2)
+			}
+		}
+	}()
+
+	downloadDir := filepath.Join(tempDir, "download")
 	if err = os.MkdirAll(downloadDir, 0o700); err != nil {
 		return "", "", fmt.Errorf("creating directory %q for %q: %w", downloadDir, url, err)
 	}
-	urlParsed, err := urlpkg.Parse(url)
+
+	var contentSubdir string
+	urlParsed, parseErr := neturl.Parse(url)
+	if parseErr != nil {
+		return "", "", fmt.Errorf("parsing url %q: %w", url, parseErr)
+	}
+
+	isGitURL := urlParsed.Scheme == "git" || strings.HasSuffix(urlParsed.Path, ".git")
+	switch {
+	case isGitURL:
+		combinedOutput, gitSubDir, cloneErr := cloneToDirectory(url, downloadDir)
+		if cloneErr != nil {
+			return "", "", fmt.Errorf("cloning %q to %q:\n%s: %w", url, tempDir, string(combinedOutput), cloneErr)
+		}
+		contentSubdir = gitSubDir
+	case strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://"):
+		if err = downloadToDirectory(url, downloadDir); err != nil {
+			return "", "", err
+		}
+	case strings.HasPrefix(url, "github.com/"):
+		ghURL := url
+		contentSubdir = path.Base(ghURL) + "-master"
+		downloadURL := fmt.Sprintf("https://%s/archive/master.tar.gz", ghURL)
+		logrus.Debugf("resolving url %q to %q", ghURL, downloadURL)
+		if err = downloadToDirectory(downloadURL, downloadDir); err != nil {
+			return "", "", err
+		}
+	case url == "-":
+		if err = stdinToDirectory(downloadDir); err != nil {
+			return "", "", err
+		}
+	}
+
+	contextDir, err := securejoin.SecureJoin(downloadDir, contentSubdir)
 	if err != nil {
-		return "", "", fmt.Errorf("parsing url %q: %w", url, err)
+		return "", "", fmt.Errorf("resolving subdirectory %q in %q: %w", contentSubdir, downloadDir, err)
 	}
-	if strings.HasPrefix(url, "git://") || strings.HasSuffix(urlParsed.Path, ".git") {
-		combinedOutput, gitSubDir, err := cloneToDirectory(url, downloadDir)
-		if err != nil {
-			if err2 := os.RemoveAll(name); err2 != nil {
-				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
-			}
-			return "", "", fmt.Errorf("cloning %q to %q:\n%s: %w", url, name, string(combinedOutput), err)
-		}
-		logrus.Debugf("Build context is at %q", filepath.Join(downloadDir, gitSubDir))
-		return name, filepath.Join(filepath.Base(downloadDir), gitSubDir), nil
+	relativeContextDir, err = filepath.Rel(tempDir, contextDir)
+	if err != nil {
+		return "", "", err
 	}
-	if strings.HasPrefix(url, "github.com/") {
-		ghurl := url
-		url = fmt.Sprintf("https://%s/archive/master.tar.gz", ghurl)
-		logrus.Debugf("resolving url %q to %q", ghurl, url)
-		subdir = path.Base(ghurl) + "-master"
-	}
-	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-		err = downloadToDirectory(url, downloadDir)
-		if err != nil {
-			if err2 := os.RemoveAll(name); err2 != nil {
-				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
-			}
-			return "", "", err
-		}
-		logrus.Debugf("Build context is at %q", filepath.Join(downloadDir, subdir))
-		return name, filepath.Join(filepath.Base(downloadDir), subdir), nil
-	}
-	if url == "-" {
-		err = stdinToDirectory(downloadDir)
-		if err != nil {
-			if err2 := os.RemoveAll(name); err2 != nil {
-				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
-			}
-			return "", "", err
-		}
-		logrus.Debugf("Build context is at %q", filepath.Join(downloadDir, subdir))
-		return name, filepath.Join(filepath.Base(downloadDir), subdir), nil
-	}
-	logrus.Debugf("don't know how to retrieve %q", url)
-	if err2 := os.RemoveAll(name); err2 != nil {
-		logrus.Debugf("error removing temporary directory %q: %v", name, err2)
-	}
-	return "", "", errors.New("unreachable code reached")
+	logrus.Debugf("Build context is at %q", contextDir)
+	succeeded = true
+	return tempDir, relativeContextDir, nil
 }
 
 // parseGitBuildContext parses git build context to `repo`, `sub-dir`
@@ -316,6 +321,8 @@ func downloadToDirectory(url, dir string) error {
 	if resp.ContentLength == 0 {
 		return fmt.Errorf("no contents in %q", url)
 	}
+	// Try to extract the response as a tar archive; if that fails,
+	// assume it is a raw Dockerfile and write it as such.
 	if err := chrootarchive.Untar(resp.Body, dir, nil); err != nil {
 		resp1, err := http.Get(url)
 		if err != nil {
@@ -326,10 +333,8 @@ func downloadToDirectory(url, dir string) error {
 		if err != nil {
 			return err
 		}
-		dockerfile := filepath.Join(dir, "Dockerfile")
-		// Assume this is a Dockerfile
-		if err := ioutils.AtomicWriteFile(dockerfile, body, 0o600); err != nil {
-			return fmt.Errorf("failed to write %q to %q: %w", url, dockerfile, err)
+		if err := writeFileInRoot(dir, "Dockerfile", body, 0o600); err != nil {
+			return fmt.Errorf("failed to write %q to %q: %w", url, filepath.Join(dir, "Dockerfile"), err)
 		}
 	}
 	return nil
@@ -342,13 +347,43 @@ func stdinToDirectory(dir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read from stdin: %w", err)
 	}
+	// Try to extract the buffered input as a tar archive; if that fails,
+	// assume it is a raw Dockerfile and write it as such.
 	reader := bytes.NewReader(b)
 	if err := chrootarchive.Untar(reader, dir, nil); err != nil {
-		dockerfile := filepath.Join(dir, "Dockerfile")
-		// Assume this is a Dockerfile
-		if err := ioutils.AtomicWriteFile(dockerfile, b, 0o600); err != nil {
-			return fmt.Errorf("failed to write bytes to %q: %w", dockerfile, err)
+		if err := writeFileInRoot(dir, "Dockerfile", b, 0o600); err != nil {
+			return fmt.Errorf("failed to write bytes to %q: %w", filepath.Join(dir, "Dockerfile"), err)
 		}
 	}
 	return nil
+}
+
+// writeFileInRoot safely writes data to a file inside root, without following
+// symlinks that escape the root directory.
+func writeFileInRoot(root, name string, data []byte, perm os.FileMode) error { //nolint:unparam,nolintlint
+	// Above:
+	// unparam: 'name' currently only receives "Dockerfile" but will potentially support other files later
+	// nolintlint: the unparam linter only triggers if there are ≥ 4 instances; we do have that
+	// with --tests defaulting to true, but not with --tests=false.
+
+	rootHandle, err := os.OpenRoot(root)
+	if err != nil {
+		return err
+	}
+	defer rootHandle.Close()
+
+	if err := rootHandle.Remove(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	fileHandle, err := rootHandle.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+
+	_, err = fileHandle.Write(data)
+	if closeErr := fileHandle.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	return err
 }

--- a/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
@@ -486,6 +486,7 @@ func (s *StageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 							// additional context contains a tar file
 							// so download and explode tar to buildah
 							// temp and point context to that.
+							// TODO: the returned path is never cleaned up, leaking disk space.
 							path, subdir, err := define.TempDirForURL(tmpdir.GetTempDir(), internal.BuildahExternalArtifactsDir, additionalBuildContext.Value)
 							if err != nil {
 								return fmt.Errorf("unable to download context from external source %q: %w", additionalBuildContext.Value, err)
@@ -679,6 +680,7 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 								// additional context contains a tar file
 								// so download and explode tar to buildah
 								// temp and point context to that.
+								// TODO: the returned path is never cleaned up, leaking disk space.
 								path, subdir, err := define.TempDirForURL(tmpdir.GetTempDir(), internal.BuildahExternalArtifactsDir, additionalBuildContext.Value)
 								if err != nil {
 									return nil, fmt.Errorf("unable to download context from external source %q: %w", additionalBuildContext.Value, err)

--- a/vendor/github.com/opencontainers/cgroups/config_linux.go
+++ b/vendor/github.com/opencontainers/cgroups/config_linux.go
@@ -90,8 +90,8 @@ type Resources struct {
 	// Cgroup's SCHED_IDLE value.
 	CPUIdle *int64 `json:"cpu_idle,omitempty"`
 
-	// Process limit; set <= `0' to disable limit.
-	PidsLimit int64 `json:"pids_limit,omitempty"`
+	// Process limit; set < `0' to disable limit. `nil` means "keep current limit".
+	PidsLimit *int64 `json:"pids_limit,omitempty"`
 
 	// Specifies per cgroup weight, range is from 10 to 1000.
 	BlkioWeight uint16 `json:"blkio_weight,omitempty"`

--- a/vendor/github.com/opencontainers/cgroups/fs/cpuacct.go
+++ b/vendor/github.com/opencontainers/cgroups/fs/cpuacct.go
@@ -129,12 +129,16 @@ func getPercpuUsageInModes(path string) ([]uint64, []uint64, error) {
 	defer fd.Close()
 
 	scanner := bufio.NewScanner(fd)
-	scanner.Scan() // skipping header line
+	scanner.Scan() // Read header line.
+	const want = "cpu user system"
+	if hdr := scanner.Text(); !strings.HasPrefix(hdr, want) {
+		return nil, nil, malformedLine(path, file, hdr)
+	}
 
 	for scanner.Scan() {
-		// Each line is: cpu user system
-		fields := strings.SplitN(scanner.Text(), " ", 3)
-		if len(fields) != 3 {
+		// Each line is: cpu user system. Keep N at 4 to ignore extra fields.
+		fields := strings.SplitN(scanner.Text(), " ", 4)
+		if len(fields) < 3 {
 			continue
 		}
 

--- a/vendor/github.com/opencontainers/cgroups/fs2/io.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/io.go
@@ -165,11 +165,22 @@ func statIo(dirPath string, stats *cgroups.Stats) error {
 			case "wios":
 				op = "Write"
 				targetTable = &parsedStats.IoServicedRecursive
+
+			case "cost.usage":
+				op = "Count"
+				targetTable = &parsedStats.IoCostUsage
+			case "cost.wait":
+				op = "Count"
+				targetTable = &parsedStats.IoCostWait
+			case "cost.indebt":
+				op = "Count"
+				targetTable = &parsedStats.IoCostIndebt
+			case "cost.indelay":
+				op = "Count"
+				targetTable = &parsedStats.IoCostIndelay
+
 			default:
-				// Skip over entries we cannot map to cgroupv1 stats for now.
-				// In the future we should expand the stats struct to include
-				// them.
-				logrus.Debugf("cgroupv2 io stats: skipping over unmappable %s entry", item)
+				logrus.Debugf("cgroupv2 io stats: unknown entry %s", item)
 				continue
 			}
 

--- a/vendor/github.com/opencontainers/cgroups/stats.go
+++ b/vendor/github.com/opencontainers/cgroups/stats.go
@@ -159,6 +159,10 @@ type BlkioStats struct {
 	IoTimeRecursive         []BlkioStatEntry `json:"io_time_recursive,omitempty"`
 	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive,omitempty"`
 	PSI                     *PSIStats        `json:"psi,omitempty"`
+	IoCostUsage             []BlkioStatEntry `json:"io_cost_usage,omitempty"`
+	IoCostWait              []BlkioStatEntry `json:"io_cost_wait,omitempty"`
+	IoCostIndebt            []BlkioStatEntry `json:"io_cost_indebt,omitempty"`
+	IoCostIndelay           []BlkioStatEntry `json:"io_cost_indelay,omitempty"`
 }
 
 type HugetlbStats struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.8.0
 ## explicit; go 1.24.2
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.43.1
+# github.com/containers/buildah v1.43.2
 ## explicit; go 1.24.2
 github.com/containers/buildah
 github.com/containers/buildah/bind
@@ -529,7 +529,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/opencontainers/cgroups v0.0.5
+# github.com/opencontainers/cgroups v0.0.6
 ## explicit; go 1.23.0
 github.com/opencontainers/cgroups
 github.com/opencontainers/cgroups/devices/config


### PR DESCRIPTION
Bump Buildah to v1.43.2 in preparation for the next Podman v5.8 release.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
