### PR TITLE
manifest push: add --retry and --retry-delay

### DIFF
--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -80,6 +80,13 @@ func init() {
 
 	flags.BoolVarP(&manifestPushOpts.RemoveSignatures, "remove-signatures", "", false, "don't copy signatures when pushing images")
 
+	retryFlagName := "retry"
+	flags.Uint(retryFlagName, registry.RetryDefault(), "number of times to retry in case of failure when performing push")
+	_ = pushCmd.RegisterFlagCompletionFunc(retryFlagName, completion.AutocompleteNone)
+	retryDelayFlagName := "retry-delay"
+	flags.String(retryDelayFlagName, registry.RetryDelayDefault(), "delay between retries in case of push failures")
+	_ = pushCmd.RegisterFlagCompletionFunc(retryDelayFlagName, completion.AutocompleteNone)
+
 	common.DefineSigningFlags(pushCmd, &manifestPushOpts.signing, &manifestPushOpts.ImagePushOptions)
 
 	flags.BoolVar(&manifestPushOpts.TLSVerifyCLI, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
@@ -147,6 +154,24 @@ func push(cmd *cobra.Command, args []string) error {
 			return errors.New("--insecure may not be used with --tls-verify")
 		}
 		manifestPushOpts.SkipTLSVerify = types.NewOptionalBool(manifestPushOpts.Insecure)
+	}
+
+	if cmd.Flags().Changed("retry") {
+		retry, err := cmd.Flags().GetUint("retry")
+		if err != nil {
+			return err
+		}
+
+		manifestPushOpts.Retry = &retry
+	}
+
+	if cmd.Flags().Changed("retry-delay") {
+		val, err := cmd.Flags().GetString("retry-delay")
+		if err != nil {
+			return err
+		}
+
+		manifestPushOpts.RetryDelay = val
 	}
 
 	if cmd.Flags().Changed("compression-level") {

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -60,6 +60,10 @@ Don't copy signatures when pushing images.
 
 Delete the manifest list or image index from local storage if pushing succeeds.
 
+@@option retry
+
+@@option retry-delay
+
 #### **--sign-by**=*fingerprint*
 
 Sign the pushed images with a “simple signing” signature using the specified key. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -359,6 +359,8 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		ForceCompressionFormat bool     `schema:"forceCompressionFormat"`
 		Format                 string   `schema:"format"`
 		RemoveSignatures       bool     `schema:"removeSignatures"`
+		Retry                  uint     `schema:"retry"`
+		RetryDelay             string   `schema:"retryDelay"`
 		TLSVerify              bool     `schema:"tlsVerify"`
 		Quiet                  bool     `schema:"quiet"`
 		AddCompression         []string `schema:"addCompression"`
@@ -403,7 +405,11 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		Password:               password,
 		Quiet:                  true,
 		RemoveSignatures:       query.RemoveSignatures,
+		RetryDelay:             query.RetryDelay,
 		Username:               username,
+	}
+	if _, found := r.URL.Query()["retry"]; found {
+		options.Retry = &query.Retry
 	}
 	if _, found := r.URL.Query()["compressionFormat"]; found {
 		if _, foundForceCompression := r.URL.Query()["forceCompressionFormat"]; !foundForceCompression {

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -94,6 +94,14 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    description: "silences extra stream data on push"
 	//    type: boolean
 	//    default: true
+	//  - in: query
+	//    name: retry
+	//    description: number of times to retry in case of failure when performing push
+	//    type: integer
+	//  - in: query
+	//    name: retryDelay
+	//    description: delay between retries in case of push failures
+	//    type: string
 	// responses:
 	//   200:
 	//     schema:

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -502,6 +503,14 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 	pushOptions.CompressionLevel = opts.CompressionLevel
 	pushOptions.AddCompression = opts.AddCompression
 	pushOptions.ForceCompressionFormat = opts.ForceCompressionFormat
+	pushOptions.MaxRetries = opts.Retry
+	if opts.RetryDelay != "" {
+		duration, err := time.ParseDuration(opts.RetryDelay)
+		if err != nil {
+			return "", err
+		}
+		pushOptions.RetryDelay = &duration
+	}
 
 	compressionFormat := opts.CompressionFormat
 	if compressionFormat == "" {

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -191,6 +191,13 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 	options := new(images.PushOptions)
 	options.WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithRemoveSignatures(opts.RemoveSignatures).WithAll(opts.All).WithFormat(opts.Format).WithCompressionFormat(opts.CompressionFormat).WithQuiet(opts.Quiet).WithProgressWriter(opts.Writer).WithAddCompression(opts.AddCompression).WithForceCompressionFormat(opts.ForceCompressionFormat)
 
+	if opts.Retry != nil {
+		options.WithRetry(*opts.Retry)
+	}
+	if opts.RetryDelay != "" {
+		options.WithRetryDelay(opts.RetryDelay)
+	}
+
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
 			options.WithSkipTLSVerify(true)

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -614,6 +614,20 @@ RUN touch /file
 		Expect(push.ErrorToString()).To(MatchRegexp("Copying blob.*Failed, retrying in 1s \\.\\.\\. \\(1/3\\).*Copying blob.*Failed, retrying in 2s"))
 	})
 
+	It("push --retry sets the retry count", func() {
+		SkipIfRemote("warning is not relayed in remote setup")
+		session := podmanTest.Podman([]string{"manifest", "create", "foo", imageList})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		// --retry overrides the default of 3, so the push should give
+		// up after a single retry instead.
+		push := podmanTest.Podman([]string{"manifest", "push", "--all", "--retry", "1", "--retry-delay", "1s", "--tls-verify=false", "--remove-signatures", "foo", "localhost:7000/bogus"})
+		push.WaitWithDefaultTimeout()
+		Expect(push).Should(ExitWithError(125, "Failed, retrying in 1s ... (1/1)"))
+		Expect(push.ErrorToString()).ToNot(ContainSubstring("(1/3)"))
+	})
+
 	It("authenticated push", func() {
 		registryOptions := &podmanRegistry.Options{
 			PodmanPath: podmanTest.PodmanBinary,


### PR DESCRIPTION
## What this does
`podman push` supports `--retry`/`--retry-delay`, but `podman manifest push`
did not, even though it's the same kind of registry push. This adds those two
flags to `manifest push`.

## Changes
- cmd/podman/manifest: add `--retry` and `--retry-delay` flags
- abi: pass MaxRetries/RetryDelay to the libimage manifest push
- tunnel + API handler: forward the options so podman-remote behaves the same
- docs (man page + swagger) and an e2e test

## Note
Manifest push already retried 3x by default via libimage; this just makes the
count/delay configurable, matching `podman push`.

Fixes: #28590
