### PR TITLE
.github/labeler: add CI label automatically

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,3 +11,7 @@ governance:
     - any-glob-to-any-file: OWNERS
     - any-glob-to-any-file: MAINTAINERS.md
     - any-glob-to-any-file: GOVERNANCE.md
+CI:
+  - changed-files:
+    - any-glob-to-any-file: .github/**
+    - any-glob-to-any-file: hack/ci/**


### PR DESCRIPTION
To make it a bit more obvious when any CI related files such as github workflows are touched add a label.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
