### PR TITLE
image scp: preserve usernames containing an "@"

### DIFF
--- a/pkg/domain/utils/scp.go
+++ b/pkg/domain/utils/scp.go
@@ -361,7 +361,10 @@ func ParseImageSCPArg(arg string) (*entities.ScpTransferImageOptions, []string, 
 
 	switch {
 	case strings.Contains(arg, "@localhost::"): // image transfer between users
-		location.User, _, _ = strings.Cut(arg, "@")
+		// Split on "@localhost::" rather than the first "@" so usernames
+		// that themselves contain an "@" (e.g. Active Directory "user@domain")
+		// are preserved. See https://github.com/containers/podman/issues/27655
+		location.User, _, _ = strings.Cut(arg, "@localhost::")
 		location, err = ValidateImagePortion(location, arg)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/domain/utils/scp_test.go
+++ b/pkg/domain/utils/scp_test.go
@@ -72,3 +72,34 @@ func TestValidateSCPArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestParseImageSCPArg(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      string
+		wantUser string
+	}{
+		{
+			name:     "user without domain",
+			arg:      "user@localhost::alpine",
+			wantUser: "user",
+		},
+		{
+			name:     "username containing an @ (e.g. Active Directory)",
+			arg:      "user@domain@localhost::example.com/foo/bar:latest",
+			wantUser: "user@domain",
+		},
+		{
+			name:     "no username before @localhost::",
+			arg:      "@localhost::alpine",
+			wantUser: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			location, _, err := ParseImageSCPArg(tt.arg)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantUser, location.User)
+		})
+	}
+}

--- a/test/e2e/image_scp_test.go
+++ b/test/e2e/image_scp_test.go
@@ -47,4 +47,20 @@ var _ = Describe("podman image scp", func() {
 		// The error given should either be a missing image (due to testing suite complications) or a no such host timeout on ssh
 		Expect(scp).Should(ExitWithError(125, "failed to connect: dial tcp: lookup "))
 	})
+
+	It("podman image scp preserves a username containing an @", func() {
+		// The user-to-user transfer path that looks up the local username
+		// only runs rootful.
+		SkipIfRootless("the local user lookup only happens during a rootful transfer")
+
+		// Regression test for https://github.com/containers/podman/issues/27655:
+		// a username that itself contains an "@" (e.g. an Active Directory
+		// "user@domain") must be parsed as a whole. Before the fix it was
+		// truncated at the first "@", so the lookup failed for "user" instead
+		// of "user@domain". The lookup happens before any image is touched, so
+		// the bogus user is enough to exercise the parsing.
+		scp := podmanTest.Podman([]string{"image", "scp", "user@domain@localhost::" + ALPINE})
+		scp.WaitWithDefaultTimeout()
+		Expect(scp).Should(ExitWithError(125, "unknown user user@domain"))
+	})
 })


### PR DESCRIPTION
## Problem
`podman image scp` parses the `user@localhost::image` argument by cutting on the
first `@`. When the username itself contains an `@` — e.g. an Active Directory
account like `user@domain` — it gets truncated to just `user`:

    $ sudo podman image scp aduser@domain@localhost::example.com/foo/bar:latest
    Error: user: unknown user aduser

## Impact
Users on AD-joined (or any `user@domain`) machines can't use `podman image scp`
to copy images between users — the local user lookup fails before the transfer
even starts.

## Fix
In `ParseImageSCPArg`, the `@localhost::` case only ever matches that exact
separator, so split the argument on `@localhost::` instead of the bare `@`. This
keeps the full username (including any `@domain`) and leaves the remote
`user@host::` SSH path unchanged.

    user@localhost::img          -> user        (unchanged)
    user@domain@localhost::img   -> user@domain  (fixed)

## Test
Added `TestParseImageSCPArg` in `pkg/domain/utils/scp_test.go` covering both the
plain `user` and the `user@domain` cases. `go test ./pkg/domain/utils/` passes.

Fixes: #27655
