### PR TITLE
fix small lint error

### DIFF
--- a/cmd/podman-testing/call.go
+++ b/cmd/podman-testing/call.go
@@ -56,9 +56,6 @@ func ls(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("setting up grpc client for podman service: %w", err)
 	}
 	reflectionClient := reflectionv1.NewServerReflectionClient(grpcClient)
-	if reflectionClient == nil {
-		return errors.New("setting up client for reflection grpc service")
-	}
 	info, err := reflectionClient.ServerReflectionInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("reflection grpc service: %w", err)


### PR DESCRIPTION
This was report on of of my PRs, I do not know why this fails there all of the sudden, it seems golangci-lint has gotten flaky recently.

Locally the linter passes without this change just fine but in CI this seems to fail:
```
Error: cmd/podman-testing/call.go:58:22: SA4023(related information): the lhs of the comparison is the 1st return value of this function call (staticcheck)
	reflectionClient := reflectionv1.NewServerReflectionClient(grpcClient)
	                    ^
Error: cmd/podman-testing/call.go:59:5: SA4023: this comparison is never true (staticcheck)
	if reflectionClient == nil {
	   ^
```
The lint seems right, NewServerReflectionClient never returns nil so lets just fix it.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
