### PR TITLE
fix podman-remote save -f oci-dir/docker-dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,8 +339,15 @@ jobs:
         priv: [rootless, root]
         mode: [local, remote]
         exclude:
-          # try to keep the task somewhat sane and not run remote test rootless
-          - priv: rootless
+          # try to keep the task somewhat sane and exclude all but one rootless+remote combination
+          - distro: fedora-prior
+            priv: rootless
+            mode: remote
+          - distro: fedora-rawhide
+            priv: rootless
+            mode: remote
+          - distro: debian-sid
+            priv: rootless
             mode: remote
         include:
           # Add buildah bud tests, only runs as root for now.

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -24,7 +24,6 @@ import (
 	"go.podman.io/podman/v6/pkg/domain/utils"
 	"go.podman.io/podman/v6/pkg/errorhandling"
 	"go.podman.io/storage/pkg/archive"
-	"go.podman.io/storage/pkg/chrootarchive"
 )
 
 func (ir *ImageEngine) Exists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
@@ -368,7 +367,7 @@ func (ir *ImageEngine) Save(_ context.Context, nameOrID string, tags []string, o
 		return err
 	}
 
-	return chrootarchive.Untar(f, opts.Output, &archive.TarOptions{NoLchown: true})
+	return archive.Untar(f, opts.Output, &archive.TarOptions{NoLchown: true})
 }
 
 func (ir *ImageEngine) Search(_ context.Context, term string, opts entities.ImageSearchOptions) ([]entities.ImageSearchReport, error) {

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1547,8 +1547,11 @@ func (s *PodmanSessionIntegration) jq(jqCommand string) (string, error) {
 }
 
 func (p *PodmanTestIntegration) buildImage(dockerfile, imageName string, layers string, label string, extraOptions []string) string {
-	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile-"+stringid.GenerateRandomID())
-	err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o755)
+	buildDir := filepath.Join(p.TempDir, "build"+stringid.GenerateRandomID())
+	err := os.Mkdir(buildDir, 0o755)
+	Expect(err).ToNot(HaveOccurred())
+	dockerfilePath := filepath.Join(buildDir, "Dockerfile-"+stringid.GenerateRandomID())
+	err = os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644)
 	Expect(err).ToNot(HaveOccurred())
 	cmd := []string{"build", "--pull-never", "--layers=" + layers, "--file", dockerfilePath}
 	if label != "" {
@@ -1560,7 +1563,7 @@ func (p *PodmanTestIntegration) buildImage(dockerfile, imageName string, layers 
 	if len(extraOptions) > 0 {
 		cmd = append(cmd, extraOptions...)
 	}
-	cmd = append(cmd, p.TempDir)
+	cmd = append(cmd, buildDir)
 	session := p.Podman(cmd)
 	session.Wait(240)
 	Expect(session).Should(Exit(0), fmt.Sprintf("BuildImage session output: %q", session.OutputToString()))

--- a/test/e2e/container_create_volume_test.go
+++ b/test/e2e/container_create_volume_test.go
@@ -10,12 +10,17 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "go.podman.io/podman/v6/test/utils"
+	"go.podman.io/storage/pkg/stringid"
 )
 
 func buildDataVolumeImage(pTest *PodmanTestIntegration, image, data, dest string) {
+	buildDir := filepath.Join(pTest.TempDir, "build"+stringid.GenerateRandomID())
+	err := os.Mkdir(buildDir, 0o755)
+	Expect(err).ToNot(HaveOccurred())
+
 	// Create a dummy file for data volume
-	dummyFile := filepath.Join(pTest.TempDir, data)
-	err := os.WriteFile(dummyFile, []byte(data), 0o644)
+	dummyFile := filepath.Join(buildDir, data)
+	err = os.WriteFile(dummyFile, []byte(data), 0o644)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create a data volume container image but no CMD binary in it
@@ -23,7 +28,11 @@ func buildDataVolumeImage(pTest *PodmanTestIntegration, image, data, dest string
 CMD doesnotexist.sh
 ADD %s %s/
 VOLUME %s/`, data, dest, dest)
-	pTest.BuildImage(containerFile, image, "false")
+
+	containerFilePath := filepath.Join(buildDir, "Containerfile")
+	err = os.WriteFile(containerFilePath, []byte(containerFile), 0o644)
+	Expect(err).ToNot(HaveOccurred())
+	pTest.PodmanExitCleanly("build", "--pull-never", "-q", "-t", image, "--layers=false", "--file", containerFilePath)
 }
 
 func createContainersConfFile(pTest *PodmanTestIntegration) {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -20,6 +20,7 @@ import (
 	"go.podman.io/common/pkg/sysinfo"
 	"go.podman.io/podman/v6/pkg/util"
 	. "go.podman.io/podman/v6/test/utils"
+	"go.podman.io/storage/pkg/stringid"
 )
 
 var _ = Describe("Podman pod create", func() {
@@ -175,8 +176,12 @@ var _ = Describe("Podman pod create", func() {
 
 	Describe("podman create pod with --hosts-file", func() {
 		BeforeEach(func() {
-			imageHosts := filepath.Join(podmanTest.TempDir, "pause_hosts")
-			err := os.WriteFile(imageHosts, []byte("56.78.12.34 image.example.com"), 0o755)
+			buildDir := filepath.Join(podmanTest.TempDir, "build"+stringid.GenerateRandomID())
+			err := os.Mkdir(buildDir, 0o755)
+			Expect(err).ToNot(HaveOccurred())
+
+			imageHosts := filepath.Join(buildDir, "pause_hosts")
+			err = os.WriteFile(imageHosts, []byte("56.78.12.34 image.example.com"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			configHosts := filepath.Join(podmanTest.TempDir, "hosts")
@@ -191,11 +196,16 @@ var _ = Describe("Podman pod create", func() {
 				podmanTest.RestartRemoteService()
 			}
 
-			dockerfile := strings.Join([]string{
+			containerfile := strings.Join([]string{
 				`FROM ` + INFRA_IMAGE,
 				`COPY pause_hosts /etc/hosts`,
 			}, "\n")
-			podmanTest.BuildImage(dockerfile, "foobar.com/hosts_test_pause:latest", "false", "--no-hosts")
+
+			containerFilePath := filepath.Join(buildDir, "Containerfile")
+			err = os.WriteFile(containerFilePath, []byte(containerfile), 0o644)
+			Expect(err).ToNot(HaveOccurred())
+
+			podmanTest.PodmanExitCleanly("build", "-q", "-t", "foobar.com/hosts_test_pause:latest", "--layers=false", "--no-hosts", buildDir)
 		})
 
 		It("--hosts-file=path", func() {

--- a/test/e2e/pull_chunked_test.go
+++ b/test/e2e/pull_chunked_test.go
@@ -69,11 +69,18 @@ func pullChunkedTests() { // included in pull_test.go, must use a Ginkgo DSL at 
 					registryRef: pullChunkedRegistryPrefix + "chunked-normal",
 					dirPath:     filepath.Join(imageDir, "chunked-normal"),
 				}
+
+				buildDir := filepath.Join(podmanTest.TempDir, "build")
+				err := os.Mkdir(buildDir, 0o755)
+				Expect(err).ToNot(HaveOccurred())
 				chunkedNormalContentPath := "chunked-normal-image-content"
-				err := os.WriteFile(filepath.Join(podmanTest.TempDir, chunkedNormalContentPath), fmt.Appendf(nil, "content-%d", rand.Int64()), 0o600)
+				err = os.WriteFile(filepath.Join(buildDir, chunkedNormalContentPath), fmt.Appendf(nil, "content-%d", rand.Int64()), 0o600)
 				Expect(err).NotTo(HaveOccurred())
 				chunkedNormalContainerFile := fmt.Sprintf("FROM scratch\nADD %s /content", chunkedNormalContentPath)
-				podmanTest.BuildImage(chunkedNormalContainerFile, chunkedNormal.localTag(), "true")
+				err = os.WriteFile(filepath.Join(buildDir, "Containerfile"), []byte(chunkedNormalContainerFile), 0o600)
+				Expect(err).NotTo(HaveOccurred())
+				podmanTest.PodmanExitCleanly("build", "-q", "-t", chunkedNormal.localTag(), "--layers=true", buildDir)
+
 				podmanTest.PodmanExitCleanly("push", "-q", "--tls-verify=false", "--force-compression", "--compression-format=zstd:chunked", chunkedNormal.localTag(), chunkedNormal.registryRef)
 				skopeo := SystemExec("skopeo", []string{"copy", "-q", "--preserve-digests", "--all", "--src-tls-verify=false", chunkedNormal.registryRef, "dir:" + chunkedNormal.dirPath})
 				skopeo.WaitWithDefaultTimeout()


### PR DESCRIPTION
With podman-remote we do not enter a our user namespace like we do with local podman so we keep running with the real user id.

So if we then try to use chrootarchive as normal user it fails with: creating mount namespace before pivot: operation not permitted

So simply revert back to the normal archive code.

Now the more interesting thing is we do have a test "podman save to directory with oci format" but it never runs rootless+remote in our CI system with our current matrix as we wanted to reduce jobs.
So rethink the matrix and add one such job as this shows it is needed.

Fixes: 25aee24cbd ("use chrootarchive over plain archive package")

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed an issue that made podman-remote save -f oci-dir/docker-dir fail on linux. 
```
