### PR TITLE
filters: accept Docker-compat status values "dead" and "restarting"

### DIFF
--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -71,6 +71,12 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 		}, nil
 	case "status":
 		for _, filterValue := range filterValues {
+			// Docker compat: "dead" and "restarting" are valid Docker
+			// container states that have no direct equivalent in Podman.
+			// Accept them without error; they will not match any container.
+			if filterValue == "dead" || filterValue == "restarting" {
+				continue
+			}
 			if _, err := define.StringToContainerStatus(filterValue); err != nil {
 				return nil, err
 			}

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -97,6 +97,13 @@ load helpers
     is "${lines[1]}" "stopped" "status=stopped: 2 of 3"
     is "${lines[2]}" "failed"  "status=stopped: 3 of 3"
 
+    # Docker-compat: "dead" and "restarting" are valid filter values that
+    # Podman accepts without error (they just never match any container).
+    run_podman ps -a --filter status=dead --format '{{.Names}}'
+    is "$output" "" "status=dead: should return no results"
+    run_podman ps -a --filter status=restarting --format '{{.Names}}'
+    is "$output" "" "status=restarting: should return no results"
+
     # ID filtering: if filter is only hex chars, it's a prefix; if it has
     # anything else, it's a regex
     run_podman rm created


### PR DESCRIPTION
The API documentation lists \"dead\" and \"restarting\" as valid status filter values, but both return a 500 error:

```
unknown container state: dead: invalid argument
unknown container state: restarting: invalid argument
```

Podman has no internal state equivalent to Docker's dead or restarting states, so containers will never match these filters. The fix is to accept them without error rather than reject the request — callers get an empty list instead of a 500.

The validation loop in `GenerateContainerFilterFuncs` now skips the `StringToContainerStatus` check for these two Docker-compat values. The filter closure itself needs no change since neither "dead" nor "restarting" will ever match a Podman container state string.

A bats test was added to `040-ps.bats` to verify both values are accepted and return empty results.

Fixes #28904