### PR TITLE
libpod: accept "dead" and "restarting" in container status filter

### DIFF
--- a/libpod/define/containerstate.go
+++ b/libpod/define/containerstate.go
@@ -91,6 +91,13 @@ func StringToContainerStatus(status string) (ContainerStatus, error) {
 		return ContainerStateRemoving, nil
 	case ContainerStateStopping.String():
 		return ContainerStateStopping, nil
+	case "dead":
+		// Docker compatibility: "dead" is equivalent to "exited"
+		return ContainerStateExited, nil
+	case "restarting":
+		// Docker compatibility: "restarting" maps to "stopping" as
+		// Podman does not have a dedicated restarting state
+		return ContainerStateStopping, nil
 	default:
 		return ContainerStateUnknown, fmt.Errorf("unknown container state: %s: %w", status, ErrInvalidArg)
 	}


### PR DESCRIPTION
## Does this PR fix an issue?

Fixes #28904

## Description

The API documentation states that the `status` filter accepts `dead` and `restarting` (matching Docker API behavior), but `StringToContainerStatus` did not recognize these values, returning a 500 error with `unknown container state`.

## Changes

Add Docker-compatible aliases in `libpod/define/containerstate.go`:
- `"dead"` → `ContainerStateExited` (Docker uses "dead" for containers that failed to be removed)
- `"restarting"` → `ContainerStateStopping` (Podman has no dedicated restarting state; stopping is the closest equivalent)

## How to verify

```bash
curl --unix-socket /run/podman/podman.sock "http://d/v5/libpod/containers/json?filters={%22status%22:[%22dead%22]}"
# Should return [] instead of 500 error
```