### PR TITLE
test/e2e: split cli tmpdir from per test tempdir

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -69,7 +69,7 @@ type PodmanTestIntegration struct {
 	SignaturePolicyPath string
 	CgroupManager       string
 	Host                HostOS
-	TmpDir              string
+	CliTmpDir           string // value of podman --tmpdir
 }
 
 var (
@@ -363,11 +363,15 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 		}
 	}
 
+	perTestTempDir := filepath.Join(tempDir, "ptemp")
+	err := os.Mkdir(perTestTempDir, 0o755)
+	Expect(err).ToNot(HaveOccurred())
+
 	p := &PodmanTestIntegration{
 		PodmanTest: PodmanTest{
 			PodmanBinary:       podmanBinary,
 			RemotePodmanBinary: podmanRemoteBinary,
-			TempDir:            tempDir,
+			TempDir:            perTestTempDir,
 			RemoteTest:         target != PodmanTestCreateUtilTargetLocal,
 			ImageCacheFS:       storageFs,
 			ImageCacheDir:      ImageCacheDir,
@@ -376,7 +380,7 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 		ConmonBinary:        conmonBinary,
 		QuadletBinary:       quadletBinary,
 		Root:                root,
-		TmpDir:              tempDir,
+		CliTmpDir:           filepath.Join(tempDir, "clitmp"),
 		NetworkConfigDir:    networkConfigDir,
 		OCIRuntime:          ociRuntime,
 		RunRoot:             filepath.Join(tempDir, "runroot"),
@@ -1417,7 +1421,7 @@ func (p *PodmanTestIntegration) makeOptions(args []string, options PodmanExecOpt
 		"--conmon", p.ConmonBinary,
 		"--network-config-dir", p.NetworkConfigDir,
 		"--cgroup-manager", p.CgroupManager,
-		"--tmpdir", p.TmpDir,
+		"--tmpdir", p.CliTmpDir,
 		"--events-backend", eventsType,
 	)
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1551,11 +1551,8 @@ func (s *PodmanSessionIntegration) jq(jqCommand string) (string, error) {
 }
 
 func (p *PodmanTestIntegration) buildImage(dockerfile, imageName string, layers string, label string, extraOptions []string) string {
-	buildDir := filepath.Join(p.TempDir, "build"+stringid.GenerateRandomID())
-	err := os.Mkdir(buildDir, 0o755)
-	Expect(err).ToNot(HaveOccurred())
-	dockerfilePath := filepath.Join(buildDir, "Dockerfile-"+stringid.GenerateRandomID())
-	err = os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644)
+	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile-"+stringid.GenerateRandomID())
+	err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o755)
 	Expect(err).ToNot(HaveOccurred())
 	cmd := []string{"build", "--pull-never", "--layers=" + layers, "--file", dockerfilePath}
 	if label != "" {
@@ -1567,7 +1564,7 @@ func (p *PodmanTestIntegration) buildImage(dockerfile, imageName string, layers 
 	if len(extraOptions) > 0 {
 		cmd = append(cmd, extraOptions...)
 	}
-	cmd = append(cmd, buildDir)
+	cmd = append(cmd, p.TempDir)
 	session := p.Podman(cmd)
 	session.Wait(240)
 	Expect(session).Should(Exit(0), fmt.Sprintf("BuildImage session output: %q", session.OutputToString()))

--- a/test/e2e/container_create_volume_test.go
+++ b/test/e2e/container_create_volume_test.go
@@ -10,17 +10,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "go.podman.io/podman/v6/test/utils"
-	"go.podman.io/storage/pkg/stringid"
 )
 
 func buildDataVolumeImage(pTest *PodmanTestIntegration, image, data, dest string) {
-	buildDir := filepath.Join(pTest.TempDir, "build"+stringid.GenerateRandomID())
-	err := os.Mkdir(buildDir, 0o755)
-	Expect(err).ToNot(HaveOccurred())
-
 	// Create a dummy file for data volume
-	dummyFile := filepath.Join(buildDir, data)
-	err = os.WriteFile(dummyFile, []byte(data), 0o644)
+	dummyFile := filepath.Join(pTest.TempDir, data)
+	err := os.WriteFile(dummyFile, []byte(data), 0o644)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create a data volume container image but no CMD binary in it
@@ -28,11 +23,7 @@ func buildDataVolumeImage(pTest *PodmanTestIntegration, image, data, dest string
 CMD doesnotexist.sh
 ADD %s %s/
 VOLUME %s/`, data, dest, dest)
-
-	containerFilePath := filepath.Join(buildDir, "Containerfile")
-	err = os.WriteFile(containerFilePath, []byte(containerFile), 0o644)
-	Expect(err).ToNot(HaveOccurred())
-	pTest.PodmanExitCleanly("build", "--pull-never", "-q", "-t", image, "--layers=false", "--file", containerFilePath)
+	pTest.BuildImage(containerFile, image, "false")
 }
 
 func createContainersConfFile(pTest *PodmanTestIntegration) {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -133,7 +133,7 @@ func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
 		"--conmon", p.ConmonBinary,
 		"--network-config-dir", networkDir,
 		"--cgroup-manager", p.CgroupManager,
-		"--tmpdir", p.TmpDir,
+		"--tmpdir", p.CliTmpDir,
 		"--events-backend", "file",
 	}
 

--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -38,12 +38,12 @@ var _ = Describe("Podman mount", func() {
 		opts := podmanTest.PodmanMakeOptions([]string{"mount", cid}, PodmanExecOptions{})
 		args = append(args, opts...)
 
-		// container root file system location is podmanTest.TempDir/...
-		// because "--root podmanTest.TempDir/..."
+		// container root file system location is podmanTest.Root/...
+		// because "--root podmanTest.Root/..."
 		session := podmanTest.Podman(args)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.TempDir))
+		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.Root))
 	})
 
 	It("podman image mount", func() {
@@ -61,11 +61,11 @@ var _ = Describe("Podman mount", func() {
 		opts := podmanTest.PodmanMakeOptions([]string{"image", "mount", CITEST_IMAGE}, PodmanExecOptions{})
 		args = append(args, opts...)
 
-		// image location is podmanTest.TempDir/... because "--root podmanTest.TempDir/..."
+		// image location is podmanTest.Root/... because "--root podmanTest.Root/..."
 		session := podmanTest.Podman(args)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.TempDir))
+		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.Root))
 
 		// We have to unmount the image again otherwise we leak the tmpdir
 		// as active mount points cannot be removed.

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5694,7 +5694,7 @@ spec:
 
 		playKube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
 		playKube.WaitWithDefaultTimeout()
-		Expect(playKube).Should(ExitWithError(125, fmt.Sprintf("securejoin.OpenInRoot testing/onlythis: openat2 %s/root/volumes/testvol/_data/testing/onlythis: no such file or directory", podmanTest.TempDir)))
+		Expect(playKube).Should(ExitWithError(125, fmt.Sprintf("securejoin.OpenInRoot testing/onlythis: openat2 %s/volumes/testvol/_data/testing/onlythis: no such file or directory", podmanTest.Root)))
 	})
 
 	It("with unsafe hostPath subpaths", func() {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -20,7 +20,6 @@ import (
 	"go.podman.io/common/pkg/sysinfo"
 	"go.podman.io/podman/v6/pkg/util"
 	. "go.podman.io/podman/v6/test/utils"
-	"go.podman.io/storage/pkg/stringid"
 )
 
 var _ = Describe("Podman pod create", func() {
@@ -176,12 +175,8 @@ var _ = Describe("Podman pod create", func() {
 
 	Describe("podman create pod with --hosts-file", func() {
 		BeforeEach(func() {
-			buildDir := filepath.Join(podmanTest.TempDir, "build"+stringid.GenerateRandomID())
-			err := os.Mkdir(buildDir, 0o755)
-			Expect(err).ToNot(HaveOccurred())
-
-			imageHosts := filepath.Join(buildDir, "pause_hosts")
-			err = os.WriteFile(imageHosts, []byte("56.78.12.34 image.example.com"), 0o755)
+			imageHosts := filepath.Join(podmanTest.TempDir, "pause_hosts")
+			err := os.WriteFile(imageHosts, []byte("56.78.12.34 image.example.com"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			configHosts := filepath.Join(podmanTest.TempDir, "hosts")
@@ -196,16 +191,11 @@ var _ = Describe("Podman pod create", func() {
 				podmanTest.RestartRemoteService()
 			}
 
-			containerfile := strings.Join([]string{
+			dockerfile := strings.Join([]string{
 				`FROM ` + INFRA_IMAGE,
 				`COPY pause_hosts /etc/hosts`,
 			}, "\n")
-
-			containerFilePath := filepath.Join(buildDir, "Containerfile")
-			err = os.WriteFile(containerFilePath, []byte(containerfile), 0o644)
-			Expect(err).ToNot(HaveOccurred())
-
-			podmanTest.PodmanExitCleanly("build", "-q", "-t", "foobar.com/hosts_test_pause:latest", "--layers=false", "--no-hosts", buildDir)
+			podmanTest.BuildImage(dockerfile, "foobar.com/hosts_test_pause:latest", "false", "--no-hosts")
 		})
 
 		It("--hosts-file=path", func() {

--- a/test/e2e/pull_chunked_test.go
+++ b/test/e2e/pull_chunked_test.go
@@ -69,18 +69,11 @@ func pullChunkedTests() { // included in pull_test.go, must use a Ginkgo DSL at 
 					registryRef: pullChunkedRegistryPrefix + "chunked-normal",
 					dirPath:     filepath.Join(imageDir, "chunked-normal"),
 				}
-
-				buildDir := filepath.Join(podmanTest.TempDir, "build")
-				err := os.Mkdir(buildDir, 0o755)
-				Expect(err).ToNot(HaveOccurred())
 				chunkedNormalContentPath := "chunked-normal-image-content"
-				err = os.WriteFile(filepath.Join(buildDir, chunkedNormalContentPath), fmt.Appendf(nil, "content-%d", rand.Int64()), 0o600)
+				err := os.WriteFile(filepath.Join(podmanTest.TempDir, chunkedNormalContentPath), fmt.Appendf(nil, "content-%d", rand.Int64()), 0o600)
 				Expect(err).NotTo(HaveOccurred())
 				chunkedNormalContainerFile := fmt.Sprintf("FROM scratch\nADD %s /content", chunkedNormalContentPath)
-				err = os.WriteFile(filepath.Join(buildDir, "Containerfile"), []byte(chunkedNormalContainerFile), 0o600)
-				Expect(err).NotTo(HaveOccurred())
-				podmanTest.PodmanExitCleanly("build", "-q", "-t", chunkedNormal.localTag(), "--layers=true", buildDir)
-
+				podmanTest.BuildImage(chunkedNormalContainerFile, chunkedNormal.localTag(), "true")
 				podmanTest.PodmanExitCleanly("push", "-q", "--tls-verify=false", "--force-compression", "--compression-format=zstd:chunked", chunkedNormal.localTag(), chunkedNormal.registryRef)
 				skopeo := SystemExec("skopeo", []string{"copy", "-q", "--preserve-digests", "--all", "--src-tls-verify=false", chunkedNormal.registryRef, "dir:" + chunkedNormal.dirPath})
 				skopeo.WaitWithDefaultTimeout()

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with conflicting volumes errors", func() {
-		mountPath := filepath.Join(podmanTest.TmpDir, "secrets")
+		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"run", "-v", mountPath + ":" + dest, "-v", "/tmp" + ":" + dest, ALPINE, "ls"})

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -67,7 +67,7 @@ type PodmanTest struct {
 	RemoteTLSClientKeyFile  string
 	RemoteTLSDetails        string
 	RemoteTest              bool
-	TempDir                 string
+	TempDir                 string // TempDir is a unique per test directory.
 }
 
 // PodmanSession wraps the gexec.session so we can extend it


### PR DESCRIPTION

Right now the tmpdir for the test and cli are are the same and worse the
root/runroot directories are subdirectories of the tmpdir so tests can
create conflicting files.

Also for rootless remote builds this cuases problems for all tests which
uses the main tmpdir as context dir as they then try to copy the storage
files with different uids which will fail. Commit https://github.com/podman-container-tools/podman/commit/79e7b0f6fd1fb73e05dc966ea365cfbfa768e7d8 tried to
work around it but it is not enough as much more tests use this pattern.

So to fix this once and for all properly separate them.

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
