### PR TITLE
test/system: Fix "command not found" with wait builtin

### DIFF
--- a/test/system/272-system-connection.bats
+++ b/test/system/272-system-connection.bats
@@ -144,7 +144,7 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true[ ]\+true" \
 
     # Stop server. Use 'run' to avoid failing on nonzero exit status
     run kill $_SERVICE_PID
-    run wait $_SERVICE_PID
+    wait $_SERVICE_PID || true
     _SERVICE_PID=
 
     run_podman system connection rm fakeconnect
@@ -205,7 +205,7 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true[ ]\+true" \
 
     # Stop server. Use 'run' to avoid failing on nonzero exit status
     run kill $_SERVICE_PID
-    run wait $_SERVICE_PID
+    wait $_SERVICE_PID || true
     _SERVICE_PID=
 
     run_podman system connection rm fakeconnect
@@ -270,7 +270,7 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true[ ]\+true" \
 
     # Stop server. Use 'run' to avoid failing on nonzero exit status
     run kill $_SERVICE_PID
-    run wait $_SERVICE_PID
+    wait $_SERVICE_PID || true
     _SERVICE_PID=
 
     run_podman system connection rm fakeconnect


### PR DESCRIPTION
Only on Fedora there's a `/bin/wait` shell script that calls Bash's builtin(1).  This is not the case of openSUSE Tumbleweed with the same Bash version and Debian 13.  Otherwise we get errors from bats like:

BW01: `run`'s command `wait 872594` exited with code 127, indicating 'Command not found'. Use run's return code checks, e.g. `run -127`, to fix this message.  See https://openqa.opensuse.org/tests/6018683/file/serial_terminal_user.txt

Replace `run wait` with `wait || true` like it's done in other tests.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
