### PR TITLE
update "No New Tests" PR filter list

### DIFF
--- a/hack/ci/pr-should-include-tests
+++ b/hack/ci/pr-should-include-tests
@@ -23,25 +23,13 @@ fi
 
 # Nothing changed under test subdirectory.
 #
-# This is OK if the only files being touched are "safe" ones.
+# This is OK if no source code files were changed.
+# Also we allow vendor updated without tests so exclude the vendor files
+# and also the version files so release PRs do not need tests.
 filtered_changes=$(git diff --name-only $base $head |
-    grep -F -vx .cirrus.yml |
-    grep -F -vx .pre-commit-config.yaml |
-    grep -F -vx .gitignore |
-    grep -F -vx go.mod |
-    grep -F -vx go.sum |
-    grep -F -vx podman.spec.rpkg |
-    grep -F -vx .golangci.yml |
-    grep -F -vx winmake.ps1 |
-    grep -E -v '/*Makefile$' |
-    grep -E -v '^[^/]+\.md$' |
-    grep -E -v '^.github' |
-    grep -E -v '^contrib/' |
-    grep -E -v '^docs/' |
-    grep -E -v '^hack/' |
-    grep -E -v '^nix/' |
-    grep -E -v '^vendor/' |
-    grep -E -v '^version/')
+    grep -E -v '^(test/tools/)?vendor/' |
+    grep -E -v '^version/' |
+    grep -E -x '.*\.(go|c|h)')
 if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi


### PR DESCRIPTION
For a while now we trigger CI tests based on if source files, i.e. *.go files were changed. The "No New Tests" filter however checked something else via a exclude list that was not being updated.

That means in many cases we needed to add the label when it is clear that these thing should not need tests, i.e. packit or rpm/ changes. To avoid the manual updates of all directories just grep for source files.

Fixes: #28849


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
