### PR TITLE
Add new subprojects

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,9 +23,12 @@ This document defines the governance of the Podman Project, including its subpro
 
 # Subprojects
 
-The Podman project currently consists of the Podman project (the repository containing this file) and two subprojects:
-* [Buildah](https://github.com/containers/buildah)
-* [Skopeo](https://github.com/containers/skopeo/)
+The Podman project currently consists of the Podman project (the repository containing this file) and several subprojects:
+* [Buildah](https://github.com/podman-container-tools/buildah)
+* [Skopeo](https://github.com/podman-container-tools/skopeo/)
+* [container-libs](https://github.com/podman-container-tools/container-libs)
+* [podman-machine-os](https://github.com/podman-container-tools/podman-machine-os)
+* [automation](https://github.com/podman-container-tools/automation)
 
 ## Adding Subprojects
 


### PR DESCRIPTION
As part of our move into the podman-container-tools org and our migration to GH Actions CI, we moved several additional repositories into the Podman Container Tools CNCF project. These include container-libs (core libraries used by Podman and CRI-O), podman-machine-os (builds OS images used by `podman machine`), and automation (tools and scripts for maintaining our CI). All of these went through the subproject process documented in our governance and are now subprojects, so let's get them listed in the governance.

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
NONE
```
