### PR TITLE
validate: disable golangci-lint cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           version: ${{ steps.gv.outputs.version }}
           install-only: true
+          skip-cache: true # cache causes flaky results https://github.com/podman-container-tools/podman/issues/28893
 
       - name: Install pre-commit
         run: pipx install pre-commit


### PR DESCRIPTION
Something with the cache is not working right and results in inconsistent lint result.

Even on PRs where there are no source code changes we observe random failures. I have seen at least 4 different instances since we the new CI setup. It is not reasonable to spot fix each new warning (mostly just adding new nolint comments) each time as it affects all PRs at once. It will also be very confusing for new contributors.

Fixes: #28893

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
