### PR TITLE
add support for ImageVolume option in Podman Quadlet

### DIFF
--- a/docs/source/markdown/options/image-volume.md
+++ b/docs/source/markdown/options/image-volume.md
@@ -1,8 +1,12 @@
 ####> This option file is used in:
-####>   podman create, run
+####>   podman podman-container.unit.5.md.in, create, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
+<< if is_quadlet >>
+### `ImageVolume=mode`
+<< else >>
 #### **--image-volume**=**bind** | *tmpfs* | *ignore*
+<< endif >>
 
 Tells Podman how to handle the builtin image volumes. Default is **bind**.
 

--- a/docs/source/markdown/podman-container.unit.5.md.in
+++ b/docs/source/markdown/podman-container.unit.5.md.in
@@ -76,6 +76,7 @@ Valid options for `[Container]` are listed below:
 | HostName=example.com                 | --hostname example.com                               |
 | HttpProxy=true                       | --http-proxy=true                                    |
 | Image=ubi8                           | Image specification - ubi8                           |
+| ImageVolume=tmpfs                    | --image-volume tmpfs                                 |
 | IP=192.5.0.1                         | --ip 192.5.0.1                                       |
 | IP6=2001:db8::1                      | --ip6 2001:db8::1                                    |
 | Label="XYZ"                          | --label "XYZ"                                        |
@@ -221,6 +222,8 @@ Special Cases:
 
 * If the `name` of the image ends with `.image`, Quadlet will use the image pulled by the corresponding `.image` file, and the generated systemd service contains a dependency on the `$name-image.service` (or the service name set in the .image file). Note that the corresponding `.image` file must exist.
 * If the `name` of the image ends with `.build`, Quadlet will use the image built by the corresponding `.build` file, and the generated systemd service contains a dependency on the `$name-build.service`. Note: the corresponding `.build` file must exist.
+
+@@option quadlet:image-volume
 
 @@option quadlet:ip
 

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -385,6 +385,7 @@ Valid options for `[Container]` are listed below:
 | HostName=example.com                 | --hostname example.com                               |
 | HttpProxy=true                       | --http-proxy=true                                    |
 | Image=ubi8                           | Image specification - ubi8                           |
+| ImageVolume=tmpfs                    | --image-volume tmpfs                                 |
 | IP=192.5.0.1                         | --ip 192.5.0.1                                       |
 | IP6=2001:db8::1                      | --ip6 2001:db8::1                                    |
 | Label="XYZ"                          | --label "XYZ"                                        |
@@ -720,6 +721,11 @@ Special Cases:
 
 * If the `name` of the image ends with `.image`, Quadlet will use the image pulled by the corresponding `.image` file, and the generated systemd service contains a dependency on the `$name-image.service` (or the service name set in the .image file). Note that the corresponding `.image` file must exist.
 * If the `name` of the image ends with `.build`, Quadlet will use the image built by the corresponding `.build` file, and the generated systemd service contains a dependency on the `$name-build.service`. Note: the corresponding `.build` file must exist.
+
+### `ImageVolume=`
+
+Tells Podman how to handle the builtin image volumes. Default is **bind**.
+Equivalent to the Podman `--image-volume` option.
 
 ### `IP=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -119,6 +119,7 @@ const (
 	KeyIgnoreFile            = "IgnoreFile"
 	KeyImage                 = "Image"
 	KeyImageTag              = "ImageTag"
+	KeyImageVolume           = "ImageVolume"
 	KeyInterfaceName         = "InterfaceName"
 	KeyInternal              = "Internal"
 	KeyIP                    = "IP"
@@ -289,6 +290,7 @@ var (
 				KeyIP6:                   true,
 				KeyIP:                    true,
 				KeyImage:                 true,
+				KeyImageVolume:           true,
 				KeyLabel:                 true,
 				KeyLogDriver:             true,
 				KeyLogOpt:                true,
@@ -700,6 +702,7 @@ func ConvertContainer(container *parser.UnitFile, unitsInfoMap map[string]*UnitI
 		KeyMemory:      "--memory",
 		KeyRetry:       "--retry",
 		KeyRetryDelay:  "--retry-delay",
+		KeyImageVolume: "--image-volume",
 	}
 	lookupAndAddString(container, ContainerGroup, stringKeys, podman)
 

--- a/test/e2e/quadlet/image-volume.container
+++ b/test/e2e/quadlet/image-volume.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args --image-volume tmpfs
+
+[Container]
+Image=localhost/imagename
+ImageVolume=tmpfs

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -947,6 +947,7 @@ BOGUS=foo
 		Entry("hostname.container", "hostname.container"),
 		Entry("idmapping.container", "idmapping.container"),
 		Entry("image.container", "image.container"),
+		Entry("image-volume.container", "image-volume.container"),
 		Entry("install.container", "install.container"),
 		Entry("ip.container", "ip.container"),
 		Entry("label.container", "label.container"),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### Add native Quadlet support for `podman run --image-volume`.

Adds a new `ImageVolume=` key to the `[Container]` section of Quadlet
`.container` units. It maps directly to the Podman `--image-volume` option
and accepts `bind`, `tmpfs`, or `ignore` (default `bind`).

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Quadlet `.container` units now support a native `ImageVolume=` key in the `[Container]` section, equivalent to the `podman run --image-volume` option (bind/tmpfs/ignore).
```

Fixes #28875 