### PR TITLE
kube play: validate duplicate hostPort bindings across containers

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -87,7 +87,10 @@ func ToPodOpt(_ context.Context, podName string, p entities.PodCreateOptions, pu
 		}
 		p.Net.AddHosts = hosts
 	}
-	podPorts := getPodPorts(podYAML.Spec.Containers, publishAllPorts)
+	podPorts, err := getPodPorts(podYAML.Spec.Containers, publishAllPorts)
+	if err != nil {
+		return p, err
+	}
 	p.Net.PublishPorts = podPorts
 
 	if dnsConfig := podYAML.Spec.DNSConfig; dnsConfig != nil {
@@ -1299,9 +1302,20 @@ func getContainerResources(container v1.Container) (v1.ResourceRequirements, err
 }
 
 // getPodPorts converts a slice of kube container descriptions to an
-// array of portmapping
-func getPodPorts(containers []v1.Container, publishAll bool) []types.PortMapping {
+// array of portmapping.
+// It returns an error if two containers in the same pod bind to the
+// same host port (same hostIP + hostPort + protocol combination).
+func getPodPorts(containers []v1.Container, publishAll bool) ([]types.PortMapping, error) {
+	type portKey struct {
+		hostIP   string
+		hostPort int32
+		protocol string
+	}
+
 	var infraPorts []types.PortMapping
+	// Track which container claimed each (hostIP, hostPort, protocol) tuple.
+	usedPorts := make(map[portKey]string)
+
 	for _, container := range containers {
 		for _, p := range container.Ports {
 			if p.HostPort != 0 && p.ContainerPort == 0 {
@@ -1322,9 +1336,18 @@ func getPodPorts(containers []v1.Container, publishAll bool) []types.PortMapping
 			// only hostPort is utilized in podman context, all container ports
 			// are accessible inside the shared network namespace
 			if p.HostPort != 0 {
+				key := portKey{
+					hostIP:   p.HostIP,
+					hostPort: p.HostPort,
+					protocol: strings.ToLower(string(p.Protocol)),
+				}
+				if prev, exists := usedPorts[key]; exists {
+					return nil, fmt.Errorf("containers %q and %q both bind to host port %d/%s", prev, container.Name, p.HostPort, strings.ToLower(string(p.Protocol)))
+				}
+				usedPorts[key] = container.Name
 				infraPorts = append(infraPorts, portBinding)
 			}
 		}
 	}
-	return infraPorts
+	return infraPorts, nil
 }

--- a/pkg/specgen/generate/kube/kube_test.go
+++ b/pkg/specgen/generate/kube/kube_test.go
@@ -59,14 +59,16 @@ func TestGetPodPorts(t *testing.T) {
 			HostPort: 5004,
 		}},
 	}
-	r := getPodPorts([]v1.Container{c1, c2}, false)
+	r, err := getPodPorts([]v1.Container{c1, c2}, false)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(r))
 	assert.Equal(t, uint16(5001), r[0].ContainerPort)
 	assert.Equal(t, uint16(5002), r[0].HostPort)
 	assert.Equal(t, uint16(5004), r[1].ContainerPort)
 	assert.Equal(t, uint16(5004), r[1].HostPort)
 
-	r = getPodPorts([]v1.Container{c1, c2}, true)
+	r, err = getPodPorts([]v1.Container{c1, c2}, true)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, len(r))
 	assert.Equal(t, uint16(5000), r[0].ContainerPort)
 	assert.Equal(t, uint16(5000), r[0].HostPort)
@@ -74,6 +76,43 @@ func TestGetPodPorts(t *testing.T) {
 	assert.Equal(t, uint16(5002), r[1].HostPort)
 	assert.Equal(t, uint16(5004), r[2].ContainerPort)
 	assert.Equal(t, uint16(5004), r[2].HostPort)
+}
+
+func TestGetPodPortsDuplicateHostPort(t *testing.T) {
+	c1 := v1.Container{
+		Name: "nginx-1",
+		Ports: []v1.ContainerPort{{
+			ContainerPort: 80,
+			HostPort:      8077,
+		}},
+	}
+	c2 := v1.Container{
+		Name: "nginx-2",
+		Ports: []v1.ContainerPort{{
+			ContainerPort: 80,
+			HostPort:      8077,
+		}},
+	}
+
+	// Same hostPort on two containers must produce an error.
+	_, err := getPodPorts([]v1.Container{c1, c2}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nginx-1")
+	assert.Contains(t, err.Error(), "nginx-2")
+	assert.Contains(t, err.Error(), "8077")
+
+	// Different hostPorts must succeed.
+	c2.Ports[0].HostPort = 8078
+	r, err := getPodPorts([]v1.Container{c1, c2}, false)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(r))
+
+	// Same hostPort but different protocols must succeed.
+	c2.Ports[0].HostPort = 8077
+	c2.Ports[0].Protocol = "udp"
+	r, err = getPodPorts([]v1.Container{c1, c2}, false)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(r))
 }
 
 func TestGetPortNumber(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

When multiple containers in a pod YAML specify the same hostPort, podman kube play previously accepted the YAML and started the containers, causing one of them to fail at runtime with a confusing bind() error.

Add early validation in `getPodPorts()` to detect duplicate `(hostIP, hostPort, protocol)` tuples across containers and return a clear error message naming both conflicting containers.

Fixes: https://github.com/podman-container-tools/podman/issues/26622

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
kube play now validates that containers in the same pod do not bind to the same host port, returning a clear error message naming the conflicting containers instead of failing silently at runtime.
```