### PR TITLE
kube: fix quantityToInt64 dropping scale for fractional BinarySI

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -294,10 +294,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	// but apply to the containers with the prefixed name
 	s.SeccompProfilePath = opts.SeccompPaths.FindForContainer(opts.Container.Name)
 
-	err = setupContainerResources(s, opts.Container)
-	if err != nil {
-		return nil, fmt.Errorf("failed to configure container resources: %w", err)
-	}
+	setupContainerResources(s, opts.Container)
 
 	err = setupContainerDevices(s, opts.Container)
 	if err != nil {
@@ -881,7 +878,7 @@ func makeHealthCheck(inCmd string, interval int32, retries int32, timeout int32,
 	return &hc, nil
 }
 
-func setupContainerResources(s *specgen.SpecGenerator, containerYAML v1.Container) error {
+func setupContainerResources(s *specgen.SpecGenerator, containerYAML v1.Container) {
 	s.ResourceLimits = &spec.LinuxResources{}
 	milliCPU := containerYAML.Resources.Limits.Cpu().MilliValue()
 	if milliCPU > 0 {
@@ -892,15 +889,9 @@ func setupContainerResources(s *specgen.SpecGenerator, containerYAML v1.Containe
 		}
 	}
 
-	limit, err := quantityToInt64(containerYAML.Resources.Limits.Memory())
-	if err != nil {
-		return fmt.Errorf("failed to set memory limit: %w", err)
-	}
+	limit := quantityToInt64(containerYAML.Resources.Limits.Memory())
 
-	memoryRes, err := quantityToInt64(containerYAML.Resources.Requests.Memory())
-	if err != nil {
-		return fmt.Errorf("failed to set memory reservation: %w", err)
-	}
+	memoryRes := quantityToInt64(containerYAML.Resources.Requests.Memory())
 
 	if limit > 0 || memoryRes > 0 {
 		s.ResourceLimits.Memory = &spec.LinuxMemory{}
@@ -913,8 +904,6 @@ func setupContainerResources(s *specgen.SpecGenerator, containerYAML v1.Containe
 	if memoryRes > 0 {
 		s.ResourceLimits.Memory.Reservation = &memoryRes
 	}
-
-	return nil
 }
 
 const PodmanDeviceResourcePrefix = "io.podman/device"
@@ -1036,16 +1025,14 @@ func setupSecurityContext(s *specgen.SpecGenerator, securityContext *v1.Security
 	}
 }
 
-func quantityToInt64(quantity *resource.Quantity) (int64, error) {
+func quantityToInt64(quantity *resource.Quantity) int64 {
 	if i, ok := quantity.AsInt64(); ok {
-		return i, nil
+		return i
 	}
 
-	if i, ok := quantity.AsDec().Unscaled(); ok {
-		return i, nil
-	}
-
-	return 0, fmt.Errorf("quantity cannot be represented as int64: %v", quantity)
+	// Value() properly accounts for the decimal scale, unlike
+	// AsDec().Unscaled() which silently drops it.
+	return quantity.Value()
 }
 
 // read a k8s secret in JSON/YAML format from the secret manager

--- a/pkg/specgen/generate/kube/kube_test.go
+++ b/pkg/specgen/generate/kube/kube_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/api/resource"
 	"go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -136,4 +137,46 @@ func TestGetPortNumber(t *testing.T) {
 	i, e = getPortNumber(portSpec, []v1.ContainerPort{cp1, cp2})
 	assert.NoError(t, e)
 	assert.Equal(t, i, 6000)
+}
+
+func TestQuantityToInt64(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int64
+	}{
+		{
+			name:     "integer BinarySI",
+			input:    "1536Mi",
+			expected: 1536 * 1024 * 1024,
+		},
+		{
+			name:     "fractional BinarySI",
+			input:    "1.5Gi",
+			expected: 1536 * 1024 * 1024,
+		},
+		{
+			name:     "larger fractional BinarySI",
+			input:    "2.5Gi",
+			expected: 2560 * 1024 * 1024,
+		},
+		{
+			name:     "fractional DecimalSI",
+			input:    "1.5G",
+			expected: 1500000000,
+		},
+		{
+			name:     "zero",
+			input:    "0",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := resource.MustParse(tt.input)
+			got := quantityToInt64(&q)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
 }

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -4274,6 +4274,28 @@ MemoryReservation: {{ .HostConfig.MemoryReservation }}`)
 		Expect(inspect.OutputToString()).To(ContainSubstring("Memory: " + expectedMemoryLimit))
 	})
 
+	It("allows setting fractional BinarySI memory limits", func() {
+		SkipIfContainerized("Resource limits require a running systemd")
+		podmanTest.CgroupManager = "systemd"
+
+		pod := getPod(withCtr(getCtr(
+			withMemoryLimit("1.5Gi"),
+			withMemoryRequest("1.5Gi"),
+		)))
+		err := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+
+		inspect := podmanTest.PodmanExitCleanly("inspect", getCtrNameInPod(pod), "--format", `
+Memory: {{ .HostConfig.Memory }}
+MemoryReservation: {{ .HostConfig.MemoryReservation }}`)
+		Expect(inspect.OutputToString()).To(ContainSubstring("Memory: 1610612736"))
+		Expect(inspect.OutputToString()).To(ContainSubstring("MemoryReservation: 1610612736"))
+	})
+
 	It("allows setting resource limits with --cpus 1", func() {
 		SkipIfContainerized("Resource limits require a running systemd")
 		SkipIfRootless("CPU limits require root")


### PR DESCRIPTION
Replace `AsDec().Unscaled()` with `Quantity.Value()` in `quantityToInt64()`, which properly handles the decimal scale. Remove the now-unused error returns from `quantityToInt64` and `setupContainerResources`. Add unit tests for fractional BinarySI inputs.

Fixes: #28789

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed `podman kube play` setting incorrect memory limits for fractional BinarySI quantities (e.g. `1.5Gi`).
```
