### PR TITLE
docs: clarify partial vs lazy pulling of images

### DIFF
--- a/docs/tutorials/performance.md
+++ b/docs/tutorials/performance.md
@@ -180,9 +180,9 @@ $ podman info -f '{{.Host.RootlessNetworkCmd}}'
 pasta
 ```
 
-### Lazy pulling of container images
+### Partial pulling of container images
 
-Podman supports lazy pulling for the following container image formats:
+Podman supports partial pulling for the following container image formats:
 
 * __zstd:chunked__
 
@@ -190,11 +190,13 @@ Podman supports lazy pulling for the following container image formats:
 
 __zstd:chunked__ has better performance than __eStargz__.
 
+Partial pulling downloads only the layer contents that are missing locally, but the image is still fully pulled before its containers run. Lazy pulling, where the image is mounted before it is fully downloaded, is out of scope for Podman itself and requires an additional snapshotter such as the [stargz-snapshotter](https://github.com/containerd/stargz-snapshotter) configured as an additional layer store.
+
 See the article [_Pull container images faster with partial pulls_](https://www.redhat.com/sysadmin/faster-container-image-pulls) by Giuseppe Scrivano and Dan Walsh.
 
 ### Choosing a host file system
 
-Lazy pulling of container images can run more efficiently when the file system has reflink support. The file systems XFS and BTRFS have reflink support.
+Partial pulling of container images can run more efficiently when the file system has reflink support. The file systems XFS and BTRFS have reflink support.
 
 ### Option --log-driver
 


### PR DESCRIPTION
Podman's built-in `zstd:chunked` / eStargz support is documented as "lazy pulling", but on its own Podman only does *partial* pulling — the image is still fully pulled before a container runs. This renames it to "partial pulling" and adds a short note on the difference, per @giuseppe on the issue.

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits (`git commit -s`).
- [x] Referenced issues using `Fixes: #24947` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
