### PR TITLE
fix: rename ManifestAddArtifactOptions.Annotations to ArtifactAnnotations

### DIFF
--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -674,14 +674,14 @@ func ManifestModify(w http.ResponseWriter, r *http.Request) {
 			// We waited until after the extraction goroutine finished to ensure
 			// that we'd pick up its changes to the ArtifactFiles list.
 			manifestAddArtifactOptions := entities.ManifestAddArtifactOptions{
-				Type:          body.ArtifactType,
-				LayerType:     body.ArtifactLayerType,
-				ConfigType:    body.ArtifactConfigType,
-				Config:        body.ArtifactConfig,
-				ExcludeTitles: body.ArtifactExcludeTitles,
-				Annotations:   body.ArtifactAnnotations,
-				Subject:       body.ArtifactSubject,
-				Files:         body.ArtifactFiles,
+				Type:                body.ArtifactType,
+				LayerType:           body.ArtifactLayerType,
+				ConfigType:          body.ArtifactConfigType,
+				Config:              body.ArtifactConfig,
+				ExcludeTitles:       body.ArtifactExcludeTitles,
+				ArtifactAnnotations: body.ArtifactAnnotations,
+				Subject:             body.ArtifactSubject,
+				Files:               body.ArtifactFiles,
 			}
 			id, err := imageEngine.ManifestAddArtifact(r.Context(), name, body.ArtifactFiles, manifestAddArtifactOptions)
 			if err != nil {

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -53,14 +53,15 @@ type ManifestAddOptions struct {
 type ManifestAddArtifactOptions struct {
 	ManifestAnnotateOptions
 	// Note to future maintainers: keep these fields synchronized with ManifestModifyOptions!
-	Type          *string           `json:"artifact_type" schema:"artifact_type"`
-	LayerType     string            `json:"artifact_layer_type" schema:"artifact_layer_type"`
-	ConfigType    string            `json:"artifact_config_type" schema:"artifact_config_type"`
-	Config        string            `json:"artifact_config" schema:"artifact_config"`
-	ExcludeTitles bool              `json:"artifact_exclude_titles" schema:"artifact_exclude_titles"`
-	Annotations   map[string]string `json:"artifact_annotations" schema:"artifact_annotations"`
-	Subject       string            `json:"artifact_subject" schema:"artifact_subject"`
-	Files         []string          `json:"artifact_files" schema:"-"`
+	Type          *string `json:"artifact_type" schema:"artifact_type"`
+	LayerType     string  `json:"artifact_layer_type" schema:"artifact_layer_type"`
+	ConfigType    string  `json:"artifact_config_type" schema:"artifact_config_type"`
+	Config        string  `json:"artifact_config" schema:"artifact_config"`
+	ExcludeTitles bool    `json:"artifact_exclude_titles" schema:"artifact_exclude_titles"`
+	// ArtifactAnnotations has a distinct Go name (the tag is unchanged) to avoid a swagger x-go-name collision with the embedded ManifestAnnotateOptions.Annotations.
+	ArtifactAnnotations map[string]string `json:"artifact_annotations" schema:"artifact_annotations"`
+	Subject             string            `json:"artifact_subject" schema:"artifact_subject"`
+	Files               []string          `json:"artifact_files" schema:"-"`
 }
 
 // ManifestAnnotateOptions provides model for annotating manifest list

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -361,7 +361,7 @@ func (ir *ImageEngine) ManifestAddArtifact(ctx context.Context, name string, fil
 		Config:        opts.Config,
 		LayerType:     opts.LayerType,
 		ExcludeTitles: opts.ExcludeTitles,
-		Annotations:   opts.Annotations,
+		Annotations:   opts.ArtifactAnnotations,
 		Subject:       opts.Subject,
 	}
 

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -117,7 +117,7 @@ func (ir *ImageEngine) ManifestAddArtifact(_ context.Context, name string, files
 	options.WithType(opts.Type).WithConfigType(opts.ConfigType).WithLayerType(opts.LayerType)
 	options.WithConfig(opts.Config)
 	options.WithExcludeTitles(opts.ExcludeTitles).WithSubject(opts.Subject)
-	options.WithAnnotations(opts.Annotations)
+	options.WithAnnotations(opts.ArtifactAnnotations)
 	options.WithFiles(files)
 	id, err := manifests.AddArtifact(ir.ClientCtx, name, options)
 	if err != nil {


### PR DESCRIPTION
The artifact-specific `Annotations` field on `ManifestAddArtifactOptions` collided (same swagger `x-go-name`) with the embedded `ManifestAnnotateOptions.Annotations`, so Go clients generated from the spec fail to compile. This renames it to `ArtifactAnnotations` (the name the sibling options struct already uses for that JSON tag); the wire format is unchanged.

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits (`git commit -s`).
- [x] Referenced issues using `Fixes: #22966` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed a duplicate field name in the generated libpod Swagger definition for the manifest add-artifact options, which could break generated API clients.
```
