### PR TITLE
[v5.8] Backport some CI fixes and one regression fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           version: ${{ steps.gv.outputs.version }}
           install-only: true
+          skip-cache: true # cache causes flaky results https://github.com/podman-container-tools/podman/issues/28893
 
       - name: Install pre-commit
         run: pipx install pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,8 +340,15 @@ jobs:
         priv: [rootless, root]
         mode: [local, remote]
         exclude:
-          # try to keep the task somewhat sane and not run remote test rootless
-          - priv: rootless
+          # try to keep the task somewhat sane and exclude all but one rootless+remote combination
+          - distro: fedora-prior
+            priv: rootless
+            mode: remote
+          - distro: fedora-rawhide
+            priv: rootless
+            mode: remote
+          - distro: debian-sid
+            priv: rootless
             mode: remote
         include:
           # Add buildah bud tests, only runs as root for now.

--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )
 
 source "$SCRIPT_DIR/lib.sh"
 
-AUTOMATION_RELEASE="20260520t200858z"
+AUTOMATION_RELEASE="20260616t073924z" # TODO should be renovate managed
 LIMA_VM_NAME=podman-ci
 
 REPO_DIR="$SCRIPT_DIR/../.."

--- a/hack/ci/pr-should-include-tests
+++ b/hack/ci/pr-should-include-tests
@@ -23,25 +23,13 @@ fi
 
 # Nothing changed under test subdirectory.
 #
-# This is OK if the only files being touched are "safe" ones.
-filtered_changes=$(git diff --name-only $base $head        |
-                       grep -F -vx .cirrus.yml             |
-                       grep -F -vx .pre-commit-config.yaml |
-                       grep -F -vx .gitignore              |
-                       grep -F -vx go.mod                  |
-                       grep -F -vx go.sum                  |
-                       grep -F -vx podman.spec.rpkg        |
-                       grep -F -vx .golangci.yml           |
-                       grep -F -vx winmake.ps1             |
-                       grep -E -v  '/*Makefile$'           |
-                       grep -E -v  '^[^/]+\.md$'           |
-                       grep -E -v  '^.github'              |
-                       grep -E -v  '^contrib/'             |
-                       grep -E -v  '^docs/'                |
-                       grep -E -v  '^hack/'                |
-                       grep -E -v  '^nix/'                 |
-                       grep -E -v  '^vendor/'              |
-                       grep -E -v  '^version/')
+# This is OK if no source code files were changed.
+# Also we allow vendor updated without tests so exclude the vendor files
+# and also the version files so release PRs do not need tests.
+filtered_changes=$(git diff --name-only $base $head |
+    grep -E -v '^(test/tools/)?vendor/' |
+    grep -E -v '^version/' |
+    grep -E -x '.*\.(go|c|h)')
 if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -24,7 +24,6 @@ import (
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/archive"
-	"go.podman.io/storage/pkg/chrootarchive"
 )
 
 func (ir *ImageEngine) Exists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
@@ -372,7 +371,7 @@ func (ir *ImageEngine) Save(_ context.Context, nameOrID string, tags []string, o
 		return err
 	}
 
-	return chrootarchive.Untar(f, opts.Output, &archive.TarOptions{NoLchown: true})
+	return archive.Untar(f, opts.Output, &archive.TarOptions{NoLchown: true})
 }
 
 func (ir *ImageEngine) Search(_ context.Context, term string, opts entities.ImageSearchOptions) ([]entities.ImageSearchReport, error) {

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -69,7 +69,7 @@ type PodmanTestIntegration struct {
 	SignaturePolicyPath string
 	CgroupManager       string
 	Host                HostOS
-	TmpDir              string
+	CliTmpDir           string // value of podman --tmpdir
 }
 
 var (
@@ -375,11 +375,15 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 		}
 	}
 
+	perTestTempDir := filepath.Join(tempDir, "ptemp")
+	err := os.Mkdir(perTestTempDir, 0o755)
+	Expect(err).ToNot(HaveOccurred())
+
 	p := &PodmanTestIntegration{
 		PodmanTest: PodmanTest{
 			PodmanBinary:       podmanBinary,
 			RemotePodmanBinary: podmanRemoteBinary,
-			TempDir:            tempDir,
+			TempDir:            perTestTempDir,
 			RemoteTest:         target != PodmanTestCreateUtilTargetLocal,
 			ImageCacheFS:       storageFs,
 			ImageCacheDir:      ImageCacheDir,
@@ -389,7 +393,7 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 		ConmonBinary:        conmonBinary,
 		QuadletBinary:       quadletBinary,
 		Root:                root,
-		TmpDir:              tempDir,
+		CliTmpDir:           filepath.Join(tempDir, "clitmp"),
 		NetworkConfigDir:    networkConfigDir,
 		OCIRuntime:          ociRuntime,
 		RunRoot:             filepath.Join(tempDir, "runroot"),
@@ -1378,7 +1382,7 @@ func (p *PodmanTestIntegration) makeOptions(args []string, options PodmanExecOpt
 	}
 
 	podmanOptions := strings.Split(fmt.Sprintf("%s--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --network-backend %s --cgroup-manager %s --tmpdir %s --events-backend %s --db-backend %s",
-		debug, p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.NetworkConfigDir, p.NetworkBackend.ToString(), p.CgroupManager, p.TmpDir, eventsType, p.DatabaseBackend), " ")
+		debug, p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.NetworkConfigDir, p.NetworkBackend.ToString(), p.CgroupManager, p.CliTmpDir, eventsType, p.DatabaseBackend), " ")
 
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
 	if !options.NoCache {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -123,7 +123,7 @@ func (p *PodmanTestIntegration) StopRemoteService() {
 func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
 	networkDir := p.NetworkConfigDir
 	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --network-backend %s --cgroup-manager %s --tmpdir %s --events-backend %s --db-backend %s",
-		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, networkDir, p.NetworkBackend.ToString(), p.CgroupManager, p.TmpDir, "file", p.DatabaseBackend), " ")
+		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, networkDir, p.NetworkBackend.ToString(), p.CgroupManager, p.CliTmpDir, "file", p.DatabaseBackend), " ")
 
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
 	podmanOptions = append(podmanOptions, args...)

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -63,8 +63,9 @@ var _ = Describe("Podman login and logout", func() {
 			"-e", strings.Join([]string{"REGISTRY_HTTP_ADDR=0.0.0.0", strconv.Itoa(port)}, ":"), "--name", "registry", "-v",
 			strings.Join([]string{authPath, "/auth:Z"}, ":"), "-e", "REGISTRY_AUTH=htpasswd", "-e",
 			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm", "-e", "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
-			"-v", strings.Join([]string{certPath, "/certs:Z"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
-			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", REGISTRY_IMAGE})
+			"-v", strings.Join([]string{certPath, "/certs:z"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
+			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", REGISTRY_IMAGE,
+		})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 

--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -39,12 +39,12 @@ var _ = Describe("Podman mount", func() {
 		opts := podmanTest.PodmanMakeOptions([]string{"mount", cid}, PodmanExecOptions{})
 		args = append(args, opts...)
 
-		// container root file system location is podmanTest.TempDir/...
-		// because "--root podmanTest.TempDir/..."
+		// container root file system location is podmanTest.Root/...
+		// because "--root podmanTest.Root/..."
 		session := podmanTest.Podman(args)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.TempDir))
+		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.Root))
 	})
 
 	It("podman image mount", func() {
@@ -62,11 +62,11 @@ var _ = Describe("Podman mount", func() {
 		opts := podmanTest.PodmanMakeOptions([]string{"image", "mount", CITEST_IMAGE}, PodmanExecOptions{})
 		args = append(args, opts...)
 
-		// image location is podmanTest.TempDir/... because "--root podmanTest.TempDir/..."
+		// image location is podmanTest.Root/... because "--root podmanTest.Root/..."
 		session := podmanTest.Podman(args)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.TempDir))
+		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.Root))
 
 		// We have to unmount the image again otherwise we leak the tmpdir
 		// as active mount points cannot be removed.

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5702,7 +5702,7 @@ spec:
 
 		playKube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
 		playKube.WaitWithDefaultTimeout()
-		Expect(playKube).Should(ExitWithError(125, fmt.Sprintf("securejoin.OpenInRoot testing/onlythis: openat2 %s/root/volumes/testvol/_data/testing/onlythis: no such file or directory", podmanTest.TempDir)))
+		Expect(playKube).Should(ExitWithError(125, fmt.Sprintf("securejoin.OpenInRoot testing/onlythis: openat2 %s/volumes/testvol/_data/testing/onlythis: no such file or directory", podmanTest.Root)))
 	})
 
 	It("with unsafe hostPath subpaths", func() {

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with conflicting volumes errors", func() {
-		mountPath := filepath.Join(podmanTest.TmpDir, "secrets")
+		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"run", "-v", mountPath + ":" + dest, "-v", "/tmp" + ":" + dest, ALPINE, "ls"})

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -86,7 +86,7 @@ type PodmanTest struct {
 	RemoteTLSClientCertFile string
 	RemoteTLSClientKeyFile  string
 	RemoteTest              bool
-	TempDir                 string
+	TempDir                 string // TempDir is a unique per test directory.
 }
 
 // PodmanSession wraps the gexec.session so we can extend it


### PR DESCRIPTION
Backports of
126d3e27ae8ccf3bac170a04895d378c344e79e6
5c189e813620e44f281fb683d275e8cc8d7d0a5f
c8ce2c60895c96e589ab0c836d5f45a7e090fd55
fd07b9c6ec2700932c42793c69159bba2b7214e6
6e20527004a4943a3872f48d00facf5a04b9cbde
1eda0cfbb4159f4b62545b241ba40d68d8cbf07a 


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed an issue that made podman-remote save -f oci-dir/docker-dir fail on linux.
```
