### PR TITLE
libpod: fix netavark DNS for rootful Podman in LXC

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -5,8 +5,10 @@ package libpod
 import (
 	"fmt"
 	"net"
+	"os"
 	"strings"
 
+	"github.com/moby/sys/capability"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -16,6 +18,31 @@ import (
 	"go.podman.io/podman/v6/libpod/define"
 	"go.podman.io/podman/v6/pkg/rootless"
 )
+
+func hasCapNetAdmin() (bool, error) {
+	currentCaps, err := capability.NewPid2(0)
+	if err != nil {
+		return false, err
+	}
+	if err = currentCaps.Load(); err != nil {
+		return false, err
+	}
+	return currentCaps.Get(capability.EFFECTIVE, capability.CAP_NET_ADMIN), nil
+}
+
+func rootfulBridgeNetworkPreflight(hasNetAdmin func() (bool, error)) error {
+	// UID 0 inside a delegated container environment should use rootful
+	// networking semantics; fail clearly if the environment lacks the
+	// capability needed to configure bridge networking.
+	hasCap, err := hasNetAdmin()
+	if err != nil {
+		return fmt.Errorf("checking CAP_NET_ADMIN for rootful netavark bridge networking: %w", err)
+	}
+	if !hasCap {
+		return fmt.Errorf("rootful netavark bridge networking requires CAP_NET_ADMIN in the current environment; Podman is running as root but this capability is not available")
+	}
+	return nil
+}
 
 // Create and configure a new network namespace for a container
 func (r *Runtime) configureNetNS(ctr *Container, ctrNS string) (status map[string]types.StatusBlock, rerr error) {
@@ -44,6 +71,11 @@ func (r *Runtime) configureNetNS(ctr *Container, ctrNS string) (status map[strin
 	// This is effectively forcing net=none.
 	if len(networks) == 0 {
 		return nil, nil
+	}
+	if os.Geteuid() == 0 && !rootless.IsRootless() {
+		if err := rootfulBridgeNetworkPreflight(hasCapNetAdmin); err != nil {
+			return nil, err
+		}
 	}
 
 	netOpts := ctr.getNetworkOptions(networks)

--- a/libpod/networking_linux_test.go
+++ b/libpod/networking_linux_test.go
@@ -3,8 +3,10 @@
 package libpod
 
 import (
+	"errors"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 
 	"go.podman.io/common/libnetwork/types"
@@ -208,6 +210,54 @@ func Test_resultToBasicNetworkConfig(t *testing.T) {
 			if !reflect.DeepEqual(tc.expectedNetworkConfig, actualNetworkConfig) {
 				t.Fatalf(
 					"Expected networkConfig %+v didn't match actual value %+v", tc.expectedNetworkConfig, actualNetworkConfig)
+			}
+		})
+	}
+}
+
+func TestRootfulBridgeNetworkPreflight(t *testing.T) {
+	t.Parallel()
+
+	testErr := errors.New("capability read failed")
+	testCases := []struct {
+		name        string
+		capNetAdmin bool
+		capErr      error
+		expectErr   string
+	}{
+		{
+			name:        "root with CAP_NET_ADMIN is allowed",
+			capNetAdmin: true,
+		},
+		{
+			name:      "root without CAP_NET_ADMIN fails",
+			expectErr: "requires CAP_NET_ADMIN",
+		},
+		{
+			name:      "root capability check error fails",
+			capErr:    testErr,
+			expectErr: "checking CAP_NET_ADMIN",
+		},
+	}
+
+	for _, tcl := range testCases {
+		tc := tcl
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := rootfulBridgeNetworkPreflight(func() (bool, error) {
+				return tc.capNetAdmin, tc.capErr
+			})
+			if tc.expectErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.expectErr)
+			}
+			if !strings.Contains(err.Error(), tc.expectErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.expectErr, err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/podman-container-tools/podman/issues/18783

Dependency support: https://github.com/podman-container-tools/container-libs/pull/932

## Summary

When Podman runs as UID 0 inside a delegated container environment such as Incus/LXC, it should use rootful networking semantics, like it does in a VM. If the environment does not delegate the networking capability needed for rootful bridge setup, Podman should fail clearly before calling netavark instead of producing a container with broken aardvark DNS.

The reported failure mode is especially confusing for netavark/aardvark DNS: Podman can create network status that causes the container resolv.conf to point at aardvark, while aardvark was started through rootless behavior and failed with `systemd-run --user`. The result is a container that appears to start successfully but has broken DNS.

## Behavior change

- UID 0 rootful bridge networking now checks effective `CAP_NET_ADMIN` before calling netavark.
- Non-root/rootless Podman remains on the existing rootless setup path.
- Existing UID 0 startup/runtime behavior is otherwise preserved.

This makes the networking boundary explicit:

- Non-root Podman: rootless networking behavior
- UID 0 with delegated networking capability: rootful bridge networking behavior
- UID 0 without `CAP_NET_ADMIN`: clear error before netavark setup

## Rationale

Incus/LXC containers are guest environments. UID 0 inside the guest should be treated like UID 0 inside a VM for Podman's networking mode selection when the required capability is delegated. If `CAP_NET_ADMIN` is not delegated, silently continuing into netavark can produce partial network/DNS state.

Rootful aardvark startup does not use `systemd-run --user`; that flag is only added by netavark when it is in rootless mode. The dependency PR keeps UID 0 in nested user namespaces on rootful network paths by using the original caller UID for network path selection.

This PR currently has a local `CAP_NET_ADMIN` helper. Once the container-libs dependency PR is merged and vendored, this should be replaced with `unshare.HasCapNetAdmin()`.

## Tests

- `gofmt`
- `git diff --check`
- `GOCACHE=/private/tmp/podman-go-cache go test ./libpod ./pkg/domain/infra/abi`

Note: libpod Linux-only tests are not executed on this macOS workspace; the package reports no test files here.
