### PR TITLE
docs: add redirect from api-static.html to api.html

### DIFF
--- a/docs/source/_static/api-static.html
+++ b/docs/source/_static/api-static.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="refresh" content="0; url=api.html"/>
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    <p>This page has moved to <a href="api.html">api.html</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist
Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #28298` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
Fixes: https://github.com/podman-container-tools/podman/issues/28546
```release-note
Fixed a 404 error when clicking the "view latest stable docs" banner
on old v3.x documentation pages. The banner previously redirected users
to _static/api-static.html on stable, which no longer exists since it
was renamed to api.html in v3.1. A redirect stub has been added so
users are now correctly forwarded to the API documentation.

Note: The ideal fix would be adding a redirect rule directly in the
Read the Docs dashboard (From: /_static/api-static.html, To: /_static/api.html),
as suggested in #28298. However, since RTD dashboard access is required
for that and is limited to project maintainers, this file-based redirect
achieves the same result without needing dashboard access.
```