### PR TITLE
fix: Clarify error message for podman restore without --tcp-established

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1455,6 +1455,11 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 			if ociLog != "" {
 				ociLogData, err := os.ReadFile(ociLog)
 				if err == nil {
+					if errs, err := parseOCIErrors(ociLogData); err == nil {
+						if tcpErr := checkOCIErrorsForTCPEstablished(errs); tcpErr != nil {
+							return -1, tcpErr
+						}
+					}
 					var ociErr ociError
 					if err := json.Unmarshal(ociLogData, &ociErr); err == nil {
 						return -1, getOCIRuntimeError(runtimeName, ociErr.Msg)
@@ -1468,6 +1473,11 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 			if ociLog != "" {
 				ociLogData, err := os.ReadFile(ociLog)
 				if err == nil {
+					if errs, err := parseOCIErrors(ociLogData); err == nil {
+						if tcpErr := checkOCIErrorsForTCPEstablished(errs); tcpErr != nil {
+							return ss.si.Data, tcpErr
+						}
+					}
 					var ociErr ociError
 					if err := json.Unmarshal(ociLogData, &ociErr); err == nil {
 						return ss.si.Data, getOCIRuntimeError(runtimeName, ociErr.Msg)

--- a/libpod/oci_util.go
+++ b/libpod/oci_util.go
@@ -3,6 +3,7 @@
 package libpod
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -28,6 +29,34 @@ type ociError struct {
 	Level string `json:"level,omitempty"`
 	Time  string `json:"time,omitempty"`
 	Msg   string `json:"msg,omitempty"`
+}
+
+func parseOCIErrors(log []byte) ([]ociError, error) {
+	var errs []ociError
+	for _, line := range bytes.Split(log, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var e ociError
+		if err := json.Unmarshal(line, &e); err != nil {
+			return nil, err
+		}
+		errs = append(errs, e)
+	}
+	return errs, nil
+}
+
+// checkOCIErrorsForTCPEstablished tries to match
+// an ociError indicating established TCP connections
+// and convert it to a user-facing message.
+func checkOCIErrorsForTCPEstablished(errs []ociError) error {
+	for _, e := range errs {
+		if strings.Contains(e.Msg, "Connected TCP socket in image") {
+			return fmt.Errorf("checkpoint contains established TCP connections, restore requires --tcp-established or --tcp-close: %w", define.ErrOCIRuntime)
+		}
+	}
+	return nil
 }
 
 // Bind ports to keep them closed on the host

--- a/libpod/oci_util_test.go
+++ b/libpod/oci_util_test.go
@@ -1,0 +1,53 @@
+//go:build !remote && (linux || freebsd)
+
+package libpod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseOCIErrors verifies parsing of multiple ociErrors
+// from a log file.
+func TestParseOCIErrors(t *testing.T) {
+	log := []byte(`{"msg":"(00.022100) Error (criu/sk-inet.c:654): Connected TCP socket in image","level":"error","time":"2025-01-01T00:00:00Z"}
+{"msg":"(00.022200) Error (criu/cr-restore.c:2522): Restoring FAILED.","level":"error","time":"2025-01-01T00:00:01Z"}
+{"msg":"(00.022418) Error (criu/cgroup.c:1970): cg: cgroupd: recv req error: No such file or directory","level":"error","time":"2025-01-01T00:00:02Z"}
+`)
+
+	errs, err := parseOCIErrors(log)
+	require.NoError(t, err)
+
+	// Verify that all 3 messages are parsed.
+	assert.Equal(t, []ociError{
+		{Msg: "(00.022100) Error (criu/sk-inet.c:654): Connected TCP socket in image", Level: "error", Time: "2025-01-01T00:00:00Z"},
+		{Msg: "(00.022200) Error (criu/cr-restore.c:2522): Restoring FAILED.", Level: "error", Time: "2025-01-01T00:00:01Z"},
+		{Msg: "(00.022418) Error (criu/cgroup.c:1970): cg: cgroupd: recv req error: No such file or directory", Level: "error", Time: "2025-01-01T00:00:02Z"},
+	}, errs)
+}
+
+// TestCheckOCIErrorsForTCPEstablished tests matching
+// of "Connected TCP socket in image" errors in a log file.
+func TestCheckOCIErrorsForTCPEstablished(t *testing.T) {
+	withTCP := []ociError{
+		{Msg: "(00.022100) Error (criu/sk-inet.c:654): Connected TCP socket in image", Level: "error"},
+		{Msg: "(00.022200) Error (criu/cr-restore.c:2522): Restoring FAILED.", Level: "error"},
+		{Msg: "(00.022418) Error (criu/cgroup.c:1970): cg: cgroupd: recv req error: No such file or directory", Level: "error"},
+	}
+
+	err := checkOCIErrorsForTCPEstablished(withTCP)
+
+	// Verify that the log message is matched and expected error converted.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--tcp-established")
+
+	withoutTCP := []ociError{
+		{Msg: "some other OCI runtime error", Level: "error"},
+	}
+
+	// Verify that different message is not matched.
+	err = checkOCIErrorsForTCPEstablished(withoutTCP)
+	assert.NoError(t, err)
+}

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -347,9 +347,9 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", cid})
 		result.WaitWithDefaultTimeout()
 
-		// Some older versions print "CRIU restoring failed: -52" while others
-		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
-		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
+		// Some older versions print "CRIU restoring failed: -52",
+		// for newer versions the error message is converted.
+		expectStderr := "checkpoint contains established TCP connections, restore requires --tcp-established or --tcp-close|CRIU restoring failed: -52"
 		if podmanTest.OCIRuntime == "runc" {
 			expectStderr = "runc: criu failed: type NOTIFY errno 0"
 		}
@@ -391,9 +391,9 @@ var _ = Describe("Podman checkpoint", func() {
 		result := podmanTest.Podman([]string{"container", "restore", cid})
 		result.WaitWithDefaultTimeout()
 
-		// Some older versions print "CRIU restoring failed: -52" while others
-		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
-		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
+		// Some older versions print "CRIU restoring failed: -52",
+		// for newer versions the error message is converted.
+		expectStderr := "checkpoint contains established TCP connections, restore requires --tcp-established or --tcp-close|CRIU restoring failed: -52"
 		if podmanTest.OCIRuntime == "runc" {
 			expectStderr = "runc: criu failed: type NOTIFY errno 0"
 		}


### PR DESCRIPTION
Newer versions of crun use `show_criu_log()` to report errors from CRIU and output multiple
error lines. It lead to a confusing behavior in `readConmonPipeData()` in Podman, because
the JSON `Unmarshal()` failed to parse multiple JSON objects over multiple lines. When `podman restore` was used without `--tcp-established` or `--tcp-close`, a confusing error message:

> `Error: crun: (00.022418) Error (criu/cgroup.c:1970): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found`

was output, instead of the former:

> `crun: CRIU restoring failed -52.`

In this PR, I parse all errors from the log and try to match
"Connected TCP socket in image". If found,
a clear error message is returned:
```
checkpoint contains established TCP connections, restore requires --tcp-established or --tcp-close: OCI runtime error
```
For other error messages, the existing behavior is retained. Tests were updated with the changed error message.

## Steps to reproduce:
```sh
podman run -d --name server quay.io/libpod/testimage:20221018 nc -lp 8888
serverIP=`podman inspect server --format {{.NetworkSettings.IPAddress}}`
podman run -d -i --name client quay.io/libpod/testimage:20221018 nc $serverIP 8888
podman container checkpoint --tcp-established server
podman container restore server
```

Fixes: https://redhat.atlassian.net/browse/RHEL-186005

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
If `podman restore` is used without with a checkpoint containing established TCP connections and without the flags --tcp-established or --tcp-close, the error message "checkpoint contains established TCP connections, restore requires --tcp-established or --tcp-close: OCI runtime error" is returned.
```
