### PR TITLE
Use gvproxy notify socket instead of polling for readiness

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -25,11 +25,7 @@ import (
 
 const applehvMACAddress = "5a:94:ef:e4:0c:ee"
 
-var (
-	gvProxyWaitBackoff        = 500 * time.Millisecond
-	gvProxyMaxBackoffAttempts = 6
-	ignitionSocketName        = "ignition.sock"
-)
+var ignitionSocketName = "ignition.sock"
 
 // ResizeDisk uses os truncate to resize (only larger) a raw disk.  the input size
 // is assumed GiB
@@ -75,10 +71,6 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 	// Set user networking with gvproxy
 	gvproxySocket, err := mc.GVProxySocket()
 	if err != nil {
-		return nil, nil, err
-	}
-	// Wait on gvproxy to be running and aware
-	if err := sockets.WaitForSocketWithBackoffs(gvProxyMaxBackoffAttempts, gvProxyWaitBackoff, gvproxySocket.GetPath(), "gvproxy"); err != nil {
 		return nil, nil, err
 	}
 	netDevice.SetUnixSocketPath(gvproxySocket.GetPath())

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -19,7 +19,10 @@ import (
 	"go.podman.io/podman/v6/pkg/machine/vmconfigs"
 )
 
-const apiUpTimeout = 20 * time.Second
+const (
+	apiUpTimeout        = 20 * time.Second
+	GvProxyReadyTimeout = 5 * time.Second
+)
 
 var ForwarderBinaryName = "gvproxy"
 

--- a/pkg/machine/gvproxy.go
+++ b/pkg/machine/gvproxy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -33,7 +34,8 @@ func readPIDFileWithRetry(f define.VMFile) ([]byte, error) {
 	return f.Read()
 }
 
-// CleanupGVProxy reads the --pid-file for gvproxy attempts to stop it
+// CleanupGVProxy reads the --pid-file for gvproxy, stops the process,
+// removes the PID file, and cleans up the notification socket.
 func CleanupGVProxy(f define.VMFile) error {
 	gvPid, err := readPIDFileWithRetry(f)
 	if err != nil {
@@ -51,5 +53,13 @@ func CleanupGVProxy(f define.VMFile) error {
 	if err := waitOnProcess(proxyPid); err != nil {
 		return err
 	}
-	return removeGVProxyPIDFile(f)
+	if err := removeGVProxyPIDFile(f); err != nil {
+		return err
+	}
+
+	// Remove notification socket after gvproxy has exited
+	runtimeDir := filepath.Dir(f.GetPath())
+	CleanupGvProxyNotifySocket(runtimeDir)
+
+	return nil
 }

--- a/pkg/machine/gvproxy_notify.go
+++ b/pkg/machine/gvproxy_notify.go
@@ -1,0 +1,160 @@
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	gvProxyTypes "github.com/containers/gvisor-tap-vsock/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+const notifySocketName = "gvproxy-notify.sock"
+
+// GvProxyNotifier listens on a unix socket for JSON notification messages
+// from gvproxy.
+type GvProxyNotifier struct {
+	listener   *net.UnixListener
+	socketPath string
+	readyCh    chan struct{}
+	errorCh    chan error
+}
+
+// SocketPath returns the path to the notification unix socket.
+func (n *GvProxyNotifier) SocketPath() string {
+	return n.socketPath
+}
+
+// NewGvProxyNotifier creates a notification listener socket in the given runtime directory.
+//
+// The socket begins accepting connections at the kernel level immediately upon creation
+// (via net.Listen), so gvproxy can be started and connect before Start() is called without
+// losing messages. The kernel backlog buffers both the connection and any data sent on it
+// until Accept()/Read() consume them.
+//
+// The notifier is only used during machine start. Close() stops the listener but
+// intentionally leaves the socket file on disk because gvproxy remains running after
+// start completes and may still dial the socket for later notifications. The socket
+// file is removed by CleanupGvProxyNotifySocket, which is called from CleanupGVProxy
+// during machine stop after gvproxy has exited. Any stale socket from a previous run
+// is removed at the top of this constructor before creating a new listener.
+func NewGvProxyNotifier(runtimeDir string) (*GvProxyNotifier, error) {
+	socketPath := filepath.Join(runtimeDir, notifySocketName)
+
+	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("removing old notification socket: %w", err)
+	}
+
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		return nil, fmt.Errorf("creating notification listener: %w", err)
+	}
+
+	// Prevent Close() from removing the socket file. gvproxy may still
+	// dial it for notifications after the listener is closed. The file is
+	// removed by CleanupGvProxyNotifySocket during machine stop.
+	listener.SetUnlinkOnClose(false)
+
+	return &GvProxyNotifier{
+		listener:   listener,
+		socketPath: socketPath,
+		readyCh:    make(chan struct{}, 1),
+		errorCh:    make(chan error, 1),
+	}, nil
+}
+
+// CleanupGvProxyNotifySocket removes the notification socket file from the given runtime directory.
+//
+// This is called from CleanupGVProxy during machine stop, at which point the notifier
+// (which only runs during machine start) has long since closed its listener.
+func CleanupGvProxyNotifySocket(runtimeDir string) {
+	socketPath := filepath.Join(runtimeDir, notifySocketName)
+	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		logrus.Debugf("failed to remove gvproxy notification socket: %v", err)
+	}
+}
+
+// Close stops the notifier listener.
+//
+// The socket file is intentionally left on disk because gvproxy may still dial it for later notifications
+// (connection_established, connection_closed).
+// The file is cleaned up by CleanupGvProxyNotifySocket after gvproxy exits.
+func (n *GvProxyNotifier) Close() {
+	n.listener.Close()
+}
+
+// Start begins accepting connections and processing notifications.
+//
+// It blocks until the context is canceled or the listener is closed,
+// intended to be run as a goroutine.
+func (n *GvProxyNotifier) Start(ctx context.Context) {
+	for {
+		conn, err := n.listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			logrus.Errorf("notification listener accept error: %v", err)
+			return
+		}
+		n.handleConnection(ctx, conn)
+	}
+}
+
+func (n *GvProxyNotifier) handleConnection(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	decoder := json.NewDecoder(conn)
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		var msg gvProxyTypes.NotificationMessage
+		if err := decoder.Decode(&msg); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			logrus.Debugf("notification decode error: %v", err)
+			return
+		}
+
+		logrus.Debugf("gvproxy notification received: type=%s mac=%s", msg.NotificationType, msg.MacAddress)
+
+		switch msg.NotificationType {
+		case gvProxyTypes.Ready:
+			select {
+			case n.readyCh <- struct{}{}:
+			default:
+			}
+		case gvProxyTypes.ConnectionEstablished:
+			logrus.Debugf("gvproxy: VM connected (mac=%s)", msg.MacAddress)
+		case gvProxyTypes.HypervisorError:
+			select {
+			case n.errorCh <- fmt.Errorf("gvproxy reported hypervisor error"):
+			default:
+			}
+		case gvProxyTypes.ConnectionClosed:
+			select {
+			case n.errorCh <- fmt.Errorf("gvproxy: VM disconnected unexpectedly (mac=%s)", msg.MacAddress):
+			default:
+			}
+		}
+	}
+}
+
+// WaitReady blocks until the "ready" notification is received or the context expires.
+func (n *GvProxyNotifier) WaitReady(ctx context.Context) error {
+	select {
+	case <-n.readyCh:
+		return nil
+	case err := <-n.errorCh:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("timeout waiting for gvproxy ready notification: %w", ctx.Err())
+	}
+}

--- a/pkg/machine/gvproxy_notify_test.go
+++ b/pkg/machine/gvproxy_notify_test.go
@@ -1,0 +1,95 @@
+//go:build amd64 || arm64
+
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	gvproxyTypes "github.com/containers/gvisor-tap-vsock/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGvProxyNotifier_Ready(t *testing.T) {
+	dir := t.TempDir()
+	notifier, err := NewGvProxyNotifier(dir)
+	require.NoError(t, err)
+	defer notifier.Close()
+
+	go notifier.Start(t.Context())
+
+	conn, err := net.Dial("unix", notifier.SocketPath())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	err = json.NewEncoder(conn).Encode(gvproxyTypes.NotificationMessage{
+		NotificationType: gvproxyTypes.Ready,
+	})
+	require.NoError(t, err)
+
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer waitCancel()
+	err = notifier.WaitReady(waitCtx)
+	assert.NoError(t, err)
+}
+
+func TestGvProxyNotifier_HypervisorError(t *testing.T) {
+	dir := t.TempDir()
+	notifier, err := NewGvProxyNotifier(dir)
+	require.NoError(t, err)
+	defer notifier.Close()
+
+	go notifier.Start(t.Context())
+
+	conn, err := net.Dial("unix", notifier.SocketPath())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	err = json.NewEncoder(conn).Encode(gvproxyTypes.NotificationMessage{
+		NotificationType: gvproxyTypes.HypervisorError,
+	})
+	require.NoError(t, err)
+
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer waitCancel()
+	err = notifier.WaitReady(waitCtx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hypervisor error")
+}
+
+func TestGvProxyNotifier_Timeout(t *testing.T) {
+	dir := t.TempDir()
+	notifier, err := NewGvProxyNotifier(dir)
+	require.NoError(t, err)
+	defer notifier.Close()
+
+	go notifier.Start(t.Context())
+
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer waitCancel()
+	err = notifier.WaitReady(waitCtx)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestCleanupGvProxyNotifySocket(t *testing.T) {
+	dir := t.TempDir()
+
+	notifier, err := NewGvProxyNotifier(dir)
+	require.NoError(t, err)
+	socketPath := notifier.SocketPath()
+	notifier.Close()
+
+	_, err = os.Stat(socketPath)
+	assert.NoError(t, err, "socket file should still exist after Close()")
+
+	CleanupGvProxyNotifySocket(dir)
+	_, err = os.Stat(socketPath)
+	assert.True(t, errors.Is(err, os.ErrNotExist), "socket file should be gone after cleanup")
+}

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -33,11 +33,6 @@ type QEMUStubber struct {
 	virtiofsHelpers []virtiofsdHelperCmd
 }
 
-var (
-	gvProxyWaitBackoff        = 500 * time.Millisecond
-	gvProxyMaxBackoffAttempts = 6
-)
-
 func (q *QEMUStubber) UserModeNetworkEnabled(*vmconfigs.MachineConfig) bool {
 	return true
 }
@@ -152,16 +147,6 @@ func (q *QEMUStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func()
 
 	readySocket, err := mc.ReadySocket()
 	if err != nil {
-		return nil, nil, err
-	}
-
-	gvProxySock, err := mc.GVProxySocket()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Wait on gvproxy to be running and aware
-	if err := sockets.WaitForSocketWithBackoffs(gvProxyMaxBackoffAttempts, gvProxyWaitBackoff, gvProxySock.GetPath(), "gvproxy"); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -615,7 +616,7 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 	}
 
 	// start gvproxy and set up the API socket forwarding
-	forwardSocketPath, forwardingState, err := startNetworking(mc, mp)
+	forwardSocketPath, forwardingState, gvProxyNotifier, err := startNetworking(mc, mp)
 	if err != nil {
 		return err
 	}
@@ -628,6 +629,23 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 		return nil
 	}
 	callbackFuncs.Add(cleanGv)
+
+	// Wait for gvproxy to signal readiness via the notification socket.
+	if gvProxyNotifier != nil {
+		notifyCtx, notifyCancel := context.WithCancel(context.Background())
+		go gvProxyNotifier.Start(notifyCtx)
+		defer func() {
+			notifyCancel()
+			gvProxyNotifier.Close()
+		}()
+
+		gvProxyReadyCtx, gvProxyReadyCancel := context.WithTimeout(context.Background(), machine.GvProxyReadyTimeout)
+		defer gvProxyReadyCancel()
+		if err := gvProxyNotifier.WaitReady(gvProxyReadyCtx); err != nil {
+			return fmt.Errorf("waiting for gvproxy readiness: %w", err)
+		}
+		logrus.Debug("gvproxy ready notification received")
+	}
 
 	// if there are generic things that need to be done, a preStart function could be added here
 	// should it be extensive

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -30,7 +30,7 @@ var (
 	ErrSSHNotListening = errors.New("machine is not listening on ssh port")
 )
 
-func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider, dirs *define.MachineDirs, hostSocks []string) error {
+func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider, dirs *define.MachineDirs, hostSocks []string) (*machine.GvProxyNotifier, error) {
 	forwardUser := mc.SSH.RemoteUsername
 
 	// TODO should this go up the stack higher or
@@ -43,12 +43,12 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 
 	cfg, err := config.Default()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	binary, err := cfg.FindHelperBinary(machine.ForwarderBinaryName, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	cmd := gvproxy.NewGvproxyCommand()
@@ -77,48 +77,63 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 	// This allows a provider to perform additional setup as well as
 	// add in any provider specific options for gvproxy
 	if err := provider.StartNetworking(mc, &cmd); err != nil {
-		return err
+		return nil, err
 	}
 
 	c := cmd.Cmd(binary)
 
-	logrus.Debugf("gvproxy command-line: %s %s", binary, strings.Join(cmd.ToCmdline(), " "))
+	gvProxyNotifier, err := machine.NewGvProxyNotifier(runDir.GetPath())
+	if err != nil {
+		return nil, fmt.Errorf("setting up gvproxy notification listener: %w", err)
+	}
+	// Ensure "unix:///absolute/path" form so gvproxy's url.Parse keeps
+	// the host empty and puts the full path into uri.Path.
+	socketPath := filepath.ToSlash(gvProxyNotifier.SocketPath())
+	if !strings.HasPrefix(socketPath, "/") {
+		socketPath = "/" + socketPath
+	}
+	c.Args = append(c.Args, "-notification", "unix://"+socketPath)
+
+	logrus.Debugf("gvproxy command-line: %s", strings.Join(c.Args, " "))
 	if err := c.Start(); err != nil {
-		return fmt.Errorf("unable to execute: %q: %w", cmd.ToCmdline(), err)
+		gvProxyNotifier.Close()
+		machine.CleanupGvProxyNotifySocket(runDir.GetPath())
+		return nil, fmt.Errorf("unable to execute: %q: %w", cmd.ToCmdline(), err)
 	}
 
-	return nil
+	return gvProxyNotifier, nil
 }
 
-func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider) (string, machine.APIForwardingState, error) {
+func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider) (string, machine.APIForwardingState, *machine.GvProxyNotifier, error) {
 	// Check if SSH port is in use, and reassign if necessary
 	if !ports.IsLocalPortAvailable(mc.SSH.Port) {
 		logrus.Warnf("detected port conflict on machine ssh port [%d], reassigning", mc.SSH.Port)
 		if err := reassignSSHPort(mc, provider); err != nil {
-			return "", 0, err
+			return "", 0, nil, err
 		}
 	}
 
 	// Provider has its own networking code path (e.g. WSL)
 	if provider.UseProviderNetworkSetup() {
-		return "", 0, provider.StartNetworking(mc, nil)
+		return "", 0, nil, provider.StartNetworking(mc, nil)
 	}
 
 	dirs, err := env.GetMachineDirs(provider.VMType())
 	if err != nil {
-		return "", 0, err
+		return "", 0, nil, err
 	}
 
 	hostSocks, forwardSock, forwardingState, err := setupMachineSockets(mc, dirs)
 	if err != nil {
-		return "", 0, err
+		return "", 0, nil, err
 	}
 
-	if err := startHostForwarder(mc, provider, dirs, hostSocks); err != nil {
-		return "", 0, err
+	gvProxyNotifier, err := startHostForwarder(mc, provider, dirs, hostSocks)
+	if err != nil {
+		return "", 0, nil, err
 	}
 
-	return forwardSock, forwardingState, nil
+	return forwardSock, forwardingState, gvProxyNotifier, nil
 }
 
 // conductVMReadinessCheck checks to make sure the machine is in the proper state

--- a/pkg/machine/sockets/sockets.go
+++ b/pkg/machine/sockets/sockets.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"go.podman.io/podman/v6/pkg/machine/define"
-	"go.podman.io/storage/pkg/fileutils"
 )
 
 // ListenAndWaitOnSocket waits for a new connection to the listener and sends
@@ -79,21 +78,6 @@ func DialSocketWithBackoffsAndProcCheck(
 		}
 	}
 	return nil, err
-}
-
-// WaitForSocketWithBackoffs attempts to discover listening socket in maxBackoffs attempts
-func WaitForSocketWithBackoffs(maxBackoffs int, backoff time.Duration, socketPath string, name string) error {
-	backoffWait := backoff
-	logrus.Debugf("checking that %q socket is ready", name)
-	for range maxBackoffs {
-		err := fileutils.Exists(socketPath)
-		if err == nil {
-			return nil
-		}
-		time.Sleep(backoffWait)
-		backoffWait *= 2
-	}
-	return fmt.Errorf("unable to connect to %q socket at %q", name, socketPath)
 }
 
 // ToUnixURL converts `socketLoc` into URL representation


### PR DESCRIPTION
Replace backoff-based polling for gvproxy socket existence with the new `--notification` flag from [gvisor-tap-vsock#566.](https://github.com/containers/gvisor-tap-vsock/pull/566) Podman creates a Unix listener and gvproxy sends a JSON ready message when its listeners are up. Faster, no race conditions.

Fixes: https://redhat.atlassian.net/browse/RUN-4471

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Machine start uses gvproxy notification socket for readiness instead of polling.
```
