### PR TITLE
Upload artifacts with build suffix

### DIFF
--- a/.github/workflows/release-build-artifacts.yml
+++ b/.github/workflows/release-build-artifacts.yml
@@ -46,8 +46,8 @@ permissions:
   contents: read
 
 jobs:
-  build-artifacts:
-    name: Build Artifacts
+  get-version:
+    name: Determine Version
     runs-on: ubuntu-latest
     if: github.repository == 'podman-container-tools/podman'
     outputs:
@@ -69,6 +69,18 @@ jobs:
         else
           echo "version_display=$VERSION-$sha" >> "$GITHUB_OUTPUT"
         fi
+
+  build-artifacts:
+    name: Build Artifacts
+    runs-on: ubuntu-latest
+    if: github.repository == 'podman-container-tools/podman'
+    needs: [get-version]
+    steps:
+    - name: Checkout Version
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ inputs.version }}
+        persist-credentials: false
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
@@ -83,13 +95,14 @@ jobs:
     - name: Upload to Actions as artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: release-artifacts
+        name: release-artifacts-${{ needs.get-version.outputs.version_display }}
         path: release/*
 
   mac-pkg:
     name: Build MacOS pkginstaller
     runs-on: macos-latest
     if: github.repository == 'podman-container-tools/podman'
+    needs: [get-version]
     env:
       APPLICATION_CERTIFICATE: ${{ secrets.MACOS_APPLICATION_CERT }}
       CODESIGN_IDENTITY: ${{ secrets.MACOS_APPLICATION_IDENTITY }}
@@ -133,7 +146,7 @@ jobs:
     - name: Artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: mac-installers
+        name: mac-installers-${{ needs.get-version.outputs.version_display }}
         path: |
           contrib/pkginstaller/out/podman-installer-macos-*.pkg
 
@@ -143,17 +156,17 @@ jobs:
       matrix:
         arch: [amd64, arm64]
     runs-on: windows-latest
-    needs: [build-artifacts]
+    needs: [get-version, build-artifacts]
     steps:
     - name: Checkout Podman
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: ${{ inputs.version }}
         persist-credentials: false
-    - name: Determine version
-      id: getversion
+    - name: Normalize version for Windows
+      id: normalized-windows-version
       env:
-        VERSION: ${{ needs.build-artifacts.outputs.version_display }}
+        VERSION: ${{ needs.get-version.outputs.version_display }}
       run: |
         $version = "${env:VERSION}"
         if ($version.Length -gt 0 -and $version[0] -eq "v") {
@@ -172,7 +185,7 @@ jobs:
     - name: Download Windows zip artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: release-artifacts
+        name: release-artifacts-${{ needs.get-version.outputs.version_display }}
         path: ${{ github.workspace }}\release-artifacts
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -209,7 +222,7 @@ jobs:
       id: build
       env:
         PODMAN_ARCH: ${{ matrix.arch }}
-        VERSION: ${{ steps.getversion.outputs.version }}
+        VERSION: ${{ steps.normalized-windows-version.outputs.version }}
       run: |
         contrib\win-installer\build.ps1 `
             -Version "${env:VERSION}" `
@@ -224,7 +237,7 @@ jobs:
     - name: Rename the MSI
       env:
         PODMAN_ARCH: ${{ matrix.arch }}
-        VERSION: ${{ steps.getversion.outputs.version }}
+        VERSION: ${{ steps.normalized-windows-version.outputs.version }}
       run: |
         Push-Location contrib\win-installer
         Copy-Item -Path "podman-${env:VERSION}.msi" -Destination "podman-installer-windows-${env:PODMAN_ARCH}.msi"
@@ -232,6 +245,6 @@ jobs:
     - name: Upload the MSI
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: win-msi-${{ matrix.arch }}
+        name: win-msi-${{ matrix.arch }}-${{ needs.get-version.outputs.version_display }}
         path: |
           .\contrib\win-installer\podman-installer-windows-${{ matrix.arch }}.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,10 +123,14 @@ jobs:
     - name: Download all artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
     - name: Show artifacts
+      env:
+        VERSION: ${{ needs.check.outputs.version }}
       run: |
-        mv mac-installers/* release-artifacts
-        mv win-msi-amd64/* release-artifacts
-        mv win-msi-arm64/* release-artifacts
+        mkdir -p release-artifacts
+        mv "mac-installers-$VERSION"/* release-artifacts/
+        mv "win-msi-amd64-$VERSION"/* release-artifacts/
+        mv "win-msi-arm64-$VERSION"/* release-artifacts/
+        mv "release-artifacts-$VERSION"/* release-artifacts/
         pushd release-artifacts
         sha256sum * > shasums
         popd


### PR DESCRIPTION
The nightly release validation builds both on main and the latest release branch, we should upload the artifacts with a suffix to differentiate the two

Fixes: https://github.com/podman-container-tools/podman/issues/29059

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
