### PR TITLE
docs: improve docs on relabelling options of `--mount`

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -76,6 +76,11 @@ Options specific to type=**volume**:
 
 - *subpath*: Mount only a specific subpath within the volume, instead of the whole volume.
 
+- *relabel*: *shared*, *private*. Recursively walk the mount and set the security system (e.g. SELinux) label on each file to grant access permissions from the container context.
+  *shared* applies a label that grants permissions to all containers, while *private* applies a label that grants permissions to this specific container.
+
+- *z*, *Z*: shorthand for *relabel=shared* and *relabel=private*, respectively.
+
 - *idmap*: If specified, create an idmapped mount to the target user namespace in the container.
   The idmap option is only supported by Podman in rootful mode. The Linux kernel does not allow the use of idmapped file systems for unprivileged users.
   The idmap option supports a custom mapping that can be different from the user namespace used by the container.
@@ -98,7 +103,10 @@ Options specific to **bind** and **glob**:
 
 - *bind-nonrecursive*: do not set up a recursive bind mount. By default it is recursive.
 
-- *relabel*: *shared*, *private*.
+- *relabel*: *shared*, *private*. Recursively walk the mount and set the security system (e.g. SELinux) label on each file to grant access permissions from the container context.
+  *shared* applies a label that grants permissions to all containers, while *private* applies a label that grants permissions to this specific container.
+
+- *z*, *Z*: shorthand for *relabel=shared* and *relabel=private*, respectively.
 
 - *idmap*: If specified, create an idmapped mount to the target user namespace in the container.
   The idmap option is only supported by Podman in rootful mode. The Linux kernel does not allow the use of idmapped file systems for unprivileged users.


### PR DESCRIPTION
Currently docs on relabelling options for `--mount` are pretty spartan/incomplete:

- Relabelling options missing from volume section
- Relabelling options in bind/glob section lack description
- `z` and `Z` shorthands undocumented

This PR adds these docs. Resolves #29124.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
