### PR TITLE
kube: use native seccompProfile fields

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -909,7 +909,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		}
 	}
 
-	seccompPaths, err := kube.InitializeSeccompPaths(podYAML.ObjectMeta.Annotations, options.SeccompProfileRoot)
+	seccompAnnotationPaths, err := kube.InitializeSeccompAnnotationPaths(podYAML.ObjectMeta.Annotations, options.SeccompProfileRoot)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1043,28 +1043,29 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		}
 
 		specgenOpts := kube.CtrSpecGenOptions{
-			Annotations:        annotations,
-			ConfigMaps:         configMaps,
-			Container:          initCtr,
-			Image:              pulledImage,
-			InitContainerType:  initCtrType,
-			Labels:             labels,
-			LogDriver:          options.LogDriver,
-			LogOptions:         options.LogOptions,
-			NetNSIsHost:        p.NetNS.IsHost(),
-			PodID:              pod.ID(),
-			PodInfraID:         podInfraID,
-			PodName:            podName,
-			PodSecurityContext: podYAML.Spec.SecurityContext,
-			ReadOnly:           readOnly,
-			RestartPolicy:      define.RestartPolicyNo,
-			SeccompPaths:       seccompPaths,
-			SecretsManager:     secretsManager,
-			UserNSIsHost:       p.Userns.IsHost(),
-			Volumes:            volumes,
-			VolumesFrom:        volumesFrom,
-			ImageVolumes:       automountImages,
-			UtsNSIsHost:        p.UtsNs.IsHost(),
+			Annotations:            annotations,
+			ConfigMaps:             configMaps,
+			Container:              initCtr,
+			Image:                  pulledImage,
+			InitContainerType:      initCtrType,
+			Labels:                 labels,
+			LogDriver:              options.LogDriver,
+			LogOptions:             options.LogOptions,
+			NetNSIsHost:            p.NetNS.IsHost(),
+			PodID:                  pod.ID(),
+			PodInfraID:             podInfraID,
+			PodName:                podName,
+			PodSecurityContext:     podYAML.Spec.SecurityContext,
+			ReadOnly:               readOnly,
+			RestartPolicy:          define.RestartPolicyNo,
+			SeccompAnnotationPaths: seccompAnnotationPaths,
+			SeccompProfileRoot:     options.SeccompProfileRoot,
+			SecretsManager:         secretsManager,
+			UserNSIsHost:           p.Userns.IsHost(),
+			Volumes:                volumes,
+			VolumesFrom:            volumesFrom,
+			ImageVolumes:           automountImages,
+			UtsNSIsHost:            p.UtsNs.IsHost(),
 		}
 		specGen, err := kube.ToSpecGen(ctx, &specgenOpts)
 		if err != nil {
@@ -1132,30 +1133,31 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		}
 
 		specgenOpts := kube.CtrSpecGenOptions{
-			Annotations:        annotations,
-			ConfigMaps:         configMaps,
-			Container:          container,
-			Image:              pulledImage,
-			IpcNSIsHost:        p.Ipc.IsHost(),
-			Labels:             labels,
-			LogDriver:          options.LogDriver,
-			LogOptions:         options.LogOptions,
-			NetNSIsHost:        p.NetNS.IsHost(),
-			PidNSIsHost:        p.Pid.IsHost(),
-			PodID:              pod.ID(),
-			PodInfraID:         podInfraID,
-			PodName:            podName,
-			PodSecurityContext: podYAML.Spec.SecurityContext,
-			RestartPolicy:      podSpec.PodSpecGen.RestartPolicy, // pass the restart policy to the container (https://github.com/containers/podman/issues/20903)
-			ReadOnly:           readOnly,
-			SeccompPaths:       seccompPaths,
-			SecretsManager:     secretsManager,
-			UserNSIsHost:       p.Userns.IsHost(),
-			Volumes:            volumes,
-			VolumesFrom:        volumesFrom,
-			ImageVolumes:       automountImages,
-			UtsNSIsHost:        p.UtsNs.IsHost(),
-			NoPodPrefix:        options.NoPodPrefix,
+			Annotations:            annotations,
+			ConfigMaps:             configMaps,
+			Container:              container,
+			Image:                  pulledImage,
+			IpcNSIsHost:            p.Ipc.IsHost(),
+			Labels:                 labels,
+			LogDriver:              options.LogDriver,
+			LogOptions:             options.LogOptions,
+			NetNSIsHost:            p.NetNS.IsHost(),
+			PidNSIsHost:            p.Pid.IsHost(),
+			PodID:                  pod.ID(),
+			PodInfraID:             podInfraID,
+			PodName:                podName,
+			PodSecurityContext:     podYAML.Spec.SecurityContext,
+			RestartPolicy:          podSpec.PodSpecGen.RestartPolicy, // pass the restart policy to the container (https://github.com/containers/podman/issues/20903)
+			ReadOnly:               readOnly,
+			SeccompAnnotationPaths: seccompAnnotationPaths,
+			SeccompProfileRoot:     options.SeccompProfileRoot,
+			SecretsManager:         secretsManager,
+			UserNSIsHost:           p.Userns.IsHost(),
+			Volumes:                volumes,
+			VolumesFrom:            volumesFrom,
+			ImageVolumes:           automountImages,
+			UtsNSIsHost:            p.UtsNs.IsHost(),
+			NoPodPrefix:            options.NoPodPrefix,
 		}
 
 		if podYAML.Spec.TerminationGracePeriodSeconds != nil {

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"slices"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/docker/go-units"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/libnetwork/types"
 	"go.podman.io/common/pkg/config"
@@ -27,6 +29,7 @@ import (
 	"go.podman.io/common/pkg/secrets"
 	"go.podman.io/image/v5/manifest"
 	itypes "go.podman.io/image/v5/types"
+	"go.podman.io/podman/v6/libpod"
 	"go.podman.io/podman/v6/libpod/define"
 	ann "go.podman.io/podman/v6/pkg/annotations"
 	"go.podman.io/podman/v6/pkg/domain/entities"
@@ -164,8 +167,10 @@ type CtrSpecGenOptions struct {
 	PodInfraID string
 	// ConfigMaps the configuration maps for environment variables
 	ConfigMaps []v1.ConfigMap
-	// SeccompPaths for finding the seccomp profile path
-	SeccompPaths *KubeSeccompPaths
+	// SeccompAnnotationPaths contains deprecated annotation-based seccomp profiles parsed from the pod
+	SeccompAnnotationPaths *SeccompAnnotationPaths
+	// SeccompProfileRoot is the base directory for Localhost seccomp profiles
+	SeccompProfileRoot string
 	// ReadOnly make all containers root file system readonly
 	ReadOnly itypes.OptionalBool
 	// RestartPolicy defines the restart policy of the container
@@ -287,7 +292,11 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 
 	s.InitContainerType = opts.InitContainerType
 
-	setupSecurityContext(s, opts.Container.SecurityContext, opts.PodSecurityContext)
+	err = setupSecurityContext(s, opts.Container.SecurityContext, opts.PodSecurityContext, opts.SeccompProfileRoot, opts.SeccompAnnotationPaths, opts.Container.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure securityContext: %w", err)
+	}
+
 	err = setupLivenessProbe(s, opts.Container, opts.RestartPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure livenessProbe: %w", err)
@@ -296,11 +305,6 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure startupProbe: %w", err)
 	}
-
-	// Since we prefix the container name with pod name to work-around the uniqueness requirement,
-	// the seccomp profile should reference the actual container name from the YAML
-	// but apply to the containers with the prefixed name
-	s.SeccompProfilePath = opts.SeccompPaths.FindForContainer(opts.Container.Name)
 
 	setupContainerResources(s, opts.Container)
 
@@ -957,7 +961,7 @@ func setupContainerDevices(s *specgen.SpecGenerator, containerYAML v1.Container)
 	return nil
 }
 
-func setupSecurityContext(s *specgen.SpecGenerator, securityContext *v1.SecurityContext, podSecurityContext *v1.PodSecurityContext) {
+func setupSecurityContext(s *specgen.SpecGenerator, securityContext *v1.SecurityContext, podSecurityContext *v1.PodSecurityContext, profileRoot string, seccompAnnotationPaths *SeccompAnnotationPaths, ctrName string) error {
 	if securityContext == nil {
 		securityContext = &v1.SecurityContext{}
 	}
@@ -1002,6 +1006,54 @@ func setupSecurityContext(s *specgen.SpecGenerator, securityContext *v1.Security
 			s.SelinuxOpts = append(s.SelinuxOpts, fmt.Sprintf("filetype:%s", seopt.FileType))
 		}
 	}
+
+	seccompProfile := securityContext.SeccompProfile
+	if seccompProfile == nil && seccompAnnotationPaths != nil {
+		// Since we prefix the container name with pod name to work-around the uniqueness requirement,
+		// the seccomp profile should reference the actual container name from the YAML
+		// but apply to the containers with the prefixed name
+		if seccompAnnotationPath, ok := seccompAnnotationPaths.FindForContainer(ctrName); ok {
+			s.SeccompProfilePath = seccompAnnotationPath
+			logrus.Warnf("Container %q: Kubernetes seccomp annotation is deprecated; use securityContext.seccompProfile instead", ctrName)
+		}
+	}
+	if seccompProfile == nil && s.SeccompProfilePath == "" {
+		seccompProfile = podSecurityContext.SeccompProfile
+	}
+	if seccompProfile == nil && s.SeccompProfilePath == "" && seccompAnnotationPaths != nil {
+		if seccompAnnotationPaths.podPath != "" {
+			s.SeccompProfilePath = seccompAnnotationPaths.podPath
+			logrus.Warn("Pod-level Kubernetes seccomp annotation is deprecated; use spec.securityContext.seccompProfile instead")
+		}
+	}
+	if seccompProfile == nil && s.SeccompProfilePath == "" {
+		seccompProfile = &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}
+	}
+
+	if seccompProfile != nil {
+		switch seccompProfile.Type {
+		case v1.SeccompProfileTypeRuntimeDefault:
+			seccompProfilePath, err := libpod.DefaultSeccompPath()
+			if err != nil {
+				return err
+			}
+			s.SeccompProfilePath = seccompProfilePath
+		case v1.SeccompProfileTypeUnconfined:
+			s.SeccompProfilePath = "unconfined"
+		case v1.SeccompProfileTypeLocalhost:
+			if seccompProfile.LocalhostProfile == nil || *seccompProfile.LocalhostProfile == "" {
+				return fmt.Errorf("seccomp profile type %q requires localhostProfile", seccompProfile.Type)
+			}
+			localhostProfile := *seccompProfile.LocalhostProfile
+			if err := validateSeccompLocalhostProfile(localhostProfile); err != nil {
+				return fmt.Errorf("invalid seccomp profile path %q: %w", localhostProfile, err)
+			}
+			s.SeccompProfilePath = filepath.Join(profileRoot, filepath.FromSlash(localhostProfile))
+		default:
+			return fmt.Errorf("invalid seccomp profile type: %s", seccompProfile.Type)
+		}
+	}
+
 	if caps := securityContext.Capabilities; caps != nil {
 		for _, capability := range caps.Add {
 			s.CapAdd = append(s.CapAdd, string(capability))
@@ -1031,6 +1083,8 @@ func setupSecurityContext(s *specgen.SpecGenerator, securityContext *v1.Security
 	for _, group := range podSecurityContext.SupplementalGroups {
 		s.Groups = append(s.Groups, strconv.FormatInt(group, 10))
 	}
+
+	return nil
 }
 
 func quantityToInt64(quantity *resource.Quantity) int64 {

--- a/pkg/specgen/generate/kube/kube_test.go
+++ b/pkg/specgen/generate/kube/kube_test.go
@@ -3,12 +3,15 @@
 package kube
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.podman.io/podman/v6/libpod"
 	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
 	"go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/api/resource"
 	"go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/util/intstr"
+	"go.podman.io/podman/v6/pkg/specgen"
 )
 
 func testPropagation(t *testing.T, propagation v1.MountPropagationMode, expected string) {
@@ -177,6 +180,137 @@ func TestQuantityToInt64(t *testing.T) {
 			q := resource.MustParse(tt.input)
 			got := quantityToInt64(&q)
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func seccompProfile(profileType v1.SeccompProfileType, localhostProfile *string) *v1.SeccompProfile {
+	return &v1.SeccompProfile{Type: profileType, LocalhostProfile: localhostProfile}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func TestSetupSecurityContextSeccompProfile(t *testing.T) {
+	profileRoot := t.TempDir()
+	defaultPath, err := libpod.DefaultSeccompPath()
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name                   string
+		ctr                    *v1.SecurityContext
+		pod                    *v1.PodSecurityContext
+		seccompAnnotationPaths *SeccompAnnotationPaths
+		ctrName                string
+		expected               string
+		expectedError          string
+	}{
+		{
+			name: "container profile",
+			ctr: &v1.SecurityContext{
+				SeccompProfile: seccompProfile(v1.SeccompProfileTypeUnconfined, nil),
+			},
+			expected: "unconfined",
+		},
+		{
+			name: "pod profile",
+			pod: &v1.PodSecurityContext{
+				SeccompProfile: seccompProfile(v1.SeccompProfileTypeLocalhost, stringPtr("profiles/pod.json")),
+			},
+			expected: filepath.Join(profileRoot, "profiles/pod.json"),
+		},
+		{
+			name: "container overrides pod",
+			ctr: &v1.SecurityContext{
+				SeccompProfile: seccompProfile(v1.SeccompProfileTypeLocalhost, stringPtr("profiles/container.json")),
+			},
+			pod: &v1.PodSecurityContext{
+				SeccompProfile: seccompProfile(v1.SeccompProfileTypeUnconfined, nil),
+			},
+			expected: filepath.Join(profileRoot, "profiles/container.json"),
+		},
+		{
+			name: "container securityContext overrides container annotation",
+			ctr: &v1.SecurityContext{
+				SeccompProfile: seccompProfile(
+					v1.SeccompProfileTypeUnconfined,
+					nil,
+				),
+			},
+			seccompAnnotationPaths: &SeccompAnnotationPaths{
+				containerPaths: map[string]string{
+					"test-container": filepath.Join(profileRoot, "annotation.json"),
+				},
+			},
+			ctrName:  "test-container",
+			expected: "unconfined",
+		},
+		{
+			name: "pod securityContext overrides pod annotation",
+			pod: &v1.PodSecurityContext{
+				SeccompProfile: seccompProfile(
+					v1.SeccompProfileTypeLocalhost,
+					stringPtr("profiles/pod.json"),
+				),
+			},
+			seccompAnnotationPaths: &SeccompAnnotationPaths{
+				containerPaths: map[string]string{},
+				podPath:        filepath.Join(profileRoot, "annotation.json"),
+			},
+			expected: filepath.Join(profileRoot, "profiles/pod.json"),
+		},
+		{
+			name:     "unset profile uses default",
+			expected: defaultPath,
+		},
+		{
+			name: "RuntimeDefault profile",
+			ctr: &v1.SecurityContext{
+				SeccompProfile: seccompProfile(v1.SeccompProfileTypeRuntimeDefault, nil),
+			},
+			expected: defaultPath,
+		},
+		{
+			name: "reject empty seccomp profile type",
+			ctr: &v1.SecurityContext{
+				SeccompProfile: &v1.SeccompProfile{},
+			},
+			expectedError: "invalid seccomp profile type",
+		},
+		{
+			name: "reject absolute localhost profile",
+			ctr: &v1.SecurityContext{
+				SeccompProfile: seccompProfile(
+					v1.SeccompProfileTypeLocalhost,
+					stringPtr("/etc/seccomp.json"),
+				),
+			},
+			expectedError: "must be a relative path",
+		},
+		{
+			name: "reject localhost profile with backstep",
+			ctr: &v1.SecurityContext{
+				SeccompProfile: seccompProfile(
+					v1.SeccompProfileTypeLocalhost,
+					stringPtr("profiles/../seccomp.json"),
+				),
+			},
+			expectedError: "must not contain '..'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &specgen.SpecGenerator{}
+			err := setupSecurityContext(s, tt.ctr, tt.pod, profileRoot, tt.seccompAnnotationPaths, tt.ctrName)
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, s.SeccompProfilePath)
 		})
 	}
 }

--- a/pkg/specgen/generate/kube/seccomp.go
+++ b/pkg/specgen/generate/kube/seccomp.go
@@ -5,39 +5,38 @@ package kube
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"go.podman.io/podman/v6/libpod"
 	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
 )
 
-// KubeSeccompPaths holds information about a pod YAML's seccomp configuration
+// SeccompAnnotationPaths holds information about a pod YAML's seccomp configuration
 // it holds both container and pod seccomp paths
-type KubeSeccompPaths struct {
+type SeccompAnnotationPaths struct {
 	containerPaths map[string]string
 	podPath        string
 }
 
-// FindForContainer checks whether a container has a seccomp path configured for it
-// if not, it returns the podPath, which should always have a value
-func (k *KubeSeccompPaths) FindForContainer(ctrName string) string {
-	if path, ok := k.containerPaths[ctrName]; ok {
-		return path
-	}
-	return k.podPath
+// FindForContainer checks whether a container has a seccomp path configured for it.
+func (k *SeccompAnnotationPaths) FindForContainer(ctrName string) (string, bool) {
+	path, ok := k.containerPaths[ctrName]
+	return path, ok
 }
 
-// InitializeSeccompPaths takes annotations from the pod object metadata and finds annotations pertaining to seccomp
+// InitializeSeccompAnnotationPaths takes annotations from the pod object metadata and finds annotations pertaining to seccomp
 // it parses both pod and container level
 // if the annotation is of the form "localhost/%s", the seccomp profile will be set to profileRoot/%s
-func InitializeSeccompPaths(annotations map[string]string, profileRoot string) (*KubeSeccompPaths, error) {
-	seccompPaths := &KubeSeccompPaths{containerPaths: make(map[string]string)}
+func InitializeSeccompAnnotationPaths(annotations map[string]string, profileRoot string) (*SeccompAnnotationPaths, error) {
+	seccompAnnotationPaths := &SeccompAnnotationPaths{containerPaths: make(map[string]string)}
 	var err error
 	if annotations != nil {
 		for annKeyValue, seccomp := range annotations {
 			// check if it is prefaced with container.seccomp.security.alpha.kubernetes.io/
 			prefixAndCtr := strings.Split(annKeyValue, "/")
-			// FIXME: Rework for deprecation removal https://github.com/containers/podman/issues/27501
+			// TODO: Remove support for deprecated Kubernetes seccomp annotations in Podman 7.
+			// See https://github.com/containers/podman/issues/27501.
 			//nolint:staticcheck // deprecated k8s annotation constant
 			if prefixAndCtr[0]+"/" != v1.SeccompContainerAnnotationKeyPrefix {
 				continue
@@ -52,42 +51,62 @@ func InitializeSeccompPaths(annotations map[string]string, profileRoot string) (
 			if err != nil {
 				return nil, err
 			}
-			seccompPaths.containerPaths[prefixAndCtr[1]] = path
+			seccompAnnotationPaths.containerPaths[prefixAndCtr[1]] = path
 		}
-		// FIXME: Rework for deprecation removal https://github.com/containers/podman/issues/27501
+		// TODO: Remove support for deprecated Kubernetes seccomp annotations in Podman 7.
+		// See https://github.com/containers/podman/issues/27501.
 		//nolint:staticcheck // deprecated k8s annotation constant
 		podSeccomp, ok := annotations[v1.SeccompPodAnnotationKey]
 		if ok {
-			seccompPaths.podPath, err = verifySeccompPath(podSeccomp, profileRoot)
-		} else {
-			seccompPaths.podPath, err = libpod.DefaultSeccompPath()
+			seccompAnnotationPaths.podPath, err = verifySeccompPath(podSeccomp, profileRoot)
 		}
 		if err != nil {
 			return nil, err
 		}
 	}
-	return seccompPaths, nil
+	return seccompAnnotationPaths, nil
 }
 
 // verifySeccompPath takes a path and checks whether it is a default, unconfined, or a path
 // the available options are parsed as defined in https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
 func verifySeccompPath(path string, profileRoot string) (string, error) {
 	switch path {
-	// FIXME: Rework for deprecation removal https://github.com/containers/podman/issues/27501
+	// TODO: Remove support for deprecated Kubernetes seccomp annotations in Podman 7.
+	// See https://github.com/containers/podman/issues/27501.
 	//nolint:staticcheck // deprecated k8s seccomp constant
 	case v1.DeprecatedSeccompProfileDockerDefault:
 		fallthrough
-	// FIXME: Rework for deprecation removal https://github.com/containers/podman/issues/27501
+	// TODO: Remove support for deprecated Kubernetes seccomp annotations in Podman 7.
+	// See https://github.com/containers/podman/issues/27501.
 	//nolint:staticcheck // deprecated k8s seccomp constant
 	case v1.SeccompProfileRuntimeDefault:
 		return libpod.DefaultSeccompPath()
 	case "unconfined":
 		return path, nil
 	default:
-		parts := strings.Split(path, "/")
-		if parts[0] == "localhost" {
-			return filepath.Join(profileRoot, parts[1]), nil
+		if profile, ok := strings.CutPrefix(path, "localhost/"); ok {
+			if profile == "" {
+				return "", fmt.Errorf("invalid seccomp path: %s", path)
+			}
+			if err := validateSeccompLocalhostProfile(profile); err != nil {
+				return "", fmt.Errorf("invalid seccomp profile %q: %w", profile, err)
+			}
+			return filepath.Join(profileRoot, filepath.FromSlash(profile)), nil
 		}
 		return "", fmt.Errorf("invalid seccomp path: %s", path)
 	}
+}
+
+// validateSeccompLocalhostProfile ensures that targetPath is relative
+// and does not contain any ".." path elements.
+func validateSeccompLocalhostProfile(targetPath string) error {
+	if filepath.IsAbs(targetPath) {
+		return fmt.Errorf("must be a relative path")
+	}
+
+	if slices.Contains(strings.Split(filepath.ToSlash(targetPath), "/"), "..") {
+		return fmt.Errorf("must not contain '..'")
+	}
+
+	return nil
 }

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -31,10 +31,12 @@ import (
 	"go.podman.io/podman/v6/pkg/bindings"
 	"go.podman.io/podman/v6/pkg/bindings/play"
 	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	metav1 "go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/apis/meta/v1"
 	"go.podman.io/podman/v6/pkg/util"
 	. "go.podman.io/podman/v6/test/utils"
 	"go.podman.io/podman/v6/utils"
 	"go.podman.io/storage/pkg/stringid"
+	"sigs.k8s.io/yaml"
 )
 
 var secretYaml = `
@@ -1569,6 +1571,15 @@ func generateKubeYaml(kind string, object any, pathname string) error {
 	}
 
 	return writeYaml(k, pathname)
+}
+
+// generateKubeObjectYaml marshals a kubernetes object and writes it as a YAML document.
+func generateKubeObjectYaml(object any, pathname string) error {
+	content, err := yaml.Marshal(object)
+	if err != nil {
+		return err
+	}
+	return writeYaml(string(content), pathname)
 }
 
 // generateMultiDocKubeYaml writes multiple kube objects in one Yaml document.
@@ -3532,18 +3543,41 @@ spec:
 
 	It("seccomp container level", func() {
 		SkipIfRemote("podman-remote does not support --seccomp-profile-root flag")
-		// expect kube play is expected to set a seccomp label if it's applied as an annotation
 		jsonFile, err := podmanTest.CreateSeccompJSON(seccompLinkEPERM)
 		if err != nil {
 			GinkgoWriter.Println(err)
 			Skip("Failed to prepare seccomp.json for test.")
 		}
+		defer os.Remove(jsonFile)
 
-		ctrAnnotation := "container.seccomp.security.alpha.kubernetes.io/" + defaultCtrName
-		ctr := getCtr(withCmd([]string{"ln"}), withArg([]string{"/etc/motd", "/noneShallPass"}))
-
-		pod := getPod(withCtr(ctr), withAnnotation(ctrAnnotation, "localhost/"+filepath.Base(jsonFile)))
-		err = generateKubeYaml("pod", pod, kubeYaml)
+		profile := filepath.Base(jsonFile)
+		pod := &v1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultPodName,
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyNever,
+				Containers: []v1.Container{
+					{
+						Name:    defaultCtrName,
+						Image:   defaultCtrImage,
+						Command: []string{"ln"},
+						Args:    []string{"/etc/motd", "/noneShallPass"},
+						SecurityContext: &v1.SecurityContext{
+							SeccompProfile: &v1.SeccompProfile{
+								Type:             v1.SeccompProfileTypeLocalhost,
+								LocalhostProfile: &profile,
+							},
+						},
+					},
+				},
+			},
+		}
+		err = generateKubeObjectYaml(pod, kubeYaml)
 		Expect(err).ToNot(HaveOccurred())
 
 		// CreateSeccompJSON will put the profile into podmanTest.TempDir. Use --seccomp-profile-root to tell kube play where to look
@@ -3551,7 +3585,7 @@ spec:
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
-		ctrName := getCtrNameInPod(pod)
+		ctrName := defaultPodName + "-" + defaultCtrName
 		wait := podmanTest.Podman([]string{"wait", ctrName})
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).Should(Exit(0), "podman wait %s", ctrName)
@@ -3564,7 +3598,6 @@ spec:
 
 	It("seccomp pod level", func() {
 		SkipIfRemote("podman-remote does not support --seccomp-profile-root flag")
-		// expect kube play is expected to set a seccomp label if it's applied as an annotation
 		jsonFile, err := podmanTest.CreateSeccompJSON(seccompLinkEPERM)
 		if err != nil {
 			GinkgoWriter.Println(err)
@@ -3572,10 +3605,34 @@ spec:
 		}
 		defer os.Remove(jsonFile)
 
-		ctr := getCtr(withCmd([]string{"ln"}), withArg([]string{"/etc/motd", "/noPodsShallPass"}))
-
-		pod := getPod(withCtr(ctr), withAnnotation("seccomp.security.alpha.kubernetes.io/pod", "localhost/"+filepath.Base(jsonFile)))
-		err = generateKubeYaml("pod", pod, kubeYaml)
+		profile := filepath.Base(jsonFile)
+		pod := &v1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultPodName,
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyNever,
+				SecurityContext: &v1.PodSecurityContext{
+					SeccompProfile: &v1.SeccompProfile{
+						Type:             v1.SeccompProfileTypeLocalhost,
+						LocalhostProfile: &profile,
+					},
+				},
+				Containers: []v1.Container{
+					{
+						Name:    defaultCtrName,
+						Image:   defaultCtrImage,
+						Command: []string{"ln"},
+						Args:    []string{"/etc/motd", "/noPodsShallPass"},
+					},
+				},
+			},
+		}
+		err = generateKubeObjectYaml(pod, kubeYaml)
 		Expect(err).ToNot(HaveOccurred())
 
 		// CreateSeccompJSON will put the profile into podmanTest.TempDir. Use --seccomp-profile-root to tell kube play where to look
@@ -3583,15 +3640,98 @@ spec:
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
-		podName := getCtrNameInPod(pod)
-		wait := podmanTest.Podman([]string{"wait", podName})
+		ctrName := defaultPodName + "-" + defaultCtrName
+		wait := podmanTest.Podman([]string{"wait", ctrName})
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).Should(ExitCleanly())
 
-		logs := podmanTest.Podman([]string{"logs", podName})
+		logs := podmanTest.Podman([]string{"logs", ctrName})
 		logs.WaitWithDefaultTimeout()
 		Expect(logs).Should(Exit(0))
 		Expect(logs.ErrorToString()).To(ContainSubstring("ln: /noPodsShallPass: Operation not permitted"))
+	})
+
+	It("rejects seccomp Localhost profile with backsteps", func() {
+		SkipIfRemote("podman-remote does not support --seccomp-profile-root flag")
+		profile := "profiles/../seccomp.json"
+
+		pod := &v1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultPodName,
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyNever,
+				Containers: []v1.Container{
+					{
+						Name:  defaultCtrName,
+						Image: defaultCtrImage,
+						SecurityContext: &v1.SecurityContext{
+							SeccompProfile: &v1.SeccompProfile{
+								Type:             v1.SeccompProfileTypeLocalhost,
+								LocalhostProfile: &profile,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := generateKubeObjectYaml(pod, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", "--seccomp-profile-root", podmanTest.TempDir, kubeYaml})
+		kube.WaitWithDefaultTimeout()
+
+		Expect(kube).Should(Exit(125))
+		Expect(kube.ErrorToString()).To(ContainSubstring("must not contain '..'"))
+	})
+
+	It("supports deprecated seccomp container annotation", func() {
+		SkipIfRemote("podman-remote does not support --seccomp-profile-root flag")
+
+		jsonFile, err := podmanTest.CreateSeccompJSON(seccompLinkEPERM)
+		if err != nil {
+			GinkgoWriter.Println(err)
+			Skip("Failed to prepare seccomp.json for test.")
+		}
+		defer os.Remove(jsonFile)
+
+		ctrAnnotation := "container.seccomp.security.alpha.kubernetes.io/" + defaultCtrName
+		ctr := getCtr(
+			withCmd([]string{"ln"}),
+			withArg([]string{"/etc/motd", "/annotationShallNotPass"}),
+		)
+
+		pod := getPod(
+			withCtr(ctr),
+			withAnnotation(
+				ctrAnnotation,
+				"localhost/"+filepath.Base(jsonFile),
+			),
+		)
+
+		err = generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", "--seccomp-profile-root", podmanTest.TempDir, kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+		Expect(kube.ErrorToString()).To(ContainSubstring("seccomp annotation is deprecated"))
+
+		ctrName := getCtrNameInPod(pod)
+
+		wait := podmanTest.Podman([]string{"wait", ctrName})
+		wait.WaitWithDefaultTimeout()
+		Expect(wait).Should(ExitCleanly())
+
+		logs := podmanTest.Podman([]string{"logs", ctrName})
+		logs.WaitWithDefaultTimeout()
+		Expect(logs).Should(Exit(0))
+		Expect(logs.ErrorToString()).To(ContainSubstring("Operation not permitted"))
 	})
 
 	It("with pull policy of never should be 125", func() {


### PR DESCRIPTION
Fixes: #27501 

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Podman kube play now uses Kubernetes securityContext.seccompProfile fields for seccomp configuration while maintaining backward compatibility with Kubernetes seccomp annotations. Kubernetest seccomp annotations will be deprecated in Podman 6.5 (version subject to change).
```

#### Description
Instead of using the deprecated seccomp annotations for seccomp configuration, this now uses the native securityContext.seccompProfile field. Removed seccomp.go because annotations no longer need to be parsed before generating the spec. Unit tests have also been added.
