### PR TITLE
ci: gate releases on podman-machine-os release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,39 @@ jobs:
       version: ${{ steps.getversion.outputs.version }}
       buildonly: ${{ steps.buildonly.outputs.buildonly }}
 
+  gate-machine-os-release:
+    name: Gate on podman-machine-os release
+    runs-on: ubuntu-latest
+    needs: check
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}
+      BUILDONLY: ${{ needs.check.outputs.buildonly }}
+      VERSION: ${{ needs.check.outputs.version }}
+      MACHINE_OS_REPO: podman-container-tools/podman-machine-os
+    steps:
+    - name: Verify matching podman-machine-os release exists
+      run: |
+        if [[ "$BUILDONLY" == "true" ]]
+        then
+          echo "::notice::Skipping podman-machine-os release gate for build-only run"
+          exit 0
+        fi
+
+        if ! gh release view "$VERSION" --repo "$MACHINE_OS_REPO" >/dev/null
+        then
+          echo "::error::Missing matching release '$VERSION' in $MACHINE_OS_REPO"
+          echo "::error::Release Podman Machine OS before cutting the Podman release."
+          exit 1
+        fi
+
+        echo "::notice::Found matching podman-machine-os release '$VERSION'"
+
   build-artifacts:
     name: Build Artifacts
     uses: ./.github/workflows/release-build-artifacts.yml
-    needs: check
+    needs: [check, gate-machine-os-release]
     with:
       version: ${{ needs.check.outputs.version }}
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
     permissions:
       contents: read
     env:
-      GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILDONLY: ${{ needs.check.outputs.buildonly }}
       VERSION: ${{ needs.check.outputs.version }}
       MACHINE_OS_REPO: podman-container-tools/podman-machine-os
@@ -123,7 +123,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     if: needs.check.outputs.buildonly == 'false'
-    needs: [check, build-artifacts]
+    needs: [check, gate-machine-os-release, build-artifacts]
     permissions:
       contents: write
     env:

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -161,11 +161,12 @@ spelled with complete minutiae.
          GitHub release in the `podman-machine-os` repository. Wait for this
          workflow to complete successfully.
    1. Return to the Podman repo.
-   1. The Podman [release workflow](https://github.com/podman-container-tools/podman/actions/workflows/release.yml)
-      checks for a matching GitHub release in `podman-machine-os` before it runs the
-      artifact build or release jobs. Build-only dispatches skip this check. If the
-      `do-not-merge/wait-machine-os-build` label is still present after the
-      `podman-machine-os` release completes, remove it before merging.
+   1. Once the `podman-machine-os` release completes, remove the
+      `do-not-merge/wait-machine-os-build` label before merging the Podman bump PR.
+      The Podman [release workflow](https://github.com/podman-container-tools/podman/actions/workflows/release.yml)
+      runs only after the Podman tag is pushed, so this matching-release check is a
+      secondary failsafe before the artifact build or release jobs start.
+      Build-only dispatches skip this check.
    1. Wait for all other PR checks to pass.
    1. Wait for other maintainers to merge the PR.
    1. Tag the `Bump to vX.Y.Z` commit as a release by running

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -148,8 +148,8 @@ spelled with complete minutiae.
    1. In the PR, under the *Checks* tab, a GitHub Actions [workflow](https://github.com/podman-container-tools/podman/actions/workflows/machine-os-pr.yml) will run.
       This workflow opens a PR on the [podman-machine-os repo](https://github.com/podman-container-tools/podman-machine-os)
       to build VM images for the release, links that PR in a comment on the Podman PR,
-      and applies the `do-not-merge/wait-machine-os-build` label until the images are built
-      and published.
+      and applies the `do-not-merge/wait-machine-os-build` label while the machine-os
+      release is still pending.
    1. Go to the `podman-machine-os` bump PR, by clicking the link in the comment, or by finding it in the [podman-machine-os repo](https://github.com/podman-container-tools/podman-machine-os/pulls).
       1. Wait for automation to finish running
       1. Once you are sure that there will be no more force pushes on the Podman release PR, merge the `podman-machine-os` bump PR
@@ -160,9 +160,12 @@ spelled with complete minutiae.
          GitHub Actions workflow. It publishes the images to Quay and creates a
          GitHub release in the `podman-machine-os` repository. Wait for this
          workflow to complete successfully.
-   1. Return to the Podman repo
-   1. The `do-not-merge/wait-machine-os-build` label should be automatically
-      un-set once the `podman-machine-os` release is finished.
+   1. Return to the Podman repo.
+   1. The Podman [release workflow](https://github.com/podman-container-tools/podman/actions/workflows/release.yml)
+      checks for a matching GitHub release in `podman-machine-os` before it runs the
+      artifact build or release jobs. Build-only dispatches skip this check. If the
+      `do-not-merge/wait-machine-os-build` label is still present after the
+      `podman-machine-os` release completes, remove it before merging.
    1. Wait for all other PR checks to pass.
    1. Wait for other maintainers to merge the PR.
    1. Tag the `Bump to vX.Y.Z` commit as a release by running


### PR DESCRIPTION
#### Summary

This wires an actual release gate into the Podman release workflow.

Right now the version-bump PR still gets the do-not-merge/wait-machine-os-build label, but that label no longer blocks anything on its own. Because of that, it's possible to cut a Podman release before the matching podman-machine-os release is out.

With this change, non-build-only runs of .github/workflows/release.yml check for a matching release in podman-machine-os before continuing. If that release is missing, the workflow stops before artifact builds and release creation.

I also updated RELEASE_PROCESS.md so the documented release steps match the current workflow behavior and label name.

Fixes #28920

#### Testing

- git diff --check
- Parsed .github/workflows/release.yml as YAML
- Manually reviewed the workflow flow to confirm:
  - build-only runs skip the new gate
  - release runs wait for the new gate before building artifacts