### PR TITLE
Warn when device group is not mapped in rootless user namespaces

### DIFF
--- a/pkg/domain/infra/abi/system_linux.go
+++ b/pkg/domain/infra/abi/system_linux.go
@@ -71,6 +71,11 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool, 
 		return fmt.Errorf("could not get rootless state directory: %w", err)
 	}
 
+	// Save device GIDs from --device flags before entering user namespace.
+	// This runs on every container invocation so device_gids file is always
+	// up to date regardless of whether a new namespace is created or joined.
+	rootless.SaveDeviceGIDsFromArgs(stateDir)
+
 	became, ret, err := rootless.TryJoinPauseProcess(stateDir)
 	if err != nil {
 		return err

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -6,10 +6,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	gosignal "os/signal"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -212,6 +214,72 @@ func copyMappings(from, to string) error {
 	return os.WriteFile(to, content, 0o600)
 }
 
+// saveDeviceGIDsFromArgs reads --device flags from os.Args and saves
+// each device's real host GID to a file in stateDir before entering
+// the user namespace. After re-exec, device GIDs may appear as 65534
+// (overflow) if unmapped, so we need to save them while still on host.
+func SaveDeviceGIDsFromArgs(stateDir string) {
+	deviceGIDs := make(map[string]int)
+
+	args := os.Args
+	for i, arg := range args {
+		var devicePath string
+		if arg == "--device" && i+1 < len(args) {
+			devicePath = args[i+1]
+		} else if len(arg) > 9 && arg[:9] == "--device=" {
+			devicePath = arg[9:]
+		}
+		if devicePath == "" {
+			continue
+		}
+		// Strip options like /dev/foo:bar:rw
+		if idx := strings.Index(devicePath, ":"); idx >= 0 {
+			devicePath = devicePath[:idx]
+		}
+		var st unix.Stat_t
+		if err := unix.Stat(devicePath, &st); err != nil {
+			logrus.Debugf("saveDeviceGIDsFromArgs: cannot stat %s: %v", devicePath, err)
+			continue
+		}
+		// If it's a directory, walk it and save GIDs for each device file
+		if st.Mode&unix.S_IFMT == unix.S_IFDIR {
+			_ = filepath.WalkDir(devicePath, func(p string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.Type()&os.ModeDevice == os.ModeDevice {
+					var dst unix.Stat_t
+					if err := unix.Stat(p, &dst); err == nil {
+						deviceGIDs[p] = int(dst.Gid)
+						logrus.Debugf("saveDeviceGIDsFromArgs: %s has host GID %d", p, dst.Gid)
+					}
+				}
+				return nil
+			})
+		} else {
+			deviceGIDs[devicePath] = int(st.Gid)
+			logrus.Debugf("saveDeviceGIDsFromArgs: %s has host GID %d", devicePath, st.Gid)
+		}
+	}
+
+	if len(deviceGIDs) == 0 {
+		return
+	}
+
+	var lines []string
+	for path, gid := range deviceGIDs {
+		lines = append(lines, fmt.Sprintf("%s:%d", path, gid))
+	}
+	deviceGIDsFile := stateDir + "/device_gids"
+	if mkdirErr := os.MkdirAll(stateDir, 0o700); mkdirErr == nil {
+		if writeErr := os.WriteFile(deviceGIDsFile, []byte(strings.Join(lines, "\n")), 0o600); writeErr != nil {
+			logrus.Debugf("saveDeviceGIDsFromArgs: failed to write %s: %v", deviceGIDsFile, writeErr)
+		} else {
+			logrus.Debugf("saveDeviceGIDsFromArgs: saved to %s", deviceGIDsFile)
+		}
+	}
+}
+
 func becomeRootInUserNS(stateDir string) (_ bool, _ int, retErr error) {
 	hasCapSysAdmin, err := unshare.HasCapSysAdmin()
 	if err != nil {
@@ -278,6 +346,29 @@ func becomeRootInUserNS(stateDir string) (_ bool, _ int, retErr error) {
 			C.reexec_in_user_namespace_wait(C.int(pid), 0)
 		}
 	}()
+
+	// Save host groups to file BEFORE re-exec.
+	// After reexec_in_user_namespace, euid becomes 0 and os.Getgroups()
+	// returns namespace-mapped groups, not real host groups.
+	// addDevice reads this file to check if user can access a device's group.
+	if hostGroups, err := os.Getgroups(); err == nil {
+		parts := make([]string, len(hostGroups))
+		for i, g := range hostGroups {
+			parts[i] = strconv.Itoa(g)
+		}
+		groupsFile := stateDir + "/host_groups"
+		if mkdirErr := os.MkdirAll(stateDir, 0o755); mkdirErr == nil {
+			if writeErr := os.WriteFile(groupsFile, []byte(strings.Join(parts, ",")), 0o600); writeErr != nil {
+				logrus.Debugf("Failed to save host groups to file: %v", writeErr)
+			} else {
+				logrus.Debugf("Saved host groups to %s: %s", groupsFile, strings.Join(parts, ","))
+			}
+		}
+	}
+
+	// Save device GIDs from --device flags BEFORE re-exec.
+	// After re-exec device GIDs may be unmapped (appear as 65534).
+	SaveDeviceGIDsFromArgs(stateDir)
 
 	pidC := C.reexec_in_user_namespace(C.int(r.Fd()), cStateDir)
 	pid = int(pidC)

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -44,6 +45,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string, config *config.Co
 		}
 		return nil
 	}
+	warnedGIDs := make(map[int]bool)
 	devs := strings.Split(devicePath, ":")
 	resolvedDevicePath := devs[0]
 	// check if it is a symbolic link
@@ -83,7 +85,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string, config *config.Co
 				if devmode != "" {
 					device = fmt.Sprintf("%s:%s", device, devmode)
 				}
-				if err := addDevice(g, device); err != nil {
+				if err := addDevice(g, device, warnedGIDs); err != nil {
 					return fmt.Errorf("failed to add %s device: %w", dpath, err)
 				}
 			}
@@ -96,7 +98,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string, config *config.Co
 		}
 		return nil
 	}
-	return addDevice(g, strings.Join(append([]string{resolvedDevicePath}, devs[1:]...), ":"))
+	return addDevice(g, strings.Join(append([]string{resolvedDevicePath}, devs[1:]...), ":"), warnedGIDs)
 }
 
 func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, mask, unmask []string, g *generate.Generator) {
@@ -128,6 +130,130 @@ func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, mask, unmask
 	}
 }
 
+// findUnmappedDeviceGID finds the host GID of a device whose GID is not
+// mapped in the current user namespace (appears as overflowGID).
+// It reads the real host GID from the device_gids file saved before re-exec.
+func getDeviceHostGID(devicePath string) int {
+	uid := os.Getenv("_CONTAINERS_ROOTLESS_UID")
+	if uid == "" {
+		return -1
+	}
+	deviceGIDsFile := fmt.Sprintf("/run/user/%s/libpod/tmp/device_gids", uid)
+	content, err := os.ReadFile(deviceGIDsFile)
+	if err != nil {
+		return -1
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(content)), "\n") {
+		idx := strings.LastIndex(line, ":")
+		if idx < 0 {
+			continue
+		}
+		path := line[:idx]
+		gidStr := line[idx+1:]
+		if path == devicePath {
+			gid, err := strconv.Atoi(gidStr)
+			if err == nil {
+				logrus.Debugf("getDeviceHostGID: %s → host GID %d", devicePath, gid)
+				return gid
+			}
+		}
+	}
+	return -1
+}
+
+// containerGIDToHostGID converts a container-namespace GID to the real host GID
+// by reading /proc/self/gid_map and doing a reverse lookup.
+// Format of /proc/self/gid_map: containerID hostID size
+func containerGIDToHostGID(containerGID int) int {
+	content, err := os.ReadFile("/proc/self/gid_map")
+	if err != nil {
+		return containerGID
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(content)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			continue
+		}
+		cStart, err1 := strconv.Atoi(fields[0])
+		hStart, err2 := strconv.Atoi(fields[1])
+		size, err3 := strconv.Atoi(fields[2])
+		if err1 != nil || err2 != nil || err3 != nil {
+			continue
+		}
+		// Check if containerGID falls in this range
+		if containerGID >= cStart && containerGID < cStart+size {
+			// Reverse map: hostGID = hStart + (containerGID - cStart)
+			hostGID := hStart + (containerGID - cStart)
+			logrus.Debugf("containerGIDToHostGID: container GID %d → host GID %d", containerGID, hostGID)
+			return hostGID
+		}
+	}
+	// No mapping found — return original
+	return containerGID
+}
+
+// overflowGID returns the overflow GID used by the kernel when a GID
+// has no mapping in the current user namespace.
+func overflowGID() int {
+	content, err := os.ReadFile("/proc/sys/kernel/overflowgid")
+	if err != nil {
+		return 65534 // default
+	}
+	gid, err := strconv.Atoi(strings.TrimSpace(string(content)))
+	if err != nil {
+		return 65534
+	}
+	return gid
+}
+
+// getHostGroups reads the host supplementary groups that were saved
+// before entering the user namespace. After re-exec, os.Getgroups()
+// returns namespace-mapped groups, not real host groups.
+func getHostGroups() []int {
+	// Try reading from state dir file first
+	// stateDir is typically /run/user/<uid>/libpod
+	uid := os.Getenv("_CONTAINERS_ROOTLESS_UID")
+	if uid == "" {
+		// Not in rootless mode or env not set
+		groups, _ := os.Getgroups()
+		return groups
+	}
+
+	// Common state dir locations
+	// stateDir in rootless_linux.go is runtimeDir/libpod/tmp
+	stateDirs := []string{
+		fmt.Sprintf("/run/user/%s/libpod/tmp/host_groups", uid),
+		fmt.Sprintf("/run/user/%s/libpod/host_groups", uid),
+	}
+
+	for _, path := range stateDirs {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var groups []int
+		for s := range strings.SplitSeq(strings.TrimSpace(string(content)), ",") {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			g, err := strconv.Atoi(s)
+			if err != nil {
+				continue
+			}
+			groups = append(groups, g)
+		}
+		if len(groups) > 0 {
+			logrus.Debugf("Read host groups from %s: %v", path, groups)
+			return groups
+		}
+	}
+
+	// Fallback
+	groups, _ := os.Getgroups()
+	return groups
+}
+
 // deviceGIDMissingFromSubgid checks if the device's owning GID is accessible
 // to the current rootless user. If the user is a member of the device's group
 // on the host but that GID is not in /etc/subgid, it logs a clear warning
@@ -135,89 +261,96 @@ func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, mask, unmask
 //
 // Returns true if the GID is already mapped (no action needed),
 // false if it is missing and the user should be warned.
-func deviceGIDMissingFromSubgid(src string) bool {
+func deviceGIDMissingFromSubgid(src string, warnedGIDs map[int]bool) bool {
 	// stat the device to get its GID
 	var st syscall.Stat_t
 	if err := syscall.Stat(src, &st); err != nil {
-		// cannot stat — let it proceed, error will surface later
+		// cannot stat let it proceed, error will surface later
 		return true
 	}
 	deviceGID := int(st.Gid)
 
-	// Get current process supplementary groups (host groups of the user)
-	hostGroups, err := os.Getgroups()
-	if err != nil {
-		return true
-	}
-
-	// Check if user is a member of the device group on the host
-	userIsMember := false
-	for _, g := range hostGroups {
-		if g == deviceGID {
-			userIsMember = true
-			break
+	// The device GID we got from stat() is a container-namespace GID.
+	// We need the real host GID for comparison with host groups.
+	// If the GID is overflowGID (65534), it means the device's real host GID
+	// has NO mapping in this user namespace — we cannot determine it from
+	// the namespace alone. In this case, find it from host_groups by exclusion.
+	// Otherwise, reverse-map container GID → host GID via /proc/self/gid_map.
+	ovGID := overflowGID()
+	if deviceGID == ovGID {
+		// Device GID is unmapped in this namespace.
+		// Read real host GID from file saved before re-exec.
+		realGID := getDeviceHostGID(src)
+		if realGID >= 0 {
+			logrus.Debugf("deviceGIDMissingFromSubgid: overflow GID, real host GID=%d", realGID)
+			deviceGID = realGID
+		} else {
+			logrus.Debugf("deviceGIDMissingFromSubgid: overflow GID but no saved GID for %s", src)
+			return true
 		}
+	} else {
+		deviceGID = containerGIDToHostGID(deviceGID)
 	}
 
-	if !userIsMember {
-		// User is not even a member of this group on the host.
-		// Warn them — Podman cannot fix this automatically.
-		logrus.Warnf("Device %s is owned by GID %d. "+
-			"You are not a member of this group on the host. "+
-			"Access will be denied inside the container. "+
-			"Ask your administrator to run: sudo usermod -aG <groupname> %s",
-			src, deviceGID, os.Getenv("USER"))
+	// Deduplicate warnings — if we already warned about this GID
+	// (e.g. directory with many devices sharing the same group), skip.
+	if warnedGIDs[deviceGID] {
 		return false
 	}
+	warnedGIDs[deviceGID] = true
 
-	// User IS a member — now check if GID is in /etc/subgid
-	subgidFile := "/etc/subgid"
+	// Get host groups saved before entering user namespace.
+	// os.Getgroups() cannot be used here because addDevice runs inside
+	// the user namespace where groups are remapped.
+	hostGroups := getHostGroups()
+	if len(hostGroups) == 0 {
+		return true
+	}
+	groupName := fmt.Sprintf("GID %d", deviceGID)
+	if grp, err := user.LookupGroupId(fmt.Sprintf("%d", deviceGID)); err == nil {
+		groupName = grp.Name
+	}
+	deviceName := filepath.Base(src)
 	username := os.Getenv("USER")
 	if username == "" {
-		// fallback: use UID to find username
-		u, err := user.LookupId(fmt.Sprintf("%d", os.Getuid()))
-		if err == nil {
+		if u, err := user.LookupId(fmt.Sprintf("%d", os.Getuid())); err == nil {
 			username = u.Username
 		}
 	}
 
-	content, err := os.ReadFile(subgidFile)
-	if err != nil {
+	// Check if user is a member of the device group on the host
+	userIsMember := slices.Contains(hostGroups, deviceGID)
+
+	if !userIsMember {
+		// User is not even a member of this group on the host.
+		// Warn them that  Podman cannot fix this automatically.
+		msg := fmt.Sprintf("Device %s is owned by group '%s' (GID %d).\n"+
+			"You are not a member of this group on the host.\n"+
+			"Access will be denied inside the container.\n"+
+			"To fix run:\n"+
+			"sudo usermod -aG %s %s\n"+
+			"Then log out and log back in.",
+			deviceName, groupName, deviceGID, groupName, username)
+		logrus.Warn(msg)
+		return false
+	}
+
+	// User IS a member check /etc/subgid
+	if isGIDInSubgid(username, deviceGID, "/etc/subgid") {
 		return true
 	}
-
-	// Parse /etc/subgid line by line
-	// Format: username:start:count
-	for _, line := range strings.Split(string(content), "\n") {
-		parts := strings.Split(strings.TrimSpace(line), ":")
-		if len(parts) != 3 {
-			continue
-		}
-		if parts[0] != username {
-			continue
-		}
-		start, err1 := strconv.Atoi(parts[1])
-		count, err2 := strconv.Atoi(parts[2])
-		if err1 != nil || err2 != nil {
-			continue
-		}
-		// Check if deviceGID falls in this range
-		if deviceGID >= start && deviceGID < start+count {
-			return true // already mapped, all good
-		}
-	}
-
-	// GID is not in subgid — warn with exact fix command
-	logrus.Warnf("Device %s is owned by GID %d. "+
-		"You are a member of this group on the host, but GID %d is not in /etc/subgid. "+
-		"The device will appear as 'nobody:nobody' inside the container and access will be denied. "+
-		"To fix this, run: echo \"%s:%d:1\" | sudo tee -a /etc/subgid && podman system migrate",
-		src, deviceGID, deviceGID, username, deviceGID)
-
+	// GID is not in subgid , warn with exact fix command
+	msg := fmt.Sprintf("Device %s is owned by group '%s' (GID %d).\n"+
+		"You are a member of this group on the host, but GID %d is not in /etc/subgid.\n"+
+		"The device will appear as 'nobody:nobody' inside the container and access will be denied.\n"+
+		"To fix this, run:\n"+
+		"echo \"%s:%d:1\" | sudo tee -a /etc/subgid && podman system migrate",
+		deviceName, groupName, deviceGID, deviceGID, username, deviceGID)
+	logrus.Warn(msg)
 	return false
 }
 
-func addDevice(g *generate.Generator, device string) error {
+func addDevice(g *generate.Generator, device string, warnedGIDs map[int]bool) error {
 	src, dst, permissions, err := ParseDevice(device)
 	if err != nil {
 		return err
@@ -232,7 +365,7 @@ func addDevice(g *generate.Generator, device string) error {
 		}
 		// Check device GID mapping and warn user if access will fail
 		// This runs only when --device is used in rootless mode
-		deviceGIDMissingFromSubgid(src)
+		deviceGIDMissingFromSubgid(src, warnedGIDs)
 		perm := "ro"
 		if strings.Contains(permissions, "w") {
 			perm = "rw"
@@ -280,4 +413,32 @@ func shouldMask(mask string, unmask []string) bool {
 		}
 	}
 	return true
+}
+
+// isGIDInSubgid checks whether the given GID is covered by any subgid
+// range for username in the given file (normally /etc/subgid).
+// Accepting the path as a parameter makes the function testable.
+func isGIDInSubgid(username string, gid int, subgidFile string) bool {
+	content, err := os.ReadFile(subgidFile)
+	if err != nil {
+		return false
+	}
+	for line := range strings.SplitSeq(string(content), "\n") {
+		parts := strings.Split(strings.TrimSpace(line), ":")
+		if len(parts) != 3 {
+			continue
+		}
+		if parts[0] != username {
+			continue
+		}
+		start, err1 := strconv.Atoi(parts[1])
+		count, err2 := strconv.Atoi(parts[2])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		if gid >= start && gid < start+count {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/user"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/podman/v6/libpod/define"
@@ -125,6 +128,95 @@ func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, mask, unmask
 	}
 }
 
+// deviceGIDMissingFromSubgid checks if the device's owning GID is accessible
+// to the current rootless user. If the user is a member of the device's group
+// on the host but that GID is not in /etc/subgid, it logs a clear warning
+// explaining exactly how to fix the issue.
+//
+// Returns true if the GID is already mapped (no action needed),
+// false if it is missing and the user should be warned.
+func deviceGIDMissingFromSubgid(src string) bool {
+	// stat the device to get its GID
+	var st syscall.Stat_t
+	if err := syscall.Stat(src, &st); err != nil {
+		// cannot stat — let it proceed, error will surface later
+		return true
+	}
+	deviceGID := int(st.Gid)
+
+	// Get current process supplementary groups (host groups of the user)
+	hostGroups, err := os.Getgroups()
+	if err != nil {
+		return true
+	}
+
+	// Check if user is a member of the device group on the host
+	userIsMember := false
+	for _, g := range hostGroups {
+		if g == deviceGID {
+			userIsMember = true
+			break
+		}
+	}
+
+	if !userIsMember {
+		// User is not even a member of this group on the host.
+		// Warn them — Podman cannot fix this automatically.
+		logrus.Warnf("Device %s is owned by GID %d. "+
+			"You are not a member of this group on the host. "+
+			"Access will be denied inside the container. "+
+			"Ask your administrator to run: sudo usermod -aG <groupname> %s",
+			src, deviceGID, os.Getenv("USER"))
+		return false
+	}
+
+	// User IS a member — now check if GID is in /etc/subgid
+	subgidFile := "/etc/subgid"
+	username := os.Getenv("USER")
+	if username == "" {
+		// fallback: use UID to find username
+		u, err := user.LookupId(fmt.Sprintf("%d", os.Getuid()))
+		if err == nil {
+			username = u.Username
+		}
+	}
+
+	content, err := os.ReadFile(subgidFile)
+	if err != nil {
+		return true
+	}
+
+	// Parse /etc/subgid line by line
+	// Format: username:start:count
+	for _, line := range strings.Split(string(content), "\n") {
+		parts := strings.Split(strings.TrimSpace(line), ":")
+		if len(parts) != 3 {
+			continue
+		}
+		if parts[0] != username {
+			continue
+		}
+		start, err1 := strconv.Atoi(parts[1])
+		count, err2 := strconv.Atoi(parts[2])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		// Check if deviceGID falls in this range
+		if deviceGID >= start && deviceGID < start+count {
+			return true // already mapped, all good
+		}
+	}
+
+	// GID is not in subgid — warn with exact fix command
+	logrus.Warnf("Device %s is owned by GID %d. "+
+		"You are a member of this group on the host, but GID %d is not in /etc/subgid. "+
+		"The device will appear as 'nobody:nobody' inside the container and access will be denied. "+
+		"To fix this, run: echo \"%s:%d:1\" | sudo tee -a /etc/subgid && podman system migrate",
+		src, deviceGID, deviceGID, username, deviceGID)
+
+	return false
+}
+
 func addDevice(g *generate.Generator, device string) error {
 	src, dst, permissions, err := ParseDevice(device)
 	if err != nil {
@@ -138,6 +230,9 @@ func addDevice(g *generate.Generator, device string) error {
 		if err := fileutils.Exists(src); err != nil {
 			return err
 		}
+		// Check device GID mapping and warn user if access will fail
+		// This runs only when --device is used in rootless mode
+		deviceGIDMissingFromSubgid(src)
 		perm := "ro"
 		if strings.Contains(permissions, "w") {
 			perm = "rw"

--- a/pkg/specgen/generate/config_linux_test.go
+++ b/pkg/specgen/generate/config_linux_test.go
@@ -3,6 +3,8 @@
 package generate
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,5 +28,85 @@ func TestShouldMask(t *testing.T) {
 	for _, test := range tests {
 		val := shouldMask(test.mask, test.unmask)
 		assert.Equal(t, val, test.shouldMask)
+	}
+}
+
+func TestIsGIDInSubgid(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "subgid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	// All values derived from these — no magic numbers
+	const (
+		username   = "testuser"
+		rangeStart = 299000
+		rangeCount = 1000
+	)
+	rangeEnd := rangeStart + rangeCount
+	gidInside := rangeStart + 500 // 299500 — clearly inside
+	gidOutside := rangeStart - 1  // 298999 — clearly outside
+	baseContent := fmt.Sprintf("%s:%d:%d\n", username, rangeStart, rangeCount)
+
+	tests := []struct {
+		name     string
+		gid      int
+		content  string
+		expected bool // true = GID is missing from subgid
+	}{
+		{
+			name:     "GID inside range",
+			gid:      gidInside,
+			content:  baseContent,
+			expected: false, // mapped, NOT missing
+		},
+		{
+			name:     "GID outside range",
+			gid:      gidOutside,
+			content:  baseContent,
+			expected: true, // NOT mapped, missing
+		},
+		{
+			name:     "GID at range start boundary",
+			gid:      rangeStart,
+			content:  baseContent,
+			expected: false, // boundary included, NOT missing
+		},
+		{
+			name:     "GID at range end boundary",
+			gid:      rangeEnd - 1,
+			content:  baseContent,
+			expected: false, // last valid GID, NOT missing
+		},
+		{
+			name:     "GID explicitly added as single entry",
+			gid:      gidOutside,
+			content:  baseContent + fmt.Sprintf("%s:%d:1\n", username, gidOutside),
+			expected: false, // explicitly mapped, NOT missing
+		},
+		{
+			name:     "empty subgid file",
+			gid:      gidOutside,
+			content:  "",
+			expected: true, // nothing mapped, missing
+		},
+		{
+			name:     "wrong username in subgid",
+			gid:      gidInside,
+			content:  fmt.Sprintf("otheruser:%d:%d\n", rangeStart, rangeCount),
+			expected: true, // mapped for different user, missing for testuser
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := os.WriteFile(tmpFile.Name(), []byte(tt.content), 0o644)
+			assert.NoError(t, err)
+
+			found := isGIDInSubgid(username, tt.gid, tmpFile.Name())
+			assert.Equal(t, tt.expected, !found)
+		})
 	}
 }

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -167,4 +167,32 @@ var _ = Describe("Podman run device", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithErrorRegex(1, "head: /dev-host/kmsg: (Operation not permitted|Permission denied)"))
 	})
+	It("podman rootless warns when device GID not in subgid", func() {
+		SkipIfNotRootless("This warning only applies to rootless mode")
+		SkipIfRemote("Warning check requires local execution")
+		// /dev/input devices are owned by 'input' group — typically not in /etc/subgid
+		// Skip if /dev/input does not exist on this machine
+		if _, err := os.Stat("/dev/input"); err != nil {
+			Skip("/dev/input not available on this host")
+		}
+		session := podmanTest.Podman([]string{
+			"run", "--rm",
+			"--group-add", "keep-groups",
+			"--device", "/dev/input/",
+			ALPINE, "true",
+		})
+		session.WaitWithDefaultTimeout()
+		// Container should run (exit 0) — warning does not block execution
+		Expect(session).Should(ExitCleanly())
+
+		// Warning should mention subgid OR user not being a member
+		// (depends on whether ubuntu is in input group)
+		errOut := session.ErrorToString()
+		Expect(errOut).To(
+			Or(
+				ContainSubstring("is not in /etc/subgid"),
+				ContainSubstring("You are not a member of this group"),
+			),
+		)
+	})
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests 
-->
Fixes: #28364

#### Problem
When running a rootless container with `--device` `/dev/XXX` with `--userns=keep-id` `--group-add keep-groups` , devices that belong to groups not mapped in the user namespace silently appear as `nobody:nobody` inside the container and are completely inaccessible. There is no error message, no warning and the container just starts and the device doesn't work.
For example:
```bash
podman run -i --rm --userns=keep-id --group-add keep-groups --device /dev/input/ alpine ls -l /dev/input/event0
```
Output:
```bash 
crw-rw----  1 nobody  nobody  ...  event0
```
The root cause is that the device's group GID is not listed in `/etc/subgid`. When the rootless user namespace is created, only GIDs in `/etc/subgid` get mapped so anything else shows up as nobody.

I tried fixing this automatically using idmapped mounts and injecting GIDs directly into the namespace, but both approaches hit kernel-level limitations as you can't map a GID that isn't already in `/etc/subgid` without root privileges. Automatically editing system files like `/etc/subgid` was also ruled out because that's an admin decision, not something Podman should do silently.

#### Solution
Since I can't fix the mapping automatically, I made the failure visible and actionable.Before Podman enters the user namespace, it saves two things to a temporary file:
- The host supplementary groups of the current user
- The real host GIDs of any devices passed via `--device`

This is necessary because once inside the user namespace, GIDs get remapped and we lose track of what the original host GIDs were.Then when the device is being set up for the container, it check:
1. What is the real host GID of this device?
2. Is the current user a member of that group on the host?
3. Is that GID listed in `/etc/subgid`?

Based on this, one of two warnings are showed: If the user is not even a member of the device group:
lets say a group input and the device GID is 994
```bash
Device event0 is owned by group 'input' (GID 994).
You are not a member of this group on the host.
Access will be denied inside the container.
To fix run:
sudo usermod -aG input ubuntu
Then log out and log back in.
```
If the user is a member but the GID is not in `/etc/subgid`:
```bash
Device event0 is owned by group 'input' (GID 994).
You are a member of this group on the host, but GID 994 is not in /etc/subgid.
The device will appear as 'nobody:nobody' inside the container and access will be denied.
To fix this, run:
echo "ubuntu:994:1" | sudo tee -a /etc/subgid && podman system migrate
```
After the user runs the suggested fix and tries again, the device works correctly and no warning is shown.

#### A note on how devices appear inside the container
The ownership shown inside the container can be a little misleading. For example, on the host a device may be owned by:
`root:input` but after the required `/etc/subgid` mapping is added, the same device inside the container may appear as:
`nobody:bin` or, when viewed with numeric IDs `65534:1`
This is expected.
- The owner (`nobody` / UID `65534`) is the kernel's overflow UID because the device owner's UID (`root`) is not mapped into the rootless user namespace.
- The group (`bin` / GID `1`) is **not** the host's group name. It is simply the container's name for container GID `1`. In this case, container GID `1` is correctly mapped to the host's `input` group (GID `994`) through `/etc/subgid`.

In other words, the displayed **group name** inside the container is independent of the host's group name. As long as the numeric GID is mapped correctly, the device permissions work as expected. This PR only detects missing mappings and provides actionable warnings; it does not attempt to preserve host group names inside the container.

#### Files changed
`pkg/rootless/rootless_linux.go` : Before entering the user namespace, saves the user's host groups and the GIDs of all devices passed via `--device` to temporary files. This is the only place where the real host GIDs are available.
`pkg/specgen/generate/config_linux.go` : When adding a device to the container spec, checks whether the device's GID is accessible and emits the appropriate warning if not. 

#### Tests added
`pkg/specgen/generate/config_linux_test.go`:  Unit tests for `isGIDInSubgid()` covering: GID inside range, GID outside range, boundary values (first and last GID in range), GID explicitly added as a single entry, empty subgid file, and wrong username. 
`test/e2e/run_device_test.go` : This runs a rootless container with `/dev/input` and verifies that a warning is emitted mentioning either missing subgid mapping or missing group membership. The test is skipped automatically if not running in rootless mode or if /dev/input` is not available on the host.
- The e2e test depends on `/dev/input/` being present on the host. If there is a better way to test this in CI, I am open to suggestions.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Added a warning when rootless containers cannot access devices due to missing GID mappings in `/etc/subgid`, with exact commands to fix the issue.
```
