### PR TITLE
Add dnsnames field & fix alias field

### DIFF
--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -739,8 +739,11 @@ type InspectAdditionalNetwork struct {
 	// Links is presently unused and maintained exclusively for
 	// compatibility.
 	Links []string `json:"Links"`
-	// Aliases are any network aliases the container has in this network.
+	// Aliases are user-provided network aliases the container has in this network.
 	Aliases []string `json:"Aliases,omitempty"`
+	// DNSNames contains the complete list of DNS names that resolve to this
+	// container, including the container name, user aliases, short ID, and hostname.
+	DNSNames []string `json:"DNSNames,omitempty"`
 }
 
 // InspectNetworkSettings holds information about the network settings of the

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -68,6 +68,14 @@ func (c *Container) getNetworkOptions(networkOpts []types.NamedPerNetworkOptions
 	} else {
 		opts.Networks = networkOpts
 	}
+
+	// Alias should only include user-provided aliases. Append the auto-generated
+	// aliases (short ID, hostname) so the network backend creates DNS records
+	// for them. Concat allocates a new slice, avoiding mutation of the stored config.
+	for i := range opts.Networks {
+		opts.Networks[i].Aliases = slices.Concat(opts.Networks[i].Aliases, getExtraNetworkAliases(c))
+	}
+
 	return opts
 }
 
@@ -259,6 +267,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 				netInfo := new(define.InspectAdditionalNetwork)
 				netInfo.NetworkID = getNetworkID(net.Name)
 				netInfo.Aliases = net.Aliases
+				netInfo.DNSNames = c.dnsNamesForNetwork(net.Aliases)
 				settings.Networks[net.Name] = netInfo
 			}
 		} else {
@@ -291,6 +300,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 			addedNet := new(define.InspectAdditionalNetwork)
 			addedNet.NetworkID = getNetworkID(network.Name)
 			addedNet.Aliases = network.Aliases
+			addedNet.DNSNames = c.dnsNamesForNetwork(network.Aliases)
 			addedNet.InspectBasicNetworkConfig = resultToBasicNetworkConfig(result)
 
 			settings.Networks[network.Name] = addedNet
@@ -529,8 +539,6 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 	// get network status before we connect
 	networkStatus := c.getNetworkStatus()
 
-	netOpts.Aliases = append(netOpts.Aliases, getExtraNetworkAliases(c)...)
-
 	// check whether interface is to be named as the network_interface
 	// when name left unspecified
 	if netOpts.InterfaceName == "" {
@@ -544,6 +552,7 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 			return errors.New("could not find free network interface name")
 		}
 	}
+	netOpts.Aliases = slices.Compact(slices.Sorted(slices.Values(netOpts.Aliases)))
 	namedOpts := types.NamedPerNetworkOptions{
 		Name:              netName,
 		PerNetworkOptions: netOpts,
@@ -579,7 +588,9 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 		ContainerName: getNetworkPodName(c),
 	}
 	opts.PortMappings = c.convertPortMappings()
-	opts.Networks = []types.NamedPerNetworkOptions{namedOpts}
+	setupOpts := namedOpts
+	setupOpts.Aliases = slices.Concat(setupOpts.Aliases, getExtraNetworkAliases(c))
+	opts.Networks = []types.NamedPerNetworkOptions{setupOpts}
 
 	results, err := c.runtime.setUpNetwork(c.state.NetNS, opts)
 	if err != nil {
@@ -681,6 +692,17 @@ func getExtraNetworkAliases(c *Container) []string {
 		alias = append(alias, c.config.Spec.Hostname)
 	}
 	return alias
+}
+
+func (c *Container) dnsNamesForNetwork(aliases []string) []string {
+	all := slices.Concat([]string{c.Name()}, aliases, getExtraNetworkAliases(c))
+	names := all[:0]
+	for _, n := range all {
+		if !slices.Contains(names, n) {
+			names = append(names, n)
+		}
+	}
+	return names
 }
 
 // DisconnectContainerFromNetwork removes a container from its network

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -298,9 +299,8 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 					return nil, errors.New("failed to find free network interface name")
 				}
 			}
-			network.Aliases = append(network.Aliases, getExtraNetworkAliases(ctr)...)
-
 			network.Name = netName
+			network.Aliases = slices.Compact(slices.Sorted(slices.Values(network.Aliases)))
 			normalizeNetworks = append(normalizeNetworks, network)
 		}
 		ctr.config.Networks = normalizeNetworks

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -1007,3 +1007,32 @@ t GET containers/healthcheck-test-running/json 200 \
   .State.Health.Status="healthy"
 
 podman rm -f healthcheck-test-running
+
+#
+# Test DNSNames / Aliases field in container inspect
+#
+podman network create dnstest
+podman create --name dnscontainer --network dnstest --hostname myhostname --network-alias myalias $IMAGE top
+t GET containers/dnscontainer/json 200
+cid=$(jq -r '.Id' <<<"$output")
+short_id=${cid:0:12}
+
+# Compat API should return DNSNames and user-only Aliases
+t GET containers/dnscontainer/json 200 \
+  .NetworkSettings.Networks.dnstest.Aliases[0]=myalias \
+  .NetworkSettings.Networks.dnstest.DNSNames[0]=dnscontainer \
+  .NetworkSettings.Networks.dnstest.DNSNames[1]=myalias \
+  .NetworkSettings.Networks.dnstest.DNSNames[2]=$short_id \
+  .NetworkSettings.Networks.dnstest.DNSNames[3]=myhostname
+
+# Test network connect adds DNSNames but not short ID/hostname to Aliases
+podman network create dnstest2
+t POST networks/dnstest2/connect Container=dnscontainer 200
+t GET containers/dnscontainer/json 200 \
+  .NetworkSettings.Networks.dnstest2.Aliases=null \
+  .NetworkSettings.Networks.dnstest2.DNSNames[0]=dnscontainer \
+  .NetworkSettings.Networks.dnstest2.DNSNames[1]=$short_id
+
+# cleanup
+podman rm -f dnscontainer
+podman network rm -f dnstest dnstest2

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -140,4 +140,31 @@ var _ = Describe("Podman container inspect", func() {
 		Expect(data).To(HaveLen(1))
 		Expect(data[0].Config.Env).To(ContainElement(Equal(secretName + "=*******")))
 	})
+
+	It("podman inspect NetworkSettings DNSNames and Aliases", func() {
+		netName := "dnstest"
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		defer podmanTest.removeNetwork(netName)
+
+		ctrName := "testdns"
+		session = podmanTest.Podman([]string{"create", "--name", ctrName, "--hostname", "myhostname", "--network", netName, "--network-alias", "myalias", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		cid := session.OutputToString()
+
+		data := podmanTest.InspectContainer(ctrName)
+		Expect(data).To(HaveLen(1))
+		Expect(data[0].NetworkSettings.Networks).To(HaveKey(netName))
+
+		network := data[0].NetworkSettings.Networks[netName]
+		// Aliases should only contain user-provided alias
+		Expect(network.Aliases).To(Equal([]string{"myalias"}))
+		// DNSNames should contain container name, user alias, short ID, and hostname
+		Expect(network.DNSNames).To(ContainElement(ctrName))
+		Expect(network.DNSNames).To(ContainElement("myalias"))
+		Expect(network.DNSNames).To(ContainElement(cid[0:12]))
+		Expect(network.DNSNames).To(ContainElement("myhostname"))
+	})
 })

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -115,11 +115,17 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(ctr).Should(ExitCleanly())
 		cid := ctr.OutputToString()
 
-		// network alias container short id is always added and shown in inspect
+		// Aliases should be empty (no user-provided aliases)
 		inspect := podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{(index .NetworkSettings.Networks \"" + netName + "\").Aliases}}"})
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(ExitCleanly())
-		Expect(inspect.OutputToString()).To(Equal("[" + cid[0:12] + "]"))
+		Expect(inspect.OutputToString()).To(Equal("[]"))
+
+		// DNSNames should contain the short ID
+		inspect = podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{(index .NetworkSettings.Networks \"" + netName + "\").DNSNames}}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(ExitCleanly())
+		Expect(inspect.OutputToString()).To(ContainSubstring(cid[0:12]))
 
 		con := podmanTest.Podman([]string{"network", "connect", netName, "test"})
 		con.WaitWithDefaultTimeout()
@@ -179,11 +185,17 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(inspect).Should(ExitCleanly())
 		Expect(inspect.OutputToString()).To(Equal("2"))
 
-		// network alias container short id is always added and shown in inspect
+		// Aliases should be empty after network connect (no user-provided aliases)
 		inspect = podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{(index .NetworkSettings.Networks \"" + newNetName + "\").Aliases}}"})
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(ExitCleanly())
-		Expect(inspect.OutputToString()).To(Equal("[" + cid[0:12] + "]"))
+		Expect(inspect.OutputToString()).To(Equal("[]"))
+
+		// DNSNames should contain the short ID
+		inspect = podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{(index .NetworkSettings.Networks \"" + newNetName + "\").DNSNames}}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(ExitCleanly())
+		Expect(inspect.OutputToString()).To(ContainSubstring(cid[0:12]))
 
 		exec = podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth1"})
 		exec.WaitWithDefaultTimeout()

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -552,12 +552,13 @@ EOCONF
 
     run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname\").IPAddress}}
 {{(index .NetworkSettings.Networks \"$netname\").MacAddress}}
-{{(index .NetworkSettings.Networks \"$netname\").Aliases}}"
+{{(index .NetworkSettings.Networks \"$netname\").DNSNames}}"
     ip="${lines[0]}"
     mac="${lines[1]}"
 
-    # check network alias for container short id
-    is "${lines[2]}" "[${cid:0:12} $hostname]" "short container id and hostname in network aliases"
+    # check DNSNames for container short id and hostname
+    assert "${lines[2]}" =~ "${cid:0:12}" "short container id in DNSNames"
+    assert "${lines[2]}" =~ "$hostname" "hostname in DNSNames"
 
     # check /etc/hosts for our entry
     run_podman exec $cid cat /etc/hosts
@@ -615,9 +616,10 @@ EOCONF
     run_podman network connect $netname2 $cid
     is "$output" "" "Output should be empty (no errors)"
 
-    # check network2 alias for container short id
-    run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname2\").Aliases}}"
-    is "$output" "[${cid:0:12} $hostname]" "short container id and hostname in network2 aliases"
+    # check network2 DNSNames for container short id and hostname
+    run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname2\").DNSNames}}"
+    assert "$output" =~ "${cid:0:12}" "short container id in network2 DNSNames"
+    assert "$output" =~ "$hostname" "hostname in network2 DNSNames"
 
     # curl should work
     run curl --max-time 3 -s -S $SERVER/index.txt


### PR DESCRIPTION
Docker now reserves alias specfically for user-defined aliases, and uses another field, dnsnames, to hold all aliases, including container ID and name.
Part of docker v1.45 compat work, but this touches the cli too, since they updated it there too.

```release-note
The NetworkSettings.Network.Aliases field in the `podman inspect` command and in returned in calls to GET /containers/{name:.*}/json API no longer contains the short container ID, and only contains user-provided network aliases. A new field, NetworkSettings.Network.DNSNames contains all aliases, container ID and name.
```
