### PR TITLE
Docker compat v1.45 : deprecate is-automated field

### DIFF
--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -10,6 +10,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/libpod"
 	"go.podman.io/podman/v6/pkg/api/handlers/utils"
+	"go.podman.io/podman/v6/pkg/api/handlers/utils/apiutil"
 	api "go.podman.io/podman/v6/pkg/api/types"
 	"go.podman.io/podman/v6/pkg/auth"
 	"go.podman.io/podman/v6/pkg/domain/entities"
@@ -49,6 +50,22 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 		password = authconf.Password
 		idToken = authconf.IdentityToken
 	}
+	// compat v1.45 deprecation: searching for is-automated=true will yield no results, while is-automated=false will be a no-op.
+	isAutomatedDeprecated := false
+	if _, err := apiutil.SupportedVersion(r, ">=1.45.0"); err == nil {
+		if !utils.IsLibpodRequest(r) {
+			isAutomatedDeprecated = true
+			if vals, ok := query.Filters["is-automated"]; ok {
+				switch vals[0] {
+				case "true":
+					utils.WriteResponse(w, http.StatusOK, []registry.SearchResult{})
+					return
+				case "false":
+					delete(query.Filters, "is-automated")
+				}
+			}
+		}
+	}
 
 	filters := []string{}
 	for key, val := range query.Filters {
@@ -79,14 +96,19 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		compatResults := make([]registry.SearchResult, len(reports))
-		for i, r := range reports {
-			compatResults[i] = registry.SearchResult{
-				Name:        r.Name,
-				Description: r.Description,
-				StarCount:   r.Stars,
-				IsOfficial:  toBool(r.Official),
-				IsAutomated: toBool(r.Automated),
+		for i, report := range reports {
+			result := registry.SearchResult{
+				Name:        report.Name,
+				Description: report.Description,
+				StarCount:   report.Stars,
+				IsOfficial:  toBool(report.Official),
+				IsAutomated: toBool(report.Automated),
 			}
+			if isAutomatedDeprecated {
+				//nolint:staticcheck
+				result.IsAutomated = false
+			}
+			compatResults[i] = result
 		}
 		utils.WriteResponse(w, http.StatusOK, compatResults)
 		return


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Docker compat API: POST /images/search will always assume a false value for the is-automated field, which is now deprecated. 
```
