### PR TITLE
Ensure log level is applied before loading configuration

### DIFF
--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.podman.io/common/pkg/config"
@@ -41,6 +42,15 @@ var (
 	TunnelMode = entities.TunnelMode.String()
 )
 
+type earlyCLIOptions struct {
+	completion bool
+	debug      bool
+	logLevel   string
+	modules    []string
+	parseErr   error
+	remote     bool
+}
+
 // PodmanConfig returns an entities.PodmanConfig built up from
 // environment and CLI.
 func PodmanConfig() *entities.PodmanConfig {
@@ -48,41 +58,80 @@ func PodmanConfig() *entities.PodmanConfig {
 	return &podmanOptions
 }
 
-// Return the index of os.Args where to start parsing CLI flags.
+// Return the index of args where to start parsing CLI flags.
 // An index > 1 implies Podman is running in shell completion.
-func parseIndex() int {
+func parseIndex(args []string) int {
 	// The shell completion logic will call a command called "__complete" or "__completeNoDesc"
 	// This command will always be the second argument
 	// To still parse --remote correctly in this case we have to set args offset to two in this case
-	if len(os.Args) > 1 && (os.Args[1] == cobra.ShellCompRequestCmd || os.Args[1] == cobra.ShellCompNoDescRequestCmd) {
+	if len(args) > 1 && (args[1] == cobra.ShellCompRequestCmd || args[1] == cobra.ShellCompNoDescRequestCmd) {
 		return 2
 	}
 	return 1
 }
 
-// Return the containers.conf modules to load.
-func containersConfModules() ([]string, error) {
-	index := parseIndex()
-	if index > 1 {
-		// Do not load the modules during shell completion.
-		return nil, nil
+// parseEarlyCLIOptions parses flags needed during command initialization.
+// Cobra parses and validates the complete command line later.
+func parseEarlyCLIOptions(args []string) *earlyCLIOptions {
+	options := new(earlyCLIOptions)
+	index := parseIndex(args)
+	options.completion = index > 1
+	if _, found := os.LookupEnv("CONTAINER_HOST"); found {
+		options.remote = true
+	} else if _, found := os.LookupEnv("CONTAINER_CONNECTION"); found {
+		options.remote = true
 	}
 
-	var modules []string
-	fs := pflag.NewFlagSet("module", pflag.ContinueOnError)
+	fs := pflag.NewFlagSet("early podman flags", pflag.ContinueOnError)
 	fs.ParseErrorsAllowlist.UnknownFlags = true
 	fs.Usage = func() {}
 	fs.SetInterspersed(false)
-	fs.StringArrayVar(&modules, "module", nil, "")
+	fs.StringArrayVar(&options.modules, "module", nil, "")
+	fs.StringVar(&options.logLevel, "log-level", "", "")
+	fs.BoolVarP(&options.debug, "debug", "D", false, "")
+	fs.BoolVarP(&options.remote, "remote", "r", options.remote, "")
+	connectionFlagName := "connection"
+	fs.StringP(connectionFlagName, "c", "", "")
+	contextFlagName := "context"
+	fs.String(contextFlagName, "", "")
+	hostFlagName := "host"
+	fs.StringP(hostFlagName, "H", "", "")
+	urlFlagName := "url"
+	fs.String(urlFlagName, "", "")
 	fs.BoolP("help", "h", false, "") // Need a fake help flag to avoid the `pflag: help requested` error
-	return modules, fs.Parse(os.Args[index:])
+
+	options.parseErr = fs.Parse(args[index:])
+	// --connection, --context, --host, or --url implies --remote.
+	options.remote = options.remote || fs.Changed(connectionFlagName) || fs.Changed(contextFlagName) || fs.Changed(hostFlagName) || fs.Changed(urlFlagName)
+	return options
+}
+
+// Set the log level before containers.conf is loaded.
+func setEarlyLogLevel(options *earlyCLIOptions) {
+	if options.completion {
+		return
+	}
+
+	if options.debug && options.logLevel == "" {
+		logrus.SetLevel(logrus.DebugLevel)
+	} else if !options.debug && options.logLevel != "" {
+		if level, err := logrus.ParseLevel(options.logLevel); err == nil {
+			logrus.SetLevel(level)
+		}
+	}
 }
 
 func newPodmanConfig() {
-	modules, err := containersConfModules()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error parsing containers.conf modules: %v\n", err)
+	options := parseEarlyCLIOptions(os.Args)
+	setEarlyLogLevel(options)
+	if options.parseErr != nil && !options.completion {
+		fmt.Fprintf(os.Stderr, "Error parsing command-line flags: %v\n", options.parseErr)
 		os.Exit(1)
+	}
+	modules := options.modules
+	if options.completion {
+		// Do not load the modules during shell completion.
+		modules = nil
 	}
 
 	if err := setXdgDirs(); err != nil {
@@ -100,13 +149,14 @@ func newPodmanConfig() {
 	}
 
 	var mode entities.EngineMode
+	remote := options.remote && !isPodmanSh(os.Args)
 	switch runtime.GOOS {
 	case "darwin", "windows":
 		mode = entities.TunnelMode
 	case "linux", "freebsd":
 		// Some linux clients might only be compiled without ABI
 		// support (e.g., podman-remote).
-		if abiSupport && !IsRemote() {
+		if abiSupport && !remote {
 			mode = entities.ABIMode
 		} else {
 			mode = entities.TunnelMode

--- a/cmd/podman/registry/config_test.go
+++ b/cmd/podman/registry/config_test.go
@@ -1,0 +1,115 @@
+package registry
+
+import (
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.podman.io/podman/v6/pkg/domain/entities"
+)
+
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	t.Setenv(key, "")
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseEarlyCLIOptions(t *testing.T) {
+	unsetEnvForTest(t, "CONTAINER_HOST")
+	unsetEnvForTest(t, "CONTAINER_CONNECTION")
+	options := parseEarlyCLIOptions([]string{"podman", "--log-level=trace", "--module=one", "--module=two", "--connection=test", "version"})
+	if options.parseErr != nil {
+		t.Fatal(options.parseErr)
+	}
+	if options.logLevel != "trace" {
+		t.Errorf("expected trace log level, got %q", options.logLevel)
+	}
+	if !slices.Equal(options.modules, []string{"one", "two"}) {
+		t.Errorf("expected modules [one two], got %v", options.modules)
+	}
+	if !options.remote {
+		t.Error("expected --connection to enable remote mode")
+	}
+}
+
+func TestParseEarlyCLIOptionsRemote(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		env        string
+		wantRemote bool
+	}{
+		{name: "context", args: []string{"podman", "--context=test", "version"}, wantRemote: true},
+		{name: "host", args: []string{"podman", "--host=unix:///run/podman.sock", "version"}, wantRemote: true},
+		{name: "url", args: []string{"podman", "--url=unix:///run/podman.sock", "version"}, wantRemote: true},
+		{name: "remote false overrides host environment", args: []string{"podman", "--remote=false", "version"}, env: "CONTAINER_HOST"},
+		{name: "remote false overrides connection environment", args: []string{"podman", "--remote=false", "version"}, env: "CONTAINER_CONNECTION"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			unsetEnvForTest(t, "CONTAINER_HOST")
+			unsetEnvForTest(t, "CONTAINER_CONNECTION")
+			if test.env != "" {
+				t.Setenv(test.env, "test")
+			}
+			if remote := parseEarlyCLIOptions(test.args).remote; remote != test.wantRemote {
+				t.Errorf("remote = %v, want %v", remote, test.wantRemote)
+			}
+		})
+	}
+}
+
+func TestParseEarlyCLIOptionsCompletion(t *testing.T) {
+	for _, completion := range []string{cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd} {
+		t.Run(completion, func(t *testing.T) {
+			options := parseEarlyCLIOptions([]string{"podman", completion, "--remote", "--module=test", "--log-level"})
+			if !options.completion {
+				t.Error("expected shell completion to be detected")
+			}
+			if !options.remote {
+				t.Error("expected --remote to be parsed during completion")
+			}
+			if options.parseErr == nil {
+				t.Error("expected the incomplete --log-level flag to produce a parse error")
+			}
+			if !slices.Equal(options.modules, []string{"test"}) {
+				t.Errorf("expected parsed modules [test], got %v", options.modules)
+			}
+		})
+	}
+}
+
+func TestIsRemotePodmanSh(t *testing.T) {
+	if isRemote(entities.TunnelMode, []string{PodmanSh, "-c", "id"}) {
+		t.Error("expected podmansh to remain local")
+	}
+}
+
+func TestParseEarlyCLIOptionsErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "module missing value", args: []string{"podman", "--module"}},
+		{name: "log level missing value", args: []string{"podman", "--log-level"}},
+		{name: "invalid debug value", args: []string{"podman", "--debug=invalid"}},
+		{name: "invalid remote value", args: []string{"podman", "--remote=invalid"}},
+		{name: "connection missing value", args: []string{"podman", "--connection"}},
+		{name: "context missing value", args: []string{"podman", "--context"}},
+		{name: "host missing value", args: []string{"podman", "--host"}},
+		{name: "url missing value", args: []string{"podman", "--url"}},
+		{name: "invalid flag syntax", args: []string{"podman", "---"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := parseEarlyCLIOptions(test.args).parseErr; err == nil {
+				t.Error("expected a parse error")
+			}
+		})
+	}
+}

--- a/cmd/podman/registry/remote.go
+++ b/cmd/podman/registry/remote.go
@@ -4,19 +4,19 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
-	"github.com/spf13/pflag"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 )
 
-// Value for --remote given on command line
-var remoteFromCLI = struct {
-	Value bool
-	sync  sync.Once
-}{}
-
 const PodmanSh = "podmansh"
+
+func isPodmanSh(args []string) bool {
+	return len(args) > 0 && strings.HasSuffix(filepath.Base(args[0]), PodmanSh)
+}
+
+func isRemote(mode entities.EngineMode, args []string) bool {
+	return !isPodmanSh(args) && mode == entities.TunnelMode
+}
 
 // IsRemote returns true if podman was built to run remote or --remote flag given on CLI
 // Use in init() functions as an initialization check
@@ -25,33 +25,5 @@ func IsRemote() bool {
 	// This is noticeable if a user with shell set to podmansh were to execute
 	// a command using ssh like so:
 	// ssh user@host id
-	if strings.HasSuffix(filepath.Base(os.Args[0]), PodmanSh) {
-		return false
-	}
-	remoteFromCLI.sync.Do(func() {
-		remote := false
-		if _, ok := os.LookupEnv("CONTAINER_HOST"); ok {
-			remote = true
-		} else if _, ok := os.LookupEnv("CONTAINER_CONNECTION"); ok {
-			remote = true
-		}
-		fs := pflag.NewFlagSet("remote", pflag.ContinueOnError)
-		fs.ParseErrorsAllowlist.UnknownFlags = true
-		fs.Usage = func() {}
-		fs.SetInterspersed(false)
-		fs.BoolVarP(&remoteFromCLI.Value, "remote", "r", remote, "")
-		connectionFlagName := "connection"
-		fs.StringP(connectionFlagName, "c", "", "")
-		contextFlagName := "context"
-		fs.String(contextFlagName, "", "")
-		hostFlagName := "host"
-		fs.StringP(hostFlagName, "H", "", "")
-		urlFlagName := "url"
-		fs.String(urlFlagName, "", "")
-
-		_ = fs.Parse(os.Args[parseIndex():])
-		// --connection or --url implies --remote
-		remoteFromCLI.Value = remoteFromCLI.Value || fs.Changed(connectionFlagName) || fs.Changed(urlFlagName) || fs.Changed(hostFlagName) || fs.Changed(contextFlagName)
-	})
-	return podmanOptions.EngineMode == entities.TunnelMode || remoteFromCLI.Value
+	return isRemote(PodmanConfig().EngineMode, os.Args)
 }

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -491,7 +491,7 @@ func configHook() {
 
 func loggingHook() {
 	if debug {
-		if logLevel != defaultLogLevel {
+		if rootCmd.Flag("log-level").Changed {
 			fmt.Fprintf(os.Stderr, "Setting --log-level and --debug is not allowed\n")
 			os.Exit(1)
 		}

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -234,6 +234,9 @@ See 'podman version --help'" "podman version --remote"
     run_podman -D        version
     assert "$output" =~ " level=debug " "podman -D gives debug output"
 
+    run_podman 1 --debug --log-level=warn version
+    is "$output" "Setting --log-level and --debug is not allowed"
+
     run_podman 1 --debug --log-level=panic version
     is "$output" "Setting --log-level and --debug is not allowed"
 }

--- a/test/system/800-config.bats
+++ b/test/system/800-config.bats
@@ -5,6 +5,22 @@
 
 load helpers
 
+@test "podman --log-level applies while loading containers.conf" {
+    skip_if_remote "containers.conf is loaded by the server for remote connections"
+
+    conf_tmp="$PODMAN_TMPDIR/containers.conf"
+    cat >$conf_tmp <<EOF
+[engine]
+invalid_option_for_test=true
+EOF
+
+    for log_arg in --log-level=debug --log-level=trace --debug; do
+        CONTAINERS_CONF_OVERRIDE="$conf_tmp" run_podman "$log_arg" version
+        assert "$output" =~ "Failed to decode the keys" "unknown containers.conf key is logged with $log_arg"
+        assert "$output" =~ "$conf_tmp" "diagnostic identifies containers.conf with $log_arg"
+    done
+}
+
 @test "podman CONTAINERS_CONF - CONTAINERS_CONF in conmon" {
     skip_if_remote "can't check conmon environment over remote"
 
@@ -204,12 +220,28 @@ EOF
 
     m1=m1odule_$(random_string)
     m2=m2$(random_string)
+    bad_module=zz-invalid-$(random_string)
 
     touch $fake_modules_dir/{$m2,$m1}
+    cat >"$fake_modules_dir/$bad_module" <<EOF
+[containers]
+sdf=
+EOF
+
+    # The incomplete flag makes the early parser return an error, which
+    # initialization must ignore while Cobra completes the flag name.
+    XDG_CONFIG_HOME=$fake_home run_podman __completeNoDesc --module
+    assert "${lines[0]}" = "--module" "completion ignores the incomplete early flag"
+
     XDG_CONFIG_HOME=$fake_home run_podman __completeNoDesc --module ""
     # Even if there are modules in /etc or elsewhere, these will be first
     assert "${lines[0]}" = "$m1" "completion finds module 1"
     assert "${lines[1]}" = "$m2" "completion finds module 2"
+
+    # A parsed module must not be loaded during completion. The invalid module
+    # would make configuration initialization fail if it were loaded.
+    XDG_CONFIG_HOME=$fake_home run_podman __completeNoDesc --module="$bad_module" ""
+    assert "$output" !~ "Failed to obtain podman configuration" "completion does not load modules"
 }
 
 @test "podman --module - supported fields" {


### PR DESCRIPTION
Podman loads its configuration during global initialization, before the `--log-level` option is processed. As a result, debug and trace messages emitted while reading configuration files are suppressed, making invalid or unknown configuration keys difficult to diagnose.

This change applies the requested log level before configuration initialization, ensuring that configuration-loading diagnostics are visible when commands are executed with `--log-level=debug` or `--log-level=trace`.

Fixes: #25362

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits (`git commit -s`).
- [x] Referenced issues using `Fixes: #00000` in commit message.
- [x] Tests have been added/updated.
- [x] Documentation has been updated or no documentation changes are needed.
- [x] All commits pass `make validatepr` (format/lint checks).
- [x] Release note entered below.

#### Does this PR introduce a user-facing change?

```release-note
Configuration parsing diagnostics are now displayed when Podman is started with an appropriate debug or trace log level.
```
