### PR TITLE
Remove unnecessary length check for container hostname ID

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -749,9 +749,6 @@ func (c *Container) hostname(network bool) string {
 	}
 
 	// Otherwise use the container's short ID as the hostname.
-	if len(c.ID()) < 11 {
-		return c.ID()
-	}
 	return c.ID()[:12]
 }
 


### PR DESCRIPTION
**Summary**

Since container IDs are validated to always be exactly 64 characters long upon creation, the `< 11` length check when determining the short ID hostname is dead code. 

This PR removes the unnecessary boundary check and unconditionally returns the truncated 12-character ID `c.ID()[:12]`.

