### PR TITLE
Fix podman exec --detach-keys help text

### DIFF
--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -64,7 +64,7 @@ func execFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&execDetach, "detach", "d", false, "Run the exec session in detached mode (backgrounded)")
 
 	detachKeysFlagName := "detach-keys"
-	flags.StringVar(&execOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Select the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _")
+	flags.StringVar(&execOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Select the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
 
 	cidfileFlagName := "cidfile"


### PR DESCRIPTION

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [ ] Referenced issues using `Fixes: #29273 ` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```

## Summary

Updates the `--detach-keys` flag help text for `podman exec` to match `podman attach` and `podman run`.

Previously, exec help only documented a single character or single `ctrl-<value>` and listed incomplete allowed values (`[, , or _`). Comma-separated sequences such as `ctrl-p,ctrl-q` work on exec but were not documented.

## Test plan

- [x] Rebuilt podman locally
- [x] Verified `podman exec --help | grep detach-keys` now mentions comma-separated sequences
- [x] Verified `podman exec --detach-keys='ctrl-a,ctrl-b' $cid echo success` still works

