### PR TITLE
libpod: do not fail prune when build container is already gone

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -44,6 +44,7 @@ import (
 	"go.podman.io/storage/pkg/fileutils"
 	"go.podman.io/storage/pkg/lockfile"
 	"go.podman.io/storage/pkg/unshare"
+	stypes "go.podman.io/storage/types"
 )
 
 // Set up the JSON library for all of Libpod
@@ -1310,6 +1311,13 @@ func (r *Runtime) LockConflicts() (map[uint32][]string, []uint32, error) {
 	return toReturn, locksHeld, nil
 }
 
+// containerGoneErr reports whether err means the container no longer exists in
+// the store. Callers that only care about the container being absent can treat
+// this as success.
+func containerGoneErr(err error) bool {
+	return errors.Is(err, stypes.ErrContainerUnknown) || errors.Is(err, stypes.ErrNotAContainer)
+}
+
 // PruneBuildContainers removes any build containers that were created during the build,
 // but were not removed because the build was unexpectedly terminated.
 //
@@ -1324,6 +1332,13 @@ func (r *Runtime) PruneBuildContainers() ([]*reports.PruneReport, error) {
 	for _, container := range containers {
 		path, err := r.store.ContainerDirectory(container.ID)
 		if err != nil {
+			// The container list is a snapshot, so a container can be removed
+			// while we are still working through it. A build that was killed
+			// cleans up its own stage containers in the background, which is
+			// exactly the case this function is meant to run after. Skip it.
+			if containerGoneErr(err) {
+				continue
+			}
 			return stageContainersPruneReports, err
 		}
 		if err := fileutils.Exists(filepath.Join(path, "buildah.json")); err != nil {
@@ -1335,11 +1350,19 @@ func (r *Runtime) PruneBuildContainers() ([]*reports.PruneReport, error) {
 		}
 		size, err := r.store.ContainerSize(container.ID)
 		if err != nil {
+			if containerGoneErr(err) {
+				continue
+			}
 			report.Err = err
 		}
 		report.Size = uint64(size)
 
 		if err := r.store.DeleteContainer(container.ID); err != nil {
+			// Pruning wants the container gone. If something else removed it
+			// first that is the result we wanted, so do not report it.
+			if containerGoneErr(err) {
+				continue
+			}
 			report.Err = errors.Join(report.Err, err)
 		}
 		stageContainersPruneReports = append(stageContainersPruneReports, report)


### PR DESCRIPTION
podman system prune --build lists the containers first, then works through them one at a time. A build that got killed is still cleaning up its own stage containers in the background, so one can disappear in between.

When that happened the prune bailed out with exit 125 and "identifier is not a container", even though the container was already gone, which is what we wanted anyway. So treat ErrContainerUnknown and ErrNotAContainer as success there.

I could not reproduce the flake locally, this is worked out from the log in the issue. No test either, I could not see a way to hit the race on purpose.

Seen in #28868, though from the discussion here that flake is really about the server side build not stopping when the remote client is killed, which is what nalind is fixing in buildah#7007.

#### Does this PR introduce a user-facing change?

```release-note
Fixed `podman system prune --build` failing when a build container was removed while the prune was already running.
```
