### PR TITLE
docs: document keep-groups limitation with systemd services

### DIFF
--- a/docs/source/markdown/options/group-add.md
+++ b/docs/source/markdown/options/group-add.md
@@ -17,3 +17,12 @@ devices are only accessible by the rootless user's group, this flag tells the OC
 runtime to pass the group access into the container. Currently only available
 with the `crun` OCI runtime. Note: `keep-groups` is exclusive, other groups cannot be specified
 with this flag. (Not available for remote commands, including Mac and Windows (excluding WSL2) machines)
+
+Note: `keep-groups` passes the supplementary groups that the *calling process*
+already has into the container, it does not look the user's groups up at
+container start. When Podman is started from a systemd user service, for example
+a rootless Quadlet, the calling process is the `systemd --user` manager, which
+only holds the groups the user had when that manager was started. Groups the user
+is added to afterwards, for example with `usermod`, are therefore not passed into
+the container. Restart the user's systemd manager to pick them up, for example
+with `loginctl terminate-user <user>` followed by a new login, or by rebooting.

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -614,6 +614,11 @@ argument passed to Podman. Using `Group=` without `User=` will result in an erro
 Assign additional groups to the primary user running within the container process. Also supports the `keep-groups` special flag.
 Equivalent to the Podman `--group-add` option.
 
+Note: for a rootless unit, `keep-groups` passes in the supplementary groups of the `systemd --user`
+manager, which only holds the groups the user had when that manager was started. Groups the user is
+added to afterwards are not passed into the container until the user's systemd manager is restarted,
+for example with `loginctl terminate-user <user>` followed by a new login.
+
 ### `HealthCmd=`
 
 Set or alter a healthcheck command for a container. A value of none disables existing healthchecks.


### PR DESCRIPTION
This PR documents a limitation with `--group-add keep-groups` (and Quadlet's `GroupAdd=keep-groups`) where supplementary groups are inherited directly from the calling process. When Podman runs as a systemd user service, `crun` inherits groups from `systemd --user`, which only holds the groups present when that session was initially started. If a user is added to new groups via `usermod` after the systemd session started, those groups aren't retroactively picked up, so they won't be passed into the container. This updates the documentation for both CLI options and Quadlets to clarify this behavior and mention that restarting the user's systemd manager (`loginctl terminate-user <user>`) resolves it.

- Fixes: #27876

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
