### PR TITLE
libpod: fix exec --user not resolving supplementary groups

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -940,6 +940,9 @@ func (c *Container) getUserOverrides() *lookup.Overrides {
 	if path, ok := c.state.BindMounts["/etc/passwd"]; ok {
 		overrides.ContainerEtcPasswdPath = path
 	}
+	if path, ok := c.state.BindMounts["/etc/group"]; ok {
+		overrides.ContainerEtcGroupPath = path
+	}
 	return &overrides
 }
 

--- a/pkg/lookup/lookup.go
+++ b/pkg/lookup/lookup.go
@@ -81,12 +81,12 @@ func GetContainerGroups(groups []string, containerMount string, override *Overri
 		err       error
 	)
 
-	groupPath := etcgroup
+	// An override is an already resolved path on the host (e.g. the file that
+	// is bind mounted onto /etc/group in the container), so it must be used
+	// as-is, exactly like GetUserGroupInfo does.
 	if override != nil && override.ContainerEtcGroupPath != "" {
-		groupPath = override.ContainerEtcGroupPath
-	}
-
-	if groupDest, err = securejoin.SecureJoin(containerMount, groupPath); err != nil {
+		groupDest = override.ContainerEtcGroupPath
+	} else if groupDest, err = securejoin.SecureJoin(containerMount, etcgroup); err != nil {
 		logrus.Debug(err)
 		return nil, err
 	}

--- a/pkg/lookup/lookup_test.go
+++ b/pkg/lookup/lookup_test.go
@@ -1,0 +1,38 @@
+package lookup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetContainerGroups(t *testing.T) {
+	// The group file shipped in the container's rootfs.
+	containerMount := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(containerMount, "etc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(containerMount, "etc", "group"), []byte("rootfs:x:100:\n"), 0o644))
+
+	// The group file Podman generates and bind mounts onto /etc/group. It is a path on the
+	// host, outside of the container mount point.
+	bindMounted := filepath.Join(t.TempDir(), "group")
+	require.NoError(t, os.WriteFile(bindMounted, []byte("bindmounted:x:200:\n"), 0o644))
+
+	// Without an override, groups are looked up in the container's rootfs.
+	gids, err := GetContainerGroups([]string{"rootfs"}, containerMount, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{100}, gids)
+
+	// An override is an already resolved host path and must be used as such, the same way
+	// GetUserGroupInfo uses it. Joining it onto the container mount point would produce a
+	// path which does not exist, and the lookup would fail.
+	gids, err = GetContainerGroups([]string{"bindmounted"}, containerMount, &Overrides{ContainerEtcGroupPath: bindMounted})
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{200}, gids)
+
+	// The override replaces the rootfs group file, it does not add to it.
+	_, err = GetContainerGroups([]string{"rootfs"}, containerMount, &Overrides{ContainerEtcGroupPath: bindMounted})
+	assert.Error(t, err)
+}

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -543,6 +543,29 @@ RUN useradd -u 1000 auser`, FEDORA_MINIMAL)
 		Expect(kill).Should(ExitCleanly())
 	})
 
+	It("podman exec --user resolves supplementary groups", func() {
+		dockerfile := fmt.Sprintf(`FROM %s
+RUN groupadd -g 4000 testgrp1
+RUN groupadd -g 4001 testgrp2
+RUN useradd -u 1000 -G testgrp1,testgrp2 testuser`, FEDORA_MINIMAL)
+		imgName := "testimg-supp"
+		podmanTest.BuildImage(dockerfile, imgName, "false")
+
+		ctrName := "testctr-supp"
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, imgName, "sleep", "300")
+
+		// exec --user should resolve supplementary groups from
+		// the container's /etc/group, not just the image rootfs.
+		exec := podmanTest.PodmanExitCleanly("exec", "--user", "testuser", ctrName, "id")
+		output := exec.OutputToString()
+		Expect(output).To(ContainSubstring("4000(testgrp1)"))
+		Expect(output).To(ContainSubstring("4001(testgrp2)"))
+		Expect(output).To(ContainSubstring("1000(testuser)"))
+
+		// Kill the container just so the test does not take 15 seconds to stop.
+		podmanTest.PodmanExitCleanly("kill", ctrName)
+	})
+
 	It("podman exec --detach", func() {
 		ctrName := "testctr"
 		ctr := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "top"})


### PR DESCRIPTION
`getUserOverrides()` checks `c.state.BindMounts["/etc/passwd"]` to find the passwd file Podman generates at container start, but never had the matching check for `/etc/group`. Exec sessions therefore resolved supplementary groups from the static image rootfs instead of the bind-mounted file. Adding the missing lookup fixes that

In its own, though, that would have broken `--group-add`. `lookup.Overrides.ContainerEtcGroupPath` is an already-resolved host path which is how `GetUserGroupInfo()` has always treated it but `GetContainerGroups()` securejoined it onto the container mount point, producing a path that doesn't exist. That was mostly harmless while the override was only set for explicit `/etc/group` (or `/etc`) bind mounts. Once it's populated for the generated `/etc/group`, `podman run --group-add somegroup` fails with `unable to find group somegroup`. both helpers now agree on what the field means

an e2e case for `exec --user` resolving supplementary groups, plus a unit test in `pkg/lookup` that fails with the old securejoin behaviour.

- Related: #29170

#### Checklist
Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)
#### Does this PR introduce a user-facing change?
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
```release-note
Fixed `podman exec --user` to properly initialize supplementary groups from the container's `/etc/group`.
```