### PR TITLE
hack: run the tooling self-tests in validate-source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
             libseccomp-dev \
             libsystemd-dev \
             libclone-perl \
+            libtest-differences-perl \
             man-db \
             podman \
             python3-pip

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,19 @@ help: ## Print this help message
 .check-ci-yaml:
 	hack/ci/ci_yaml_test.py
 
+# Self-tests that ship next to the tooling they cover. These only need python3,
+# bash and perl, so they can run in validate-source.
+# Not included here:
+#   hack/xref-helpmsgs-manpages.t   needs a built podman and docs, so it belongs
+#                                   with validate-binaries instead
+.PHONY: .check-self-tests
+.check-self-tests:
+	hack/markdown-preprocess.t
+	hack/ci/pr-removes-fixed-skips.t
+	hack/ci/pr-should-include-tests.t
+	hack/ci/logformatter.t
+	test/system/helpers.t
+
 .PHONY: lint
 lint: golangci-lint ## Run all linters (golangci-lint + pre-commit hooks)
 ifeq ($(PRE_COMMIT),)
@@ -323,7 +336,7 @@ codespell:
 
 # Code validation target that **DOES NOT** require building podman binaries
 .PHONY: validate-source
-validate-source: lint shfmt .commit-subject-check .check-ci-yaml swagger-check tests-expect-exit pr-removes-fixed-skips
+validate-source: lint shfmt .commit-subject-check .check-ci-yaml .check-self-tests swagger-check tests-expect-exit pr-removes-fixed-skips
 
 # Code validation target that **DOES** require building podman binaries
 .PHONY: validate-binaries


### PR DESCRIPTION
We have a few self-tests sitting next to the scripts they cover, but nothing actually runs them, so they just rot. hack/ci/logformatter.t is broken right now and nobody noticed.

This wires up the three that pass today and only need python3, bash and perl. I ran the target in a clean container to check.

Left out: xref-helpmsgs-manpages.t needs a built podman and docs so it fits validate-binaries better, pr-should-include-tests.t says in its own header that it does not work with the shallow checkout CI uses, and logformatter.t is currently failing.

pr-removes-fixed-skips already runs in validate-source but its test needs Test::Differences, so I added that to the deps.

#### Does this PR introduce a user-facing change?

```release-note
None
```