### PR TITLE
swagger: fix deprecated alias annotations and model name collisions

### DIFF
--- a/libpod/define/container.go
+++ b/libpod/define/container.go
@@ -67,11 +67,13 @@ const (
 	K8sKindJob = "job"
 )
 
+// swagger:model LibpodWeightDevice
 type WeightDevice struct {
 	Path   string
 	Weight uint16
 }
 
+// swagger:model LibpodThrottleDevice
 type ThrottleDevice struct {
 	Path string
 	Rate uint64

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -870,6 +870,8 @@ type InspectExecProcess struct {
 }
 
 // DriverData handles the data for a storage driver
+//
+// swagger:model LibpodDriverData
 type DriverData struct {
 	Name string            `json:"Name"`
 	Data map[string]string `json:"Data"`

--- a/libpod/define/version.go
+++ b/libpod/define/version.go
@@ -22,6 +22,8 @@ var (
 )
 
 // Version is an output struct for API
+//
+// swagger:model LibpodVersion
 type Version struct {
 	APIVersion  string
 	Version     string

--- a/pkg/domain/entities/reports/prune.go
+++ b/pkg/domain/entities/reports/prune.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 )
 
+// swagger:model ReportsPruneReport
 type PruneReport struct {
 	Id   string `json:"Id"`
 	Err  error  `json:"Err,omitempty"`

--- a/pkg/domain/entities/types/images.go
+++ b/pkg/domain/entities/types/images.go
@@ -142,7 +142,7 @@ type ImageHistoryReport struct {
 	Layers []ImageHistoryLayer
 }
 
-// swagger:alias
+// swagger:model ImagePullStatus
 type ImagePullStatus string
 
 const (
@@ -179,7 +179,7 @@ type ImagePullReport struct {
 	Progress *ArtifactPullProgress `json:"pullProgress,omitempty"`
 }
 
-// swagger:alias
+// swagger:model ArtifactPullStatus
 type ArtifactPullStatus string
 
 const (

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -37,6 +37,8 @@ type ImageData struct {
 }
 
 // RootFS holds the root fs information of an image.
+//
+// swagger:model InspectRootFS
 type RootFS struct {
 	Type   string          `json:"Type"`
 	Layers []digest.Digest `json:"Layers"`

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -649,6 +649,7 @@ func (s *SpecGenerator) IsInitContainer() bool {
 	return len(s.InitContainerType) != 0
 }
 
+// swagger:model SpecgenSecret
 type Secret struct {
 	Source string
 	Target string


### PR DESCRIPTION
This PR fixes actionable swagger warnings emitted during OpenAPI spec generation. The deprecated `swagger:alias` annotations on `ImagePullStatus` and `ArtifactPullStatus` are replaced with `swagger:model`, and explicit uniquely-named `swagger:model` annotations are added to Podman types (`DriverData`, `PruneReport`, `RootFS`, `Secret`, `ThrottleDevice`, `WeightDevice`, `Version`) that collide with identically-named types in vendor packages. This eliminates 9 out of 11 fixable warnings; the remaining 2 collisions (`Mount`, `Summary`) are between two vendor types each and can't be resolved from the Podman side.

- Related: #29199

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```