### PR TITLE
CI: re-enable farm tests in GitHub Actions

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -44,6 +44,10 @@ upgrade:
   - 'test/upgrade/**'
   - 'test/system/*.bash'
 
+farm:
+  - 'test/farm/**'
+  - 'test/system/*.bash'
+
 windows:
   - 'winmake.ps1'
   - 'hack/ci/win-*.ps1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       sys: ${{ steps.filter.outputs.sys }}
       machine: ${{ steps.filter.outputs.machine }}
       upgrade: ${{ steps.filter.outputs.upgrade }}
+      farm: ${{ steps.filter.outputs.farm }}
       windows: ${{ steps.filter.outputs.windows }}
 
     steps:
@@ -413,6 +414,10 @@ jobs:
             distro: fedora-current
             mode: v5.6.2
             priv: root
+          # farm tests only make sense rootless
+          - test: farm
+            distro: fedora-current
+            priv: rootless
 
     uses: ./.github/workflows/lima.yml
     with:
@@ -707,9 +712,6 @@ jobs:
       - name: Post-run cleanup
         if: always()
         run: ./hack/ci/gha_mac_cleanup.sh
-
-### TODO missing
-# Farm, needs extra setup I need to look into
 
   # Merge protection is setup for this job name, do not change it.
   success:

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -229,6 +229,14 @@ function run_machine() {
     $SUDO make ${MODE}machine
 }
 
+function run_farm() {
+    # The farm tests add a system connection to ourselves over ssh to localhost
+    # and then talk to the rootless API socket through it.
+    systemctl --user enable --now podman.socket
+
+    $SUDO bats test/farm |& logformatter
+}
+
 echo "Starting Test"
 
 run_$TEST

--- a/test/farm/setup_suite.bash
+++ b/test/farm/setup_suite.bash
@@ -15,7 +15,7 @@ function setup_suite(){
         export ROOTLESS_USER=$(id -un)
     fi
 
-    sshdir=/home/$ROOTLESS_USER/.ssh
+    sshdir=$HOME/.ssh
     sshkey=$sshdir/id_rsa
     if [[ ! -e $sshkey ]]; then
         ssh-keygen -t rsa -N "" -f $sshkey


### PR DESCRIPTION
Farm tests (`test/farm/`) were skipped during the Cirrus-to-GHA CI migration. this reenables them & drops the `### TODO missing` note in `ci.yml` that was tracking it

`run_farm()` in `hack/ci/runner.sh` starts the rootless podman socket, which is the only setup still needed. the farm tests add a system connection to ourselves over ssh to localhost and then talk to that socket through it. sshd is already running (that's how we got into the VM) and we already have a login session, so no linger either

`test/farm/setup_suite.bash` assumed the rootless user's home is `/home/$ROOTLESS_USER`, which doesn't hold on the CI VMs. it now just uses `$HOME`

on the CI side, farm goes into the `small-tests` matrix as a rootless `fedora-current` include rather than a job of its own so it reuses the runner, timeout and path filter wiring that's already there. the filter makes it trigger on `test/farm/` or shared system test helper changes

- Fixes: #28833

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```