### PR TITLE
podman exec: align --detach-keys help text with run, start, and attach

### DIFF
--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -64,7 +64,7 @@ func execFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&execDetach, "detach", "d", false, "Run the exec session in detached mode (backgrounded)")
 
 	detachKeysFlagName := "detach-keys"
-	flags.StringVar(&execOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Select the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _")
+	flags.StringVar(&execOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Select the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
 
 	cidfileFlagName := "cidfile"


### PR DESCRIPTION
## Does this PR introduce a user-facing change?

The `podman exec --detach-keys` help text was inconsistent with `podman run`,
`start`, and `attach`: it described only a single `ctrl-<value>` (not the
comma-separated sequences that `exec` actually accepts) and listed the allowed
`ctrl` values as `a-z, @, ^, [, , or _` (a stray double comma, and missing `\`
and `]`).

This uses the same wording the other three commands already share, so `podman
exec --help` now correctly documents comma-separated sequences and the right
`ctrl` value set.

```release-note
Fixed the `podman exec --detach-keys` flag help text to match `run`, `start`, and `attach`.
```

Closes #29273