### PR TITLE
Fix deferred event emission on failed container update

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -162,14 +162,11 @@ func (c *Container) Update(updateOptions *entities.ContainerUpdateOptions) error
 		return err
 	}
 
-	var updateErr error
-	defer func() {
-		if updateErr == nil {
-			c.newContainerEvent(events.Update)
-		}
-	}()
-	updateErr = c.update(updateOptions)
-	return updateErr
+	if err := c.update(updateOptions); err != nil {
+		return err
+	}
+	c.newContainerEvent(events.Update)
+	return nil
 }
 
 // Attach to a container.

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -162,11 +162,14 @@ func (c *Container) Update(updateOptions *entities.ContainerUpdateOptions) error
 		return err
 	}
 
-	if err := c.update(updateOptions); err != nil {
-		return err
-	}
-	c.newContainerEvent(events.Update)
-	return nil
+	var updateErr error
+	defer func() {
+		if updateErr == nil {
+			c.newContainerEvent(events.Update)
+		}
+	}()
+	updateErr = c.update(updateOptions)
+	return updateErr
 }
 
 // Attach to a container.

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -162,8 +162,11 @@ func (c *Container) Update(updateOptions *entities.ContainerUpdateOptions) error
 		return err
 	}
 
-	defer c.newContainerEvent(events.Update)
-	return c.update(updateOptions)
+	if err := c.update(updateOptions); err != nil {
+		return err
+	}
+	c.newContainerEvent(events.Update)
+	return nil
 }
 
 // Attach to a container.


### PR DESCRIPTION
## Summary

In `libpod/container_api.go`, `Container.Update()` defers emission of the `events.Update` event before invoking `c.update()`:

```go
defer c.newContainerEvent(events.Update)
return c.update(updateOptions)
```

Because deferred functions execute regardless of whether the function returns successfully or with an error, an `Update` event is emitted even when `c.update()` fails.


## Problem

If `c.update(updateOptions)` returns an error (for example, due to invalid options, storage failures, or permission issues), the deferred event is still emitted.

This means an `events.Update` notification may be generated even though the container update did not complete successfully.

## Possible Impact

Depending on how `events.Update` is consumed, this may lead to:

- Event streams indicating an update that never completed.
- Audit logs or monitoring systems observing an update event for a failed operation.
- Consumers having to infer success or failure from additional context instead of the event itself.

## Proposed Fix

Emit the event only after `c.update()` completes successfully:

```go
if err := c.update(updateOptions); err != nil {
    return err
}

c.newContainerEvent(events.Update)
return nil
```

This ensures that `events.Update` is emitted only for successful container updates.