### PR TITLE
Respect container StopTimeout in container restart REST APIs

### DIFF
--- a/pkg/api/handlers/compat/containers_restart.go
+++ b/pkg/api/handlers/compat/containers_restart.go
@@ -38,11 +38,15 @@ func RestartContainer(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 
 	options := entities.RestartOptions{
-		All:     query.All,
-		Timeout: &query.DockerTimeout,
+		All: query.All,
+	}
+	if _, found := r.URL.Query()["t"]; found {
+		options.Timeout = &query.DockerTimeout
 	}
 	if utils.IsLibpodRequest(r) {
-		options.Timeout = &query.LibpodTimeout
+		if _, found := r.URL.Query()["timeout"]; found {
+			options.Timeout = &query.LibpodTimeout
+		}
 	}
 	report, err := containerEngine.ContainerRestart(r.Context(), []string{name}, options)
 	if err != nil {

--- a/test/apiv2/21-restart.at
+++ b/test/apiv2/21-restart.at
@@ -1,0 +1,47 @@
+# -*- sh -*-
+#
+# test 'restart' endpoints
+#
+
+podman pull $IMAGE &>/dev/null
+
+# restart, by name
+# Exit cleanly on SIGTERM; leak lockfile on SIGKILL (will fail to restart, allowing indirect observation of SIGKILL)
+podman run -dt --name mypause $IMAGE ./pause &>/dev/null
+
+t GET  libpod/containers/mypause/json 200 .State.Status=running
+RESTART=$(date +%s.%N)
+t POST libpod/containers/mypause/restart 204
+t GET "libpod/events?stream=false&since=$RESTART"  200  \
+  'select(.status | contains("restart")).Action=restart' \
+  'select(.status | contains("died")).Action=died' \
+  'select(.status | contains("died")).Actor.Attributes.containerExitCode=0'
+
+# restart, by ID
+# Remember that podman() hides all output; we need to get our CID via inspect
+t GET  libpod/containers/mypause/json 200 .State.Status=running
+cid=$(jq -r .Id <<<"$output")
+RESTART=$(date +%s.%N)
+t POST libpod/containers/$cid/restart  204
+t GET "libpod/events?stream=false&since=$RESTART"  200  \
+  'select(.status | contains("restart")).Action=restart' \
+  'select(.status | contains("died")).Action=died' \
+  'select(.status | contains("died")).Actor.Attributes.containerExitCode=0'
+
+# restart, using compat API
+t GET  containers/mypause/json 200 .State.Status=running
+RESTART=$(date +%s.%N)
+t POST containers/mypause/restart 204
+t GET "libpod/events?stream=false&since=$RESTART"  200  \
+  'select(.status | contains("restart")).Action=restart' \
+  'select(.status | contains("died")).Action=died' \
+  'select(.status | contains("died")).Actor.Attributes.containerExitCode=0'
+t GET  containers/mypause/json 200 .State.Status=running
+cid=$(jq -r .Id <<<"$output")
+RESTART=$(date +%s.%N)
+t POST containers/$cid/restart 204
+t GET "libpod/events?stream=false&since=$RESTART"  200  \
+  'select(.status | contains("restart")).Action=restart' \
+  'select(.status | contains("died")).Action=died' \
+  'select(.status | contains("died")).Actor.Attributes.containerExitCode=0'
+t DELETE containers/mypause?force=true    204


### PR DESCRIPTION
RestartContainer was always setting options.Timeout with values from query, without checking if the caller had specified them or if they were simply zero values. Copy logic from StopContainer to check for caller-specified values, leaving Timeout nil if not specified. Test derived from `22-stop.at`.

fixes: https://github.com/podman-container-tools/podman/issues/29276

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed libpod/compat REST APIs not respecting container `StopTimeout` on container restart, which lead to containers receiving an immediate `SIGKILL` if the caller did not specify a timeout argument.
```
