### PR TITLE
hack/ci: rename STORAGE_FS to CI_DESIRED_STORAGE and add PODMAN_CI

### DIFF
--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -11,20 +11,20 @@ source "$SCRIPT_DIR/lib.sh"
 
 parse_args "$@"
 
-PRESERVE_ENVS="CI_USE_REGISTRY_CACHE,CI_DESIRED_COMPOSEFS,OCI_RUNTIME,CGROUP_MANAGER,STORAGE_FS,STORAGE_OPTIONS_OVERLAY,STORAGE_OPTIONS_VFS,PODMAN_UPGRADE_FROM"
+PRESERVE_ENVS="PODMAN_CI,CI_USE_REGISTRY_CACHE,CI_DESIRED_COMPOSEFS,CI_DESIRED_STORAGE,OCI_RUNTIME,CGROUP_MANAGER,STORAGE_OPTIONS_OVERLAY,STORAGE_OPTIONS_VFS,PODMAN_UPGRADE_FROM"
 # run as root or or not
 SUDO=""
 if [[ "$PRIV" == "root" ]]; then
     SUDO="sudo --non-interactive --preserve-env=$PRESERVE_ENVS"
 fi
 
-STORAGE_FS=overlay
+CI_DESIRED_STORAGE=overlay
 
 case "$DISTRO_NAME" in
 fedora-current)
     ;;
 fedora-prior)
-    STORAGE_FS=vfs
+    CI_DESIRED_STORAGE=vfs
     ;;
 fedora-rawhide)
     # On rawhide enable composefs testing
@@ -56,8 +56,18 @@ if [[ -x $LCR ]]; then
 fi
 
 ## Used in tests so we need to export them
-export STORAGE_FS
-export CI_DESIRED_COMPOSEFS
+export CI_DESIRED_STORAGE
+
+# Marker for the tests so they can insist the CI_DESIRED_* values are set
+# instead of silently skipping. GITHUB_ACTIONS is no use here, it is not
+# carried into the VM, and anyone can run our tests under github actions.
+export PODMAN_CI=1
+
+# composefs is only written into the rootful config below, so only tell the
+# tests to expect it when we actually run rootful.
+if [[ "$PRIV" == "root" ]]; then
+    export CI_DESIRED_COMPOSEFS
+fi
 
 ### SETUP HERE
 
@@ -68,7 +78,7 @@ if [[ -e $conf ]]; then
 fi
 sudo tee $conf << EOF
 [storage]
-driver = "$STORAGE_FS"
+driver = "$CI_DESIRED_STORAGE"
 EOF
 
 if [[ -n "$CI_DESIRED_COMPOSEFS" ]]; then

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -351,8 +351,8 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 	}
 
 	storageOptions := STORAGE_OPTIONS
-	if os.Getenv("STORAGE_FS") != "" {
-		storageFs = os.Getenv("STORAGE_FS")
+	if os.Getenv("CI_DESIRED_STORAGE") != "" {
+		storageFs = os.Getenv("CI_DESIRED_STORAGE")
 		storageOptions = "--storage-driver " + storageFs
 
 		// Look for STORAGE_OPTIONS_OVERLAY / STORAGE_OPTIONS_VFS

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -123,19 +123,6 @@ var _ = Describe("Podman Info", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("pids"))
 	})
 
-	It("Podman info: check desired runtime", func() {
-		// defined in .cirrus.yml
-		want := os.Getenv("CI_DESIRED_RUNTIME")
-		if want == "" {
-			if os.Getenv("CIRRUS_CI") == "" {
-				Skip("CI_DESIRED_RUNTIME is not set--this is OK because we're not running under Cirrus")
-			}
-			Fail("CIRRUS_CI is set, but CI_DESIRED_RUNTIME is not! See #14912")
-		}
-		session := podmanTest.PodmanExitCleanly("info", "--format", "{{.Host.OCIRuntime.Name}}")
-		Expect(session.OutputToString()).To(Equal(want))
-	})
-
 	It("Podman info: check desired network backend", func() {
 		session := podmanTest.PodmanExitCleanly("info", "--format", "{{.Host.NetworkBackend}}")
 		Expect(session.OutputToString()).To(Equal("netavark"))
@@ -222,13 +209,13 @@ var _ = Describe("Podman Info", func() {
 	})
 
 	It("Podman info: check desired storage driver", func() {
-		// defined in .cirrus.yml
+		// set by hack/ci/runner.sh
 		want := os.Getenv("CI_DESIRED_STORAGE")
 		if want == "" {
-			if os.Getenv("CIRRUS_CI") == "" {
-				Skip("CI_DESIRED_STORAGE is not set--this is OK because we're not running under Cirrus")
+			if os.Getenv("PODMAN_CI") == "" {
+				Skip("CI_DESIRED_STORAGE is not set--this is OK because we're not running in podman CI")
 			}
-			Fail("CIRRUS_CI is set, but CI_DESIRED_STORAGE is not! See #20161")
+			Fail("PODMAN_CI is set, but CI_DESIRED_STORAGE is not! See #20161")
 		}
 		session := podmanTest.PodmanExitCleanly("info", "--format", "{{.Store.GraphDriverName}}")
 		Expect(session.OutputToString()).To(Equal(want), ".Store.GraphDriverName from podman info")

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -65,24 +65,6 @@ store.imageStore.number   | 1
     done < <(parse_table "$tests")
 }
 
-@test "podman info - confirm desired runtime" {
-    if [[ -z "$CI_DESIRED_RUNTIME" ]]; then
-        # When running in Cirrus, CI_DESIRED_RUNTIME *must* be defined
-        # in .cirrus.yml so we can double-check that all CI VMs are
-        # using crun/runc as desired.
-        if [[ -n "$CIRRUS_CI" ]]; then
-            die "CIRRUS_CI is set, but CI_DESIRED_RUNTIME is not! See #14912"
-        fi
-
-        # Not running under Cirrus (e.g., gating tests, or dev laptop).
-        # Totally OK to skip this test.
-        skip "CI_DESIRED_RUNTIME is unset--OK, because we're not in Cirrus"
-    fi
-
-    run_podman info --format '{{.Host.OCIRuntime.Name}}'
-    is "$output" "$CI_DESIRED_RUNTIME" "CI_DESIRED_RUNTIME (from .cirrus.yml)"
-}
-
 @test "podman info - confirm desired network backend" {
     if [[ -z "$CI_DESIRED_NETWORK" ]]; then
         # When running on RHEL, CI_DESIRED_NETWORK *must* be defined
@@ -105,19 +87,19 @@ store.imageStore.number   | 1
 
 @test "podman info - confirm desired storage driver" {
     if [[ -z "$CI_DESIRED_STORAGE" ]]; then
-        # When running in Cirrus, CI_DESIRED_STORAGE *must* be defined
-        # in .cirrus.yml so we can double-check that all CI VMs are
-        # using overlay or vfs as desired.
-        if [[ -n "$CIRRUS_CI" ]]; then
-            die "CIRRUS_CI is set, but CI_DESIRED_STORAGE is not! See #20161"
+        # In our CI, CI_DESIRED_STORAGE *must* be set by hack/ci/runner.sh
+        # so we can double-check that all CI VMs are using overlay or vfs
+        # as desired.
+        if [[ -n "$PODMAN_CI" ]]; then
+            die "PODMAN_CI is set, but CI_DESIRED_STORAGE is not! See #20161"
         fi
 
-        # Not running under Cirrus (e.g., gating tests, or dev laptop).
+        # Not running in podman CI (e.g., gating tests, or dev laptop).
         # Totally OK to skip this test.
-        skip "CI_DESIRED_STORAGE is unset--OK, because we're not in Cirrus"
+        skip "CI_DESIRED_STORAGE is unset--OK, because we're not in podman CI"
     fi
 
-    is "$(podman_storage_driver)" "$CI_DESIRED_STORAGE" "podman storage driver is not CI_DESIRED_STORAGE (from .cirrus.yml)"
+    is "$(podman_storage_driver)" "$CI_DESIRED_STORAGE" "podman storage driver is not CI_DESIRED_STORAGE"
 
     # Confirm desired setting of composefs
     if [[ "$CI_DESIRED_STORAGE" = "overlay" ]]; then


### PR DESCRIPTION
Renamed the variable the way you suggested rather than adding an alias, so `STORAGE_FS` is now `CI_DESIRED_STORAGE` in `runner.sh` and in the one place `test/e2e/common_test.go` reads it.

Dropped the runtime side completely, including the checks in `005-info.bats` and `info_test.go`, since crun is the only thing we test. `podman_runtime()` stays, it is used in eight other files.

The cirrus guards now key on `PODMAN_CI`, exported from `runner.sh`. `GITHUB_ACTIONS` was no good, `limactl shell` does not carry the host env into the VM.

Also only exporting `CI_DESIRED_COMPOSEFS` when we run rootful. That was danishprakash's point, un-skipping the storage test switches on the composefs assert below it and the config is only written into `storage.rootful.conf.d`, so rootless rawhide would have expected true and got `<no value>`.

#### Does this PR introduce a user-facing change?

```
None
```
