### PR TITLE
testvol: return error in Path endpoint when volume is unmounted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ test/testvol/testvol: $(wildcard test/testvol/*.go)
 
 .PHONY: volume-plugin-test-img
 volume-plugin-test-img:
-	./bin/podman build --network none -t quay.io/libpod/volume-plugin-test-img:$$(date +%Y%m%d) -f ./test/testvol/Containerfile .
+	./bin/podman build --network none --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x --manifest quay.io/libpod/volume-plugin-test-img:$$(date +%Y%m%d) -f ./test/testvol/Containerfile .
 
 .PHONY: test/goecho/goecho
 test/goecho/goecho: $(wildcard test/goecho/*.go)

--- a/test/NEW-IMAGES
+++ b/test/NEW-IMAGES
@@ -12,3 +12,4 @@
 #
 # Format is one FQIN per line. Enumerate them below:
 #
+quay.io/libpod/volume-plugin-test-img:20260807

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -2,4 +2,4 @@
 
 package integration
 
-var volumeTest = "quay.io/libpod/volume-plugin-test-img:20220623"
+var volumeTest = "quay.io/libpod/volume-plugin-test-img:20260807"

--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -18,7 +18,6 @@ var _ = Describe("Podman volume plugins", func() {
 		os.Setenv("CONTAINERS_CONF", "config/containers.conf")
 		SkipIfRemote("Volume plugins only supported as local")
 		SkipIfRootless("Root is required for volume plugin testing")
-		SkipIfNotAMD64() // https://github.com/containers/podman/issues/28270
 		err = os.MkdirAll("/run/docker/plugins", 0o755)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/test/testvol/Containerfile
+++ b/test/testvol/Containerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/golang:1.26-alpine AS build-img
-COPY ./ /go/src/github.com/containers/podman/
-WORKDIR /go/src/github.com/containers/podman
-RUN GO111MODULE=off go build -o /testvol ./test/testvol
+COPY ./ /go/src/github.com/podman-container-tools/podman/
+WORKDIR /go/src/github.com/podman-container-tools/podman
+RUN go build -o /testvol ./test/testvol
 
 FROM alpine
 COPY --from=build-img /testvol /usr/local/bin

--- a/test/testvol/main.go
+++ b/test/testvol/main.go
@@ -253,12 +253,15 @@ func (d *DirDriver) Path(req *volume.PathRequest) (*volume.PathResponse, error) 
 
 	logrus.Infof("Hit Path() endpoint")
 
-	// TODO: Should we return error if not mounted?
-
 	vol, exists := d.volumes[req.Name]
 	if !exists {
 		logrus.Debugf("Cannot locate volume %s", req.Name)
 		return nil, fmt.Errorf("no volume with name %s found", req.Name)
+	}
+
+	if len(vol.mounts) == 0 {
+		logrus.Debugf("Volume %s is not mounted", req.Name)
+		return nil, fmt.Errorf("volume %s is not mounted", req.Name)
 	}
 
 	return &volume.PathResponse{


### PR DESCRIPTION
This updates the `testvol` mock driver's `Path()` endpoint to verify if a volume is actually mounted before returning a path. If the volume has no active mounts, it now correctly returns an error instead of a fake path, resolving the existing TODO in `test/testvol/main.go`.
