### PR TITLE
compat: report cgroup driver "none" when rootless with cgroupfs

### DIFF
--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -66,7 +66,7 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 			CPUCfsQuota:         sysInfo.CPUCfsQuota,
 			CPUSet:              sysInfo.Cpuset,
 			CPUShares:           sysInfo.CPUShares,
-			CgroupDriver:        configInfo.Engine.CgroupManager,
+			CgroupDriver:        getCgroupDriver(configInfo.Engine.CgroupManager, rootless.IsRootless()),
 			CDISpecDirs:         infoData.Host.CDISpecDirs,
 			ContainerdCommit:    dockerSystem.Commit{},
 			Containers:          infoData.Store.ContainerStore.Number,
@@ -192,6 +192,21 @@ func getGraphStatus(storeInfo map[string]string) [][2]string {
 		graphStatus = append(graphStatus, [2]string{k, v})
 	}
 	return graphStatus
+}
+
+// getCgroupDriver returns the cgroup driver reported to Docker API clients.
+//
+// Rootless Podman using the cgroupfs manager cannot honor a cgroup parent
+// chosen by the client: only the delegated subtree is writable, and container
+// creation deliberately leaves the parent unset in that case.  Reporting
+// "cgroupfs" leads clients to assume a rootful daemon and ask for a parent that
+// cannot be created, so report "none" instead, matching what rootless Docker
+// does.
+func getCgroupDriver(cgroupManager string, isRootless bool) string {
+	if isRootless && cgroupManager == config.CgroupfsCgroupsManager {
+		return "none"
+	}
+	return cgroupManager
 }
 
 func getSecOpts(sysInfo *sysinfo.SysInfo, c *config.Config) []string {

--- a/pkg/api/handlers/compat/info_test.go
+++ b/pkg/api/handlers/compat/info_test.go
@@ -1,0 +1,51 @@
+//go:build !remote && (linux || freebsd)
+
+package compat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCgroupDriver(t *testing.T) {
+	tests := []struct {
+		name           string
+		cgroupManager  string
+		isRootless     bool
+		expectedDriver string
+	}{
+		{
+			name:           "rootful cgroupfs is reported as-is",
+			cgroupManager:  "cgroupfs",
+			isRootless:     false,
+			expectedDriver: "cgroupfs",
+		},
+		{
+			// Rootless cannot create a cgroup parent outside of the
+			// delegated subtree, so clients must not be told to pick one.
+			name:           "rootless cgroupfs is reported as none",
+			cgroupManager:  "cgroupfs",
+			isRootless:     true,
+			expectedDriver: "none",
+		},
+		{
+			name:           "rootful systemd is reported as-is",
+			cgroupManager:  "systemd",
+			isRootless:     false,
+			expectedDriver: "systemd",
+		},
+		{
+			name:           "rootless systemd is reported as-is",
+			cgroupManager:  "systemd",
+			isRootless:     true,
+			expectedDriver: "systemd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedDriver, getCgroupDriver(tt.cgroupManager, tt.isRootless))
+		})
+	}
+}


### PR DESCRIPTION
Rootless Podman with the cgroupfs manager cannot create a cgroup parent outside its delegated subtree, and container creation already leaves it unset (`libpod/runtime_ctr.go:412`). Compat `/info` still reports `cgroupfs` though, so buildx pins its BuildKit container to `/docker/buildx` and crun fails:

```
crun: create `/sys/fs/cgroup/docker`: Permission denied: OCI permission denied
```

Rootless dockerd reports `none`, never `cgroupfs` (`cgroupDriver` in moby `daemon/daemon_unix.go`). This does the same.

Repro without Docker involved:

```
podman --cgroup-manager=cgroupfs run --rm alpine true                                  # works
podman --cgroup-manager=cgroupfs run --rm --cgroup-parent=/docker/buildx alpine true   # fails
```

With the same buildx client against a rootless service, `HostConfig.CgroupParent` on the buildkit container goes from `/docker/buildx` to empty.

Fixes #27824
