### PR TITLE
save: reject docker transport image references

### DIFF
--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -104,6 +104,9 @@ func save(cmd *cobra.Command, args []string) (finalErr error) {
 		tags      []string
 		succeeded = false
 	)
+	if strings.HasPrefix(args[0], "docker://") {
+		return fmt.Errorf("image %q is not in local storage; remove the docker:// prefix", args[0])
+	}
 	if cmd.Flag("compress").Changed && saveOpts.Format != define.V2s2ManifestDir {
 		return errors.New("--compress can only be set when --format is 'docker-dir'")
 	}

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -67,6 +67,12 @@ var _ = Describe("Podman save", func() {
 		Expect(save).To(ExitWithError(125, "repository name must be lowercase"))
 	})
 
+	It("podman save rejects docker transport", func() {
+		save := podmanTest.Podman([]string{"save", "-q", "docker://" + ALPINE})
+		save.WaitWithDefaultTimeout()
+		Expect(save).To(ExitWithError(125, "is not in local storage; remove the docker:// prefix"))
+	})
+
 	It("podman save to directory with oci format", func() {
 		outdir := filepath.Join(podmanTest.TempDir, "save")
 


### PR DESCRIPTION
## Summary
- The change to podman save.
- Rejection of docker:// image references with a clearer error.
- Addition of the e2e test.
- Referenced issues using: #20775.

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits (`git commit -s`).
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [ ] Documentation has been updated
- [x] All commits pass `make validatepr`
- [x] Release note entered below (or no user-facing changes)

#### Does this PR introduce a user-facing change?

No

```release-note
When `podman save` is invoked with `docker://{image}`, a more appropriate error is now returned.
```