### PR TITLE
pkg/machine/env: add tests for WithPodmanPrefix and dir prefixes

### DIFF
--- a/pkg/machine/env/dir_test.go
+++ b/pkg/machine/env/dir_test.go
@@ -1,0 +1,29 @@
+package env_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.podman.io/podman/v6/pkg/machine/env"
+)
+
+func TestWithPodmanPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"adds prefix to a bare name", "machine", "podman-machine"},
+		{"leaves an already-prefixed name unchanged", "podman-machine", "podman-machine"},
+		{"treats any podman-leading name as already prefixed", "podmanx", "podmanx"},
+		{"leaves the bare word podman unchanged", "podman", "podman"},
+		{"prefixes a name that merely contains podman", "mypodman", "podman-mypodman"},
+		{"prefixes an empty name", "", "podman-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, env.WithPodmanPrefix(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #29314

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
Adds unit tests for `pkg/machine/env` which had none. Covers the subtle `WithPodmanPrefix` prefixing rules (only prepends `podman-` when the name does not already start with `podman`) and that `DataDirPrefix`/`ConfDirPrefix` end with `containers/podman/machine`.

Pure test-only change, no behaviour change. `go test -race ./pkg/machine/env/` passes 



#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
