### PR TITLE
Allow setting the service container name via annotation

### DIFF
--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -154,6 +154,10 @@ const (
 	// pod creation
 	InfraNameAnnotation = "io.podman.annotations.infra.name"
 
+	// ServiceNameAnnotation is used by generate and play kube when the service container is set during
+	// pod creation
+	ServiceNameAnnotation = "io.podman.annotations.service.name"
+
 	// UserNsAnnotation is used by play kube when playing a kube yaml to specify userns
 	// of the container
 	UserNsAnnotation = "io.podman.annotations.userns"

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -329,7 +329,22 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 
 		// TODO: create constants for the various "kinds" of yaml files.
 		if options.ServiceContainer && serviceContainer == nil && (kind == "Pod" || kind == "Deployment") {
-			ctr, err := ic.createServiceContainer(ctx, k8sName(content, "service"), options)
+
+			// If the serviceNameAnnotation is set in the yaml, use that as the service container name
+			// If not, fall back to the default infra container name
+			var svcCtrName string
+			svcCtrName = k8sName(content, "service")
+
+			name, err := getServiceContainerName(kind, document)
+			if err != nil {
+				return nil, err
+			}
+
+			if name != "" {
+				svcCtrName = name
+			}
+
+			ctr, err := ic.createServiceContainer(ctx, svcCtrName, options)
 			if err != nil {
 				return nil, err
 			}
@@ -1617,6 +1632,28 @@ func getKubeKind(obj []byte) (string, error) {
 	}
 
 	return kubeObject.Kind, nil
+}
+
+func getServiceContainerName(kind string, obj []byte) (string, error) {
+	var podYAML v1.Pod
+	var deploymentYAML v1.Deployment
+
+	switch kind {
+	case "Pod":
+		if err := yaml.Unmarshal(obj, &podYAML); err != nil {
+			return "", err
+		}
+
+		return podYAML.Annotations[define.ServiceNameAnnotation], nil
+	case "Deployment":
+		if err := yaml.Unmarshal(obj, &deploymentYAML); err != nil {
+			return "", err
+		}
+
+		return deploymentYAML.Annotations[define.ServiceNameAnnotation], nil
+	default:
+		return "", fmt.Errorf("can only read service name from pod or deployment")
+	}
 }
 
 // sortKubeKinds adds the correct creation order for the kube kinds.


### PR DESCRIPTION
When running a k8s manifest via systemd there are two additional containers created: an infra container and a service container. It's currently possible to set the name of the infra container with an annotation making it clear which k8s manifest the container belongs to. This PR extends this ability to the service container.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)

Looking for advice on what kinds of tests would be appropriate here.

- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)

Since `--service-container` is undocumented I assume this is fine to be undocumented as well.

- [x] All commits pass `make validatepr` (format/lint checks)

I think it passed, something is weird on my system and it wasn't able to build for Windows or Darwin but I did get some linting errors that I fixed so I think I made it through the important bits.

- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

I'm not sure actually if this counts as user-facing because `--service-container` is a "secret" option and undocumented. This annotation would only be for people like me who _really_ care.

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
