### PR TITLE
rmi: reject docker transport image references

### DIFF
--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -3,6 +3,7 @@ package images
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -67,6 +68,11 @@ func rm(_ *cobra.Command, args []string) error {
 	}
 	if len(args) > 0 && imageOpts.All {
 		return errors.New("when using the --all switch, you may not pass any images names or IDs")
+	}
+	for _, image := range args {
+		if strings.HasPrefix(image, "docker://") {
+			return fmt.Errorf("image %q is not in local storage; remove the docker:// prefix", image)
+		}
 	}
 
 	if imageOpts.Force {

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -12,6 +12,12 @@ import (
 )
 
 var _ = Describe("Podman rmi", func() {
+	It("podman rmi rejects docker transport", func() {
+		session := podmanTest.Podman([]string{"rmi", "docker://" + ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, "is not in local storage; remove the docker:// prefix"))
+	})
+
 	It("podman rmi bogus image", func() {
 		session := podmanTest.Podman([]string{"rmi", "debian:6.0.10"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
##  Summary
- Update `podman rmi` to reject `docker://` image references before image removal is attempted.
- This avoids the generic "unsupported transport" error and returns a clearer error indicating that transport-qualified
-  image references are not supported for local image removal.
- An e2e test has been added to cover this behavior.

Referenced issue:
Non-actionable error message: 'Error: unsupported transport "docker" for looking up local images' #20775
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

#### Does this PR introduce a user-facing change?

```release-note
When `podman rmi` is invoked with `docker://{image}`, a clearer error is now returned instead of the generic unsupported transport error.
```
