### PR TITLE
build: fix remote seccomp default

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -312,6 +312,17 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 	if err != nil {
 		return nil, err
 	}
+	if registry.IsRemote() {
+		hasSeccompOption := slices.ContainsFunc(flags.SecurityOpt, func(opt string) bool {
+			return strings.HasPrefix(opt, "seccomp=")
+		})
+		// Do not send the client's local default seccomp profile to
+		// the remote server; the server must adopt its own default.
+		// See #24318
+		if !hasSeccompOption {
+			commonOpts.SeccompProfilePath = ""
+		}
+	}
 
 	pullFlagsCount := 0
 	if c.Flag("pull").Changed {

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -723,6 +723,32 @@ subdir**`
 		Expect(output).NotTo(ContainSubstring("subdir"))
 	})
 
+	// This test verifies that remote podman does not forward the client's
+	// default seccomp profile from containers.conf to the server
+	// See https://github.com/podman-container-tools/podman/issues/24318
+	It("podman remote build uses the server seccomp default (#24318)", func() {
+		SkipIfNotRemote("Testing remote build seccomp defaults")
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
+
+		serverConfigPath := filepath.Join(podmanTest.TempDir, "server-containers.conf")
+		Expect(os.WriteFile(serverConfigPath, []byte("[containers]\n"), 0o644)).To(Succeed())
+		GinkgoT().Setenv("CONTAINERS_CONF", serverConfigPath)
+		podmanTest.RestartRemoteService()
+
+		clientConfigPath := filepath.Join(podmanTest.TempDir, "client-containers.conf")
+		Expect(os.WriteFile(clientConfigPath, []byte("[containers]\nseccomp_profile=\"unconfined\"\n"), 0o644)).To(Succeed())
+		// The service is already running, so this only changes the client config.
+		GinkgoT().Setenv("CONTAINERS_CONF", clientConfigPath)
+
+		contextDir := filepath.Join(podmanTest.TempDir, "seccomp-build")
+		Expect(os.Mkdir(contextDir, 0o755)).To(Succeed())
+
+		containerfile := fmt.Appendf(nil, "FROM %s\nRUN test \"$(awk '/^Seccomp:/ { print $2 }' /proc/self/status)\" = 2\n", CITEST_IMAGE)
+		Expect(os.WriteFile(filepath.Join(contextDir, "Containerfile"), containerfile, 0o644)).To(Succeed())
+
+		podmanTest.PodmanExitCleanly("build", "--pull-never", "--security-opt", "label=disable", contextDir)
+	})
+
 	It("podman remote test context dir contains empty dirs and symlinks", func() {
 		SkipIfNotRemote("Testing remote contextDir empty")
 		podmanTest.RestartRemoteService()


### PR DESCRIPTION
Fixes: #24318

- Podman remote was sending the client's default seccomp profile path to the server during builds when no seccomp option was specified. 
- Remote server fails to read the path as it was only for client. 
- This patch clears the client's default seccomp path afther Buildah option parsing so that the remote server uses it's own default seccomp.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a bug where the Podman remote server used the client's default seccomp profile path.
```


