### PR TITLE
hack/ci: let the fixed-skips check see issue numbers at end of line

### DIFF
--- a/hack/ci/pr-removes-fixed-skips
+++ b/hack/ci/pr-removes-fixed-skips
@@ -108,7 +108,7 @@ END_ADVICE
 sub unremoved_skips {
     my $issues = join('|', @_);
 
-    my $re = "(^\\s\+skip|fixme).*#($issues)[^0-9]";
+    my $re = "(^\\s\+skip|fixme).*#($issues)([^0-9]|\$)";
     # FIXME FIXME FIXME: use File::Find instead of enumerating directories
     # (the important thing here is to exclude vendor)
     my @grep = ('grep', '-E', '-rin', $re, "test", "cmd", "libpod", "pkg");

--- a/hack/ci/pr-removes-fixed-skips.t
+++ b/hack/ci/pr-removes-fixed-skips.t
@@ -128,6 +128,12 @@ __END__
 ! pkg/podman/foo_test.go~:10:    Skip("#10101: no match in ~ file")
 ! pkg/podman/foo_test.go.bkp:10:    Skip("#10101: no match in .bkp file")
 
+== issue number at end of line
+[11871]
++ cmd/podman/foo_test.go:12:    // FIXME: see #11871
++ test/system/foo.bats:10:    # FIXME: debugging for #11871
+! test/system/foo.bats:14:    # FIXME: unrelated #118710
+
 == no match if Skip is commented out
 [123]
 ! test/e2e/foo_test.go:10:   // Skip("#123: commented out")


### PR DESCRIPTION
The check builds `#($issues)[^0-9]` and hands it to `grep -E`, so it needs a character after the issue number. grep strips the newline before matching, so when the number is the last thing on the line there is nothing for `[^0-9]` to match and the skip is invisible to the gate.

Most skips are unaffected because something usually follows, even just a closing quote. It is trailing comments that go missing. There are two in the tree right now that the gate cannot see, `test/system/500-networking.bats:266` referencing #11871 and `test/buildah-bud/apply-podman-deltas:335` referencing #25756, both closed. If someone opened a PR saying it fixed either one, the check would pass and the FIXME would stay.

`([^0-9]|$)` keeps the existing behaviour and adds the end of line case. I checked it still does not match #118710 when looking for #11871.

Added a case to `pr-removes-fixed-skips.t` for it. It passes with the change and fails without it.

#### Does this PR introduce a user-facing change?

```
None
```
