### PR TITLE
prevent goroutine leak in StartGenericAppleVM

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -251,25 +251,33 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 	// the main goroutine completes.
 	term := make(chan os.Signal, 1)
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+	// done is closed by waitForReadyFunc (via defer) to give the signal
+	// forwarding goroutine a clean exit path once the VM has started or
+	// failed to start. Without this the goroutine leaks on every call.
+	done := make(chan struct{})
 	// Get the PID first because cmd.Process will
 	// be released in the main thread
 	pid := cmd.Process.Pid
 	go func() {
-		<-term
-		logrus.Debugf("Termination signal forwarded to the VM process (PID: %d)\n", pid)
-		p, err := os.FindProcess(pid)
-		if err != nil {
-			logrus.Errorf("Failed to find process %d: %v", pid, err)
-			return
-		}
-		err = p.Signal(os.Interrupt)
-		if err != nil {
-			logrus.Errorf("Termination signal received, but terminating the VM process (PID: %d) failed: %v", pid, err)
-			return
-		}
-		// Wait and release the resources associated with the process
-		if _, err := p.Wait(); err != nil {
-			logrus.Debugf("Failed waiting for the process after terminating it: %v", err)
+		select {
+		case <-term:
+			logrus.Debugf("Termination signal forwarded to the VM process (PID: %d)\n", pid)
+			p, err := os.FindProcess(pid)
+			if err != nil {
+				logrus.Errorf("Failed to find process %d: %v", pid, err)
+				return
+			}
+			err = p.Signal(os.Interrupt)
+			if err != nil {
+				logrus.Errorf("Termination signal received, but terminating the VM process (PID: %d) failed: %v", pid, err)
+				return
+			}
+			// Wait and release the resources associated with the process
+			if _, err := p.Wait(); err != nil {
+				logrus.Debugf("Failed waiting for the process after terminating it: %v", err)
+			}
+		case <-done:
+			logrus.Debug("VM signal-forwarding goroutine: done")
 		}
 	}()
 
@@ -277,6 +285,12 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 	// uses to block its execution until the the VM is ready or an error
 	// occurs
 	waitForReadyFunc := func() error {
+		// Stop signal forwarding and unblock the goroutine regardless of
+		// whether the VM started successfully or returned an error.
+		defer func() {
+			signal.Stop(term)
+			close(done)
+		}()
 		processErrChan := make(chan error)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
Added a done channel and select block to cleanly terminate the signal-forwarding goroutine when the VM starts or fails, preventing a goroutine leak on every `podman machine start`.

Fixes: #29342

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #29342` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a resource leak on macOS where a signal-forwarding goroutine would persist indefinitely in the background after running `podman machine start`.