### PR TITLE
docs: clarify --all-tags and --include-volumes

### DIFF
--- a/docs/source/markdown/options/all-tags.md
+++ b/docs/source/markdown/options/all-tags.md
@@ -10,4 +10,8 @@
 
 All tagged images in the repository are pulled.
 
-*IMPORTANT: When using the all-tags flag, Podman does not iterate over the search registries in the **[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)** but always uses docker.io for unqualified image names.*
+*IMPORTANT: With **--all-tags**, Podman does **not** walk the unqualified-search registries from
+**[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)**
+for short (unqualified) names. Unqualified names are resolved as if they lived on **docker.io**
+(for example `alpine` becomes `docker.io/library/alpine`). To pull every tag from another registry,
+use a fully qualified image name such as `quay.io/myorg/myimage` or `registry.example.com/ns/name`.*

--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -55,7 +55,7 @@ Write the image ID to the file.
 #### **--include-volumes**
 
 Include in the committed image any volumes added to the container by the **--volume** or **--mount** OPTIONS to the **[podman create](podman-create.1.md)** and **[podman run](podman-run.1.md)** commands.\
-The default is **false**.
+This only takes effect when set to **true**. The default is **false** (volume contents are not copied into the image).
 
 #### **--message**, **-m**=*message*
 


### PR DESCRIPTION
small docs fixes:

- `--all-tags`: unqualified names don't walk registries.conf search lists; they go through docker.io. fully-qualified names are the way to hit other registries.
- `--include-volumes`: only does something when set to true (default false).

also glanced at #17514 — the Label YXZ typo looks already fixed on main.

Fixes #23625
Fixes #15387