### PR TITLE
test/e2e: fix remaining hardcoded alpine_nginx reference in play_kube_test.go

### DIFF
--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5598,7 +5598,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: quay.io/libpod/alpine_nginx:latest
+        image: ` + NGINX_IMAGE + `
         ports:
         - containerPort: 1234
           hostPort: 80


### PR DESCRIPTION
The "podman kube --quiet with error" test hardcoded
quay.io/libpod/alpine_nginx:latest directly inside a YAML string, which breaks
on non-amd64 architectures (#28272).

This instance was missed in commit cd2f122fb4, which fixed the same pattern in
five other tests in this file, because it used a raw inline literal rather than
the NGINX_IMAGE variable.

Switched to NGINX_IMAGE, which is already defined per architecture, so no skip is needed here.

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`)
- [ ] Referenced issues using `Fixes: #00000` in the commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

Note: ran `golangci-lint` v2.12.2 (`GOOS=linux`) against `./test/e2e/...` and `gofmt`, both clean. I wasn't able to run the full `make validatepr` container locally as I don't have podman installed on this machine.

I left Fixes: off intentionally; this doesn't close #28272 on its own. The default amd64 image is still single-arch; building an actual multi-arch image is separate work that's still open. This just routes the one remaining test through the same per-arch NGINX_IMAGE constant used everywhere else in the file.

#### Does this PR introduce a user-facing change?

```release-note
None
```
