### PR TITLE
Makefile: build ginkgo before running localunit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -670,7 +670,7 @@ run-docker-py-tests:
 	rm -f test/__init__.py
 
 .PHONY: localunit
-localunit: test/goecho/goecho test/version/version ## Run unit tests with coverage
+localunit: .install.ginkgo test/goecho/goecho test/version/version ## Run unit tests with coverage
 	rm -rf ${COVERAGE_PATH} && mkdir -p ${COVERAGE_PATH}
 	UNIT=1 $(GINKGO) \
 		-r \

--- a/Makefile
+++ b/Makefile
@@ -670,7 +670,7 @@ run-docker-py-tests:
 	rm -f test/__init__.py
 
 .PHONY: localunit
-localunit: test/goecho/goecho test/version/version ## Run unit tests with coverage
+localunit: $(GINKGO) test/goecho/goecho test/version/version ## Run unit tests with coverage
 	rm -rf ${COVERAGE_PATH} && mkdir -p ${COVERAGE_PATH}
 	UNIT=1 $(GINKGO) \
 		-r \
@@ -1013,6 +1013,9 @@ install.tools: .install.golangci-lint ## Install development tools (linters, etc
 .PHONY: .install.ginkgo
 .install.ginkgo:
 	$(GO) build -o $(GINKGO) ./vendor/github.com/onsi/ginkgo/v2/ginkgo
+
+$(GINKGO):
+	$(MAKE) .install.ginkgo
 
 .PHONY: .install.golangci-lint
 .install.golangci-lint:

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -190,7 +190,6 @@ function run_docker_py() {
 }
 
 function run_unit() {
-    make .install.ginkgo
     $SUDO make localunit
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change? 
```release-note
 None
```

On a fresh clone `make localunit` fails on clean checkout
```$ git clean -xfd && make localunit
/usr/bin/bash: line 1: ./bin/ginkgo: No such file or directory
make: *** [Makefile:675: localunit] Error 127
```

The current recipe runs `$(GINKGO)` which is `./bin/ginkgo` but the target only declares `test/goecho/goecho` and `test/version/version` as prereq. Nothing builds ginkgo, so on a fresh clone the binary is missing. `/bin/` is gitignored, so it is never checked in.

The other three targets that use ginkgo all declare `.install.ginkgo`: `ginkgo-run` (line 695), `testbindings` (715) and `system.test-binary` (766). `localunit` is the only one that does not.

But
`hack/ci/runner.sh` already works around this:

 ```bash
 function run_unit() {
     make .install.ginkgo
     $SUDO make localunit
 }
 ```
This makes that first line unnecessary.
I used a file target rather than adding `.install.ginkgo` to the prerequisite list, because `.install.ginkgo` is `.PHONY` and would rebuild on every invocation. That matters here: `run_unit` runs `localunit` under sudo, so an unconditional rebuild would produce a root-owned `bin/ginkgo`. With a file target, make skips the build when the binary is present, which I checked with
 `make -n` on a warm tree (no rebuild commands emitted).
 
 With the fix, ginkgo builds and 64 suites run. 63 pass. The one failure is `pkg/machine/provider TestBadInstalledProviders`, which needs  `qemu-system-x86_64` that I do not have installed locally, and is unrelated to this change.
`make validatepr` passes.