### PR TITLE
compat: ignore dead and restarting status filters

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -126,6 +127,25 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 
 	filterFuncs := make([]libpod.ContainerFilter, 0, len(*filterMap))
 	all := query.All || query.Limit > 0
+	matchNothing := false
+	if statusValues, ok := (*filterMap)["status"]; ok {
+		// Docker thinks that if status is given as an input, then we should override
+		// the all setting and always deal with all containers.
+		all = true
+		// "dead" and "restarting" are valid status values for Docker but
+		// have no equivalent state in Podman, so no container can ever
+		// match them. Drop them instead of erroring so Docker clients can
+		// use them; a status filter left empty by this matches nothing.
+		statusValues = slices.DeleteFunc(statusValues, func(status string) bool {
+			return status == "dead" || status == "restarting"
+		})
+		if len(statusValues) == 0 {
+			matchNothing = true
+			delete(*filterMap, "status")
+		} else {
+			(*filterMap)["status"] = statusValues
+		}
+	}
 	if len(*filterMap) > 0 {
 		for k, v := range *filterMap {
 			generatedFunc, err := filters.GenerateContainerFilterFuncs(k, v, runtime)
@@ -136,11 +156,9 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 			filterFuncs = append(filterFuncs, generatedFunc)
 		}
 	}
-
-	// Docker thinks that if status is given as an input, then we should override
-	// the all setting and always deal with all containers.
-	if len((*filterMap)["status"]) > 0 {
-		all = true
+	if matchNothing {
+		utils.WriteResponse(w, http.StatusOK, []*handlers.Container{})
+		return
 	}
 	if !all {
 		runningOnly, err := filters.GenerateContainerFilterFuncs("status", []string{define.ContainerStateRunning.String()}, runtime)

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -87,7 +87,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//        - `network`=(`<network id>` or `<network name>`)
 	//        - `publish`=(`<port>[/<proto>]` or `<startport-endport>/[<proto>]`)
 	//        - `since`=(`<container id>` or `<container name>`)
-	//        - `status`=(`created`, `restarting`, `running`, `removing`, `paused`, `exited` or `dead`)
+	//        - `status`=(`created`, `restarting`, `running`, `removing`, `paused`, `exited` or `dead`). Note: `restarting` and `dead` have no equivalent in Podman and match no containers.
 	//        - `volume`=(`<volume name>` or `<mount point destination>`)
 	// produces:
 	// - application/json
@@ -830,7 +830,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//        - `pod`=(`<pod id>` or `<pod name>`)
 	//        - `publish`=(`<port>[/<proto>]` or `<startport-endport>/[<proto>]`)
 	//        - `since`=(`<container id>` or `<container name>`)
-	//        - `status`=(`created`, `restarting`, `running`, `removing`, `paused`, `exited` or `dead`)
+	//        - `status`=(`created`, `initialized`, `running`, `stopping`, `stopped`, `exited`, `paused`, `removing` or `unknown`)
 	//        - `volume`=(`<volume name>` or `<mount point destination>`)
 	// produces:
 	// - application/json

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -495,10 +495,32 @@ t GET containers/json?filters='garb1age}' 500 \
 t GET containers/json?filters='{"label":["testl' 500 \
     .cause="unexpected end of JSON input"
 
+# "dead" and "restarting" are documented Docker status values with no Podman
+# equivalent; the compat endpoint accepts them and they match no containers #28904
+podman run --name statusfilter-exited $IMAGE true
+t GET containers/json?filters='{"status":["dead"]}' 200 '[]'
+t GET containers/json?filters='{"status":["restarting"]}' 200 length=0
+t GET containers/json?filters='{"status":["dead","running"]}' 200 length=2
+t GET containers/json?filters='{"status":["dead","exited"]}' 200 \
+  length=1 \
+  .[0].Names[0]="/statusfilter-exited"
+t GET containers/json?filters='{"status":["dead"],"label":["slartibart=fast"]}' 200 length=0
+t GET containers/json?filters='{"status":["bogus"]}' 500 \
+    .cause="invalid argument"
+# other filters must still be validated when the status filter matches nothing
+t GET containers/json?filters='{"status":["dead"],"bogusfilter":["x"]}' 500 \
+    .cause="bogusfilter is an invalid filter"
+podman rm statusfilter-exited
 
 #libpod api list containers sanity checks
 t GET libpod/containers/json?filters='{"status":["removing"]}' 200 length=0
 t GET libpod/containers/json?filters='{"status":["bogus"]}' 500 \
+    .cause="invalid argument"
+# unlike the compat endpoint, the libpod endpoint does not accept Docker-only
+# status values
+t GET libpod/containers/json?filters='{"status":["dead"]}' 500 \
+    .cause="invalid argument"
+t GET libpod/containers/json?filters='{"status":["restarting"]}' 500 \
     .cause="invalid argument"
 t GET libpod/containers/json?filters='garb1age}' 500 \
     .cause="invalid character 'g' looking for beginning of value"


### PR DESCRIPTION
## Summary

docker allows `dead` and `restarting` as values for the `status` filter on the compat `/containers/json` endpoint, but podman currently returns HTTP 500 when either of them is used. this changes the compat api to ignore those values and return an empty list if no other status filters are left, which matches docker's behavior.

*the libpod api still rejects these values since they are docker specific states, as discussed in #28926. the libpod api docs are also updated to list only the states podman supports.*

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed the Docker-compatible `/containers/json` API to accept the `dead` and `restarting` status filters instead of returning an internal server error. (#28904)
```
