### PR TITLE
fix(exec): inherit precreate hook changes in exec sessions

### DIFF
--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -683,8 +683,15 @@ func (c *Container) prepareProcessExec(options *ExecOptions, env []string, sessi
 	if err != nil {
 		return nil, err
 	}
+	ctrSpec, err := c.specFromState()
+	if err != nil {
+		return nil, err
+	}
+	if ctrSpec.Process == nil {
+		ctrSpec.Process = c.config.Spec.Process
+	}
 	pspec := new(spec.Process)
-	if err := JSONDeepCopy(c.config.Spec.Process, pspec); err != nil {
+	if err := JSONDeepCopy(ctrSpec.Process, pspec); err != nil {
 		return nil, err
 	}
 	pspec.SelinuxLabel = c.config.ProcessLabel

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -312,4 +312,39 @@ load helpers
 
     run_podman rm -f -t0 $cid
 }
+
+# bats test_tags=ci:parallel
+@test "podman exec inherits precreate hook environment" {
+    # Regression test for #29347: podman exec must see environment variables
+    # set by a precreate hook, just like the container's init process does.
+    ctr=c_$(safename)
+    hooksdir=$PODMAN_TMPDIR/hooks_$(safename)
+
+    skip_if_remote "--hooks-dir is not usable with remote"
+
+    mkdir -p "$hooksdir"
+    cat > "$hooksdir/settings.json" <<EOF
+{
+    "version": "1.0.0",
+    "when": { "always": true },
+    "hook": {
+        "path": "$hooksdir/hook.sh"
+    },
+    "stages": ["precreate"]
+}
+EOF
+    cat >"$hooksdir/hook.sh" <<EOF
+#!/bin/sh
+jq '.process.env += ["PODMAN_HOOK_VAR=set_by_hook"]'
+EOF
+    chmod +x "$hooksdir/hook.sh"
+
+    run_podman run -d --name="$ctr" --hooks-dir="$hooksdir" $IMAGE sleep infinity
+
+    run_podman exec "$ctr" printenv PODMAN_HOOK_VAR
+    assert "$output" = "set_by_hook" "exec must inherit env var set by precreate hook"
+
+    run_podman rm -f -t0 "$ctr"
+    rm -rf "$hooksdir"
+}
 # vim: filetype=sh


### PR DESCRIPTION
## Problem

A precreate hook that changes the container's process spec, for example one that appends an env var to process.env, is reflected in the running container: the container's init process sees it, podman inspect shows it, and exec capability handling already reads the on-disk spec. But podman exec itself still built its process spec from the container's stored config, which predates the hooks. So env vars added by a precreate hook were missing from exec sessions.

Reproducer (from issue #29347): install a precreate hook that runs jq '.process.env += ["FOO=BAR"]', run a container, then `podman exec <ctr> env` — FOO=BAR is absent even though the container's init process has it.

## Fix

prepareProcessExec now reads the on-disk spec from the bundle (same source as podman inspect and setProcessCapabilitiesExec) instead of the stored pre-hook config, so exec sessions inherit process changes made by precreate hooks. When the on-disk spec does not exist (container never started) it falls back to the stored config, preserving previous behavior.

## Tests

Added a bats regression test in test/system/075-exec.bats: a precreate hook appends PODMAN_HOOK_VAR to process.env, and the test asserts `podman exec printenv PODMAN_HOOK_VAR` returns it.

Fixes #29347