### PR TITLE
quadlet: do not set RemainAfterExit=yes for volume units by default

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1662,7 +1662,8 @@ This key can be listed multiple times.
 
 Volume files are named with a `.volume` extension and contain a section `[Volume]` describing the
 named Podman volume. The generated service is a one-time command that ensures that the volume
-exists on the host, creating it if needed.
+exists on the host, creating it if needed. Unlike `.network`, `.image`, and `.artifact` oneshot units,
+the generated service for `.volume` units does not set `RemainAfterExit=yes` by default.
 
 By default, the Podman volume has the same name as the unit, but with a `systemd-` prefix, i.e. for
 a volume file named `$NAME.volume`, the generated Podman volume is called `systemd-$NAME`, and the

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1220,7 +1220,7 @@ func ConvertVolume(volume *parser.UnitFile, unitsInfoMap map[string]*UnitInfo, i
 
 	service.AddCmdline(ServiceGroup, "ExecStart", podman.Args)
 
-	defaultOneshotServiceGroup(service, true)
+	defaultOneshotServiceGroup(service, false)
 
 	// Store the name of the created resource
 	unitInfo.ResourceName = volumeName

--- a/test/e2e/quadlet/basic.volume
+++ b/test/e2e/quadlet/basic.volume
@@ -1,6 +1,6 @@
 ## assert-key-is Unit RequiresMountsFor "%t/containers"
 ## assert-key-is Service Type oneshot
-## assert-key-is Service RemainAfterExit yes
+## !assert-key-is Service RemainAfterExit yes
 ## assert-key-is-regex Service ExecStart ".*/podman volume create --ignore systemd-basic"
 ## assert-key-is Service SyslogIdentifier "%N"
 

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -111,7 +111,7 @@ function service_setup() {
     if [ "$option" == "wait" ]; then
         startargs="--wait"
         statusexit=3
-        local activestate="inactive"
+        activestate="inactive"
     fi
 
     systemctl_start $startargs "$service"
@@ -390,7 +390,7 @@ EOF
 
     run_quadlet "$quadlet_file"
 
-    service_setup $QUADLET_SERVICE_NAME
+    service_setup $QUADLET_SERVICE_NAME wait
 
     local volume_name=systemd-$(basename $quadlet_file .volume)
     run_podman volume ls
@@ -415,7 +415,7 @@ EOF
 
     run_quadlet "$quadlet_file"
 
-    service_setup $QUADLET_SERVICE_NAME
+    service_setup $QUADLET_SERVICE_NAME wait
 
     local volume_name=systemd-$(basename $quadlet_file .volume)
     run_podman volume ls
@@ -468,10 +468,10 @@ EOF
     # Start the container service which should also trigger the start of the volume service
     service_setup $container_service
 
-    # Volume system unit should be active
+    # Volume system unit should be inactive (oneshot)
     run systemctl show --property=ActiveState "$vol_service"
-    assert "$output" = "ActiveState=active" \
-           "volume should be active via dependency"
+    assert "$output" = "ActiveState=inactive" \
+           "volume should be inactive via dependency"
 
     # Volume should exist
     run_podman volume exists ${volume_name}
@@ -552,10 +552,10 @@ EOF
     SERVICES_TO_STOP+=("$vol_service_instance")
     SERVICES_TO_STOP+=("$net_service_instance")
 
-    # Volume system unit instance should be active
+    # Volume system unit instance should be inactive (oneshot)
     run systemctl show --property=ActiveState "$vol_service_instance"
-    assert "$output" = "ActiveState=active" \
-           "volume template instance should be active via dependency"
+    assert "$output" = "ActiveState=inactive" \
+           "volume template instance should be inactive via dependency"
 
     # Network system unit instance should be active
     run systemctl show --property=ActiveState "$net_service_instance"
@@ -614,9 +614,9 @@ EOF
     # Start the container service which should also trigger the start of the volume service
     service_setup $container_service
 
-    # Volume system unit should be active
+    # Volume system unit should be inactive (oneshot)
     run systemctl show --property=ActiveState "$vol_service"
-    assert "$output" = "ActiveState=active" "volume should be active via dependency"
+    assert "$output" = "ActiveState=inactive" "volume should be inactive via dependency"
 
     # Volume should exist
     run_podman volume exists ${volume_name}
@@ -1466,10 +1466,10 @@ EOF
     assert "$output" = "ActiveState=active" \
            "quadlet - image files: image should be active via dependency but is not"
 
-    # Volume system unit should be active
+    # Volume system unit should be inactive (oneshot)
     run systemctl show --property=ActiveState "$volume_service"
-    assert "$output" = "ActiveState=active" \
-           "quadlet - image files: volume should be active via dependency but is not"
+    assert "$output" = "ActiveState=inactive" \
+           "quadlet - image files: volume should be inactive via dependency"
 
     # Image should exist
     run_podman image exists ${image_for_test}
@@ -1764,9 +1764,9 @@ EOF
     assert "$output" = "ActiveState=active" \
            "quadlet - image tag: image service ActiveState"
 
-    # Volume system unit should be active
+    # Volume system unit should be inactive (oneshot)
     run systemctl show --property=ActiveState "$volume_service"
-    assert "$output" = "ActiveState=active" \
+    assert "$output" = "ActiveState=inactive" \
            "quadlet - image tag: volume service ActiveState"
 
     # Image should exist


### PR DESCRIPTION
fixes #27862

### Summary
Quadlet previously set `RemainAfterExit=yes` by default when converting `.volume` unit files into systemd oneshot services. 

Because `RemainAfterExit=yes` keeps the service unit in the `active (exited)` state, if a volume is deleted (e.g. to update volume options) and a dependent container service is restarted, systemd skips re-executing the volume service since it is already marked active.

### Changes
- Updated `ConvertVolume()` in `pkg/systemd/quadlet/quadlet.go` to pass `false` for `remainAfterExit`.
- Updated Quadlet test fixture assertion in `test/e2e/quadlet/basic.volume`.

### Checklist
- [x] Code is signed off (`git commit -s`)
- [x] Tests pass / modified test updated
