### PR TITLE
CI: run logformatter on the windows jobs again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
         provider: [hyperv, wsl]
     env:
       PROVIDER: ${{ matrix.provider }}
+      PODMAN_CI: 1
     steps:
       - name: Configure git line endings
         shell: pwsh
@@ -498,6 +499,8 @@ jobs:
     runs-on: windows-2025-vs2026
     timeout-minutes: 20
     permissions: {}
+    env:
+      PODMAN_CI: 1
     steps:
       - name: Configure git line endings
         shell: pwsh
@@ -531,6 +534,8 @@ jobs:
     name: windows e2e
     runs-on: windows-2025-vs2026
     timeout-minutes: 20
+    env:
+      PODMAN_CI: 1
     steps:
       - name: Configure git line endings
         shell: pwsh
@@ -577,6 +582,7 @@ jobs:
         provider: [hyperv, wsl]
     env:
       CONTAINERS_MACHINE_PROVIDER: ${{ matrix.provider }}
+      PODMAN_CI: 1
     steps:
       - name: Configure git line endings
         shell: pwsh

--- a/hack/ci/win-lib.ps1
+++ b/hack/ci/win-lib.ps1
@@ -101,7 +101,11 @@ function Run-Command {
 
     $exitCode = $LASTEXITCODE
 
-    if ($Env:CIRRUS_CI -eq "true") {
+    # Only our own CI has perl and the logformatter script available, and only
+    # there is the HTML log worth generating. PODMAN_CI is set by the workflow
+    # rather than read from GITHUB_ACTIONS, so a fork running winmake.ps1 in
+    # its own workflow does not get this.
+    if ($Env:PODMAN_CI) {
         Invoke-Logformatter $unformattedLog
     }
 


### PR DESCRIPTION
.cirrus.yml was the only thing setting CIRRUS_CI and it went away with 3743b9f806 ("Goodbye Cirrus"). Run-Command in hack/ci/win-lib.ps1 still checks for it before calling Invoke-Logformatter, so on the windows jobs that call just never happens and we get the raw ginkgo output with no html log at all.

winmake.ps1 sources that file and ci.yml calls winmake in four jobs, so this is windows installer, unit, e2e and machine.

I went with a PODMAN_CI set from the workflow instead of checking GITHUB_ACTIONS. GITHUB_ACTIONS is true for anyone running our tests out of their own workflow in a fork and they won't necessarily have perl, saw the same point come up on #29301. The github hosted windows-2025 image ships perl 5.42 so our own jobs are fine.

This only turns the call back on, I didn't touch logformatter itself. #29091 is doing that side for linux and doesn't touch win-lib.ps1, so I don't think these conflict. Happy to rebase if that one lands first.

One thing I left alone on purpose: lines 35-39 of the same file still Remove-Item CIRRUS_COMMIT_MESSAGE / CIRRUS_CHANGE_MESSAGE / CIRRUS_PR_BODY, which are also dead now. That felt like mixing cleanup into a behaviour fix so I skipped it.

I can't run the windows jobs locally, so I'm leaning on CI here to confirm the html log actually turns up.