### PR TITLE
farm: handle tagged --tag references on build

### DIFF
--- a/docs/source/markdown/podman-farm-build.1.md.in
+++ b/docs/source/markdown/podman-farm-build.1.md.in
@@ -151,7 +151,7 @@ This option specifies the name of the farm to be used in the build process.
 
 #### **--local**, **-l**
 
-Build image on local machine as well as on farm nodes.
+Build image on local machine as well as on farm nodes (Default: true).
 
 @@option logfile
 

--- a/pkg/farm/farm.go
+++ b/pkg/farm/farm.go
@@ -272,7 +272,10 @@ func (f *Farm) Build(ctx context.Context, schedule Schedule, options entities.Bu
 		authfile:      options.Authfile,
 		skipTLSVerify: options.SkipTLSVerify,
 	}
-	manifestListBuilder := newManifestListBuilder(reference, f.localEngine, listBuilderOptions)
+	manifestListBuilder, err := newManifestListBuilder(reference, f.localEngine, listBuilderOptions)
+	if err != nil {
+		return fmt.Errorf("failed to create manifest list %q: %w", reference, err)
+	}
 
 	// Start builds in parallel and wait for them all to finish.
 	var (

--- a/pkg/farm/list_builder.go
+++ b/pkg/farm/list_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/image/v5/docker"
+	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 )
@@ -22,19 +23,34 @@ type listBuilderOptions struct {
 }
 
 type listLocal struct {
-	listName    string
+	listRef     reference.Named
 	localEngine entities.ImageEngine
 	options     listBuilderOptions
 }
 
+// untaggedImageRef returns the destination reference without a tag, e.g. "quay.io/example/repo".
+func (l *listLocal) untaggedImageRef() string {
+	return l.listRef.Name()
+}
+
+// taggedImageRef returns the full reference, e.g. "quay.io/example/repo:tag".
+func (l *listLocal) taggedImageRef() string {
+	return l.listRef.String()
+}
+
 // newManifestListBuilder returns a manifest list builder which saves a
-// manifest list and images to local storage.
-func newManifestListBuilder(listName string, localEngine entities.ImageEngine, options listBuilderOptions) *listLocal {
+// manifest list and images to local storage. Returns an error if listName
+// is not a valid image reference.
+func newManifestListBuilder(listName string, localEngine entities.ImageEngine, options listBuilderOptions) (*listLocal, error) {
+	ref, err := reference.ParseNamed(listName)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse reference %q: %w", listName, err)
+	}
 	return &listLocal{
-		listName:    listName,
+		listRef:     ref,
 		options:     options,
 		localEngine: localEngine,
-	}
+	}, nil
 }
 
 // Build retrieves images from the build reports and assembles them into a
@@ -46,15 +62,15 @@ func (l *listLocal) build(ctx context.Context, images map[entities.BuildReport]e
 		skipTLSVerify = types.NewOptionalBool(*l.options.skipTLSVerify)
 	}
 
-	exists, err := l.localEngine.ManifestExists(ctx, l.listName)
+	exists, err := l.localEngine.ManifestExists(ctx, l.taggedImageRef())
 	if err != nil {
 		return "", err
 	}
 	// Create list if it doesn't exist
 	if !exists.Value {
-		_, err = l.localEngine.ManifestCreate(ctx, l.listName, []string{}, entities.ManifestCreateOptions{SkipTLSVerify: skipTLSVerify})
+		_, err = l.localEngine.ManifestCreate(ctx, l.taggedImageRef(), []string{}, entities.ManifestCreateOptions{SkipTLSVerify: skipTLSVerify})
 		if err != nil {
-			return "", fmt.Errorf("creating manifest list %q: %w", l.listName, err)
+			return "", fmt.Errorf("creating manifest list %q: %w", l.taggedImageRef(), err)
 		}
 	}
 
@@ -69,13 +85,13 @@ func (l *listLocal) build(ctx context.Context, images map[entities.BuildReport]e
 			logrus.Infof("pushing image %s", image.ID)
 			defer logrus.Infof("pushed image %s", image.ID)
 			// Push the image to the registry
-			report, err := engine.Push(ctx, image.ID, l.listName+docker.UnknownDigestSuffix, entities.ImagePushOptions{Authfile: l.options.authfile, Quiet: false, SkipTLSVerify: skipTLSVerify})
+			report, err := engine.Push(ctx, image.ID, l.untaggedImageRef()+docker.UnknownDigestSuffix, entities.ImagePushOptions{Authfile: l.options.authfile, Quiet: false, SkipTLSVerify: skipTLSVerify})
 			if err != nil {
 				return fmt.Errorf("pushing image %q to registry: %w", image, err)
 			}
 			refsMutex.Lock()
 			defer refsMutex.Unlock()
-			refs = append(refs, "docker://"+l.listName+"@"+report.ManifestDigest)
+			refs = append(refs, "docker://"+l.untaggedImageRef()+"@"+report.ManifestDigest)
 			return nil
 		})
 	}
@@ -109,18 +125,18 @@ func (l *listLocal) build(ctx context.Context, images map[entities.BuildReport]e
 
 	// Clear the list in the event it already existed
 	if exists.Value {
-		_, err = l.localEngine.ManifestListClear(ctx, l.listName)
+		_, err = l.localEngine.ManifestListClear(ctx, l.taggedImageRef())
 		if err != nil {
-			return "", fmt.Errorf("error clearing list %q", l.listName)
+			return "", fmt.Errorf("error clearing list %q: %w", l.taggedImageRef(), err)
 		}
 	}
 
 	// Add the images to the list
-	listID, err := l.localEngine.ManifestAdd(ctx, l.listName, refs, entities.ManifestAddOptions{Authfile: l.options.authfile, SkipTLSVerify: skipTLSVerify})
+	listID, err := l.localEngine.ManifestAdd(ctx, l.taggedImageRef(), refs, entities.ManifestAddOptions{Authfile: l.options.authfile, SkipTLSVerify: skipTLSVerify})
 	if err != nil {
 		return "", fmt.Errorf("adding images %q to list: %w", refs, err)
 	}
-	_, err = l.localEngine.ManifestPush(ctx, l.listName, l.listName, entities.ImagePushOptions{Authfile: l.options.authfile, SkipTLSVerify: skipTLSVerify})
+	_, err = l.localEngine.ManifestPush(ctx, l.taggedImageRef(), l.taggedImageRef(), entities.ImagePushOptions{Authfile: l.options.authfile, SkipTLSVerify: skipTLSVerify})
 	if err != nil {
 		return "", err
 	}
@@ -137,5 +153,5 @@ func (l *listLocal) build(ctx context.Context, images map[entities.BuildReport]e
 		}
 	}
 
-	return l.listName, nil
+	return l.taggedImageRef(), nil
 }

--- a/test/farm/001-farm.bats
+++ b/test/farm/001-farm.bats
@@ -8,7 +8,7 @@ load helpers.bash
 @test "farm - check farm has been created" {
     run_podman farm ls
     assert "$output" =~ $FARMNAME
-    assert "$output" =~ "test-node"
+    assert "$output" =~ ${CONNECTION_NAME}
 }
 
 @test "farm - build on local only" {
@@ -112,22 +112,44 @@ EOF
     run_podman image prune -f
 }
 
+# https://github.com/containers/podman/issues/25039
+@test "farm - build with a tagged reference" {
+    iname="test-image-6"
+    tag="mytag"
+    run_podman farm build --authfile $AUTHFILE --tls-verify=false -t $REGISTRY/$iname:$tag $FARM_TMPDIR
+    assert "$output" =~ "Farm \"$FARMNAME\" ready"
+
+    run_podman info --format '{{.Host.Arch}}'
+    ARCH=$output
+    run_podman manifest inspect $iname:$tag
+    assert "$output" =~ $ARCH
+
+    echo "# skopeo inspect ..."
+    run skopeo inspect "$@" --tls-verify=false --authfile $AUTHFILE docker://$REGISTRY/$iname:$tag
+    echo "$output"
+    is "$status" "0" "skopeo inspect - exit status"
+
+    run_podman manifest rm $iname:$tag
+    run_podman image prune -f
+}
+
 # Test out podman-remote
 
 @test "farm - build on farm node only (podman-remote)" {
     iname="test-image-5"
     # ManifestAdd only
     echo "Running test with ManifestAdd only..."
-    run_podman --remote farm build --authfile $AUTHFILE --tls-verify=false -t $REGISTRY/$iname $FARM_TMPDIR
+    # Now uses a explicit --connection, rather than relying on the default.
+    run_podman --remote --connection=${CONNECTION_NAME} farm build --authfile $AUTHFILE --tls-verify=false -t $REGISTRY/$iname $FARM_TMPDIR
     assert "$output" =~ "Farm \"$FARMNAME\" ready"
 
     # ManifestListClear and ManifestAdd
     echo "Running test with ManifestListClear and ManifestAdd..."
-    run_podman --remote farm build --authfile $AUTHFILE --tls-verify=false -t $REGISTRY/$iname $FARM_TMPDIR
+    run_podman --remote --connection=${CONNECTION_NAME} farm build --authfile $AUTHFILE --tls-verify=false -t $REGISTRY/$iname $FARM_TMPDIR
     assert "$output" =~ "Farm \"$FARMNAME\" ready"
 
     # get the system architecture
-    run_podman --remote info --format '{{.Host.Arch}}'
+    run_podman --remote --connection=${CONNECTION_NAME} info --format '{{.Host.Arch}}'
     ARCH=$output
     # inspect manifest list built and saved
     run_podman manifest inspect $iname

--- a/test/farm/setup_suite.bash
+++ b/test/farm/setup_suite.bash
@@ -31,10 +31,11 @@ function setup_suite(){
     type -P podman || die "No 'podman' in \$PATH"
 
     export FARMNAME="test-farm-$(random_string 5)"
+    export CONNECTION_NAME="test-conn-$(random_string 5)"
 
     # only set up the podman farm before the first test
-    run_podman system connection add --identity $sshkey test-node $ROOTLESS_USER@localhost
-    run_podman farm create $FARMNAME test-node
+    run_podman system connection add --identity $sshkey ${CONNECTION_NAME} $ROOTLESS_USER@localhost
+    run_podman farm create $FARMNAME ${CONNECTION_NAME}
 
     export PODMAN_LOGIN_WORKDIR=$(mktemp -d --tmpdir=${BATS_TMPDIR:-${TMPDIR:-/tmp}} podman-bats-registry.XXXXXX)
 
@@ -60,4 +61,7 @@ function teardown_suite(){
     # clear out the farms after the last farm test
     run_podman farm rm --all
     stop_registry
+
+    # ...and the connection
+    run_podman system connection rm ${CONNECTION_NAME}
 }


### PR DESCRIPTION
podman farm build pushes each per-arch image to the registry by appending `UnknownDigestSuffix` to the image specified using --tag. This fails because a tag is not expected when UnknownDigestSuffix is used. Parse the image reference and pass only the untagged image reference when podman does this suffixed push to the registry.

Fixes #25039

This continues the work from https://github.com/podman-container-tools/podman/pull/27088

@Firstyear

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
