### PR TITLE
test/e2e: accept RESTORE in checkpoint tcp error match

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -368,6 +368,10 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman restore container with tcp-close", func() {
+		if podmanTest.OCIRuntime != "crun" {
+			Skip("tcp-close only implemented for crun")
+		}
+
 		// Start a container with redis (which listens on tcp port)
 		localRunString := getRunString([]string{REDIS_IMAGE})
 		session := podmanTest.PodmanExitCleanly(localRunString...)
@@ -396,9 +400,6 @@ var _ = Describe("Podman checkpoint", func() {
 		// Some older versions print "CRIU restoring failed: -52" while others
 		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
 		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
-		if podmanTest.OCIRuntime == "runc" {
-			expectStderr = "runc: criu failed: type (NOTIFY|RESTORE) errno 0"
-		}
 		Expect(result).Should(ExitWithErrorRegex(125, expectStderr))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -353,7 +353,7 @@ var _ = Describe("Podman checkpoint", func() {
 		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
 		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
 		if podmanTest.OCIRuntime == "runc" {
-			expectStderr = "runc: criu failed: type NOTIFY errno 0"
+			expectStderr = "runc: criu failed: type (NOTIFY|RESTORE) errno 0"
 		}
 		Expect(result).Should(ExitWithErrorRegex(125, expectStderr))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
@@ -397,7 +397,7 @@ var _ = Describe("Podman checkpoint", func() {
 		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
 		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
 		if podmanTest.OCIRuntime == "runc" {
-			expectStderr = "runc: criu failed: type NOTIFY errno 0"
+			expectStderr = "runc: criu failed: type (NOTIFY|RESTORE) errno 0"
 		}
 		Expect(result).Should(ExitWithErrorRegex(125, expectStderr))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))


### PR DESCRIPTION
Both the tcp-established and tcp-close checkpoint/restore tests expect a restore rejected due to an established TCP connection to fail with "runc: criu failed: type NOTIFY errno 0". criu's RPC server actually reports this failure as type RESTORE, not NOTIFY. Widen the regex in both tests to accept RESTORE while still tolerating NOTIFY.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
