### PR TITLE
cmd/quadlet: use filepath instead of path package for host paths

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -106,7 +105,7 @@ func loadUnitsFromDir(sourcePath string) ([]*parser.UnitFile, error) {
 	for _, file := range files {
 		name := file.Name()
 		if _, ok := seen[name]; !ok && quadlet.IsExtSupported(name) {
-			path := path.Join(sourcePath, name)
+			path := filepath.Join(sourcePath, name)
 
 			Debugf("Loading source unit file %s", path)
 
@@ -140,7 +139,7 @@ func loadUnitDropins(unit *parser.UnitFile, sourcePaths []string) error {
 	dropinDirs := make([]string, 0, len(unitDropinPaths))
 	for _, dropinPath := range unitDropinPaths {
 		for _, sourcePath := range sourcePaths {
-			dropinDirs = append(dropinDirs, path.Join(sourcePath, dropinPath))
+			dropinDirs = append(dropinDirs, filepath.Join(sourcePath, dropinPath))
 		}
 	}
 
@@ -165,7 +164,7 @@ func loadUnitDropins(unit *parser.UnitFile, sourcePaths []string) error {
 				continue // We already saw this name
 			}
 
-			dropinPaths[dropinName] = path.Join(dropinDir, dropinName)
+			dropinPaths[dropinName] = filepath.Join(dropinDir, dropinName)
 		}
 	}
 
@@ -264,14 +263,14 @@ func enableServiceFile(outputPath string, service *parser.UnitFile) {
 	}
 
 	for _, symlinkRel := range symlinks {
-		target, err := filepath.Rel(path.Dir(symlinkRel), service.Filename)
+		target, err := filepath.Rel(filepath.Dir(symlinkRel), service.Filename)
 		if err != nil {
 			Logf("Can't create symlink %s: %s", symlinkRel, err)
 			continue
 		}
-		symlinkPath := path.Join(outputPath, symlinkRel)
+		symlinkPath := filepath.Join(outputPath, symlinkRel)
 
-		symlinkDir := path.Dir(symlinkPath)
+		symlinkDir := filepath.Dir(symlinkPath)
 		err = os.MkdirAll(symlinkDir, os.ModePerm)
 		if err != nil {
 			Logf("Can't create dir %s: %s", symlinkDir, err)
@@ -441,7 +440,7 @@ func main() {
 func process() bool {
 	var processErred bool
 
-	prgname := path.Base(os.Args[0])
+	prgname := filepath.Base(os.Args[0])
 	isUserFlag = strings.Contains(prgname, "user")
 
 	flag.Parse()
@@ -567,7 +566,7 @@ func process() bool {
 			continue
 		}
 
-		service.Path = path.Join(outputPath, service.Filename)
+		service.Path = filepath.Join(outputPath, service.Filename)
 
 		if dryRunFlag {
 			data, err := service.ToString()


### PR DESCRIPTION
Replace path package functions (path.Base, path.Join, path.Dir) with filepath equivalents in cmd/quadlet/main.go.

path package functions only recognize POSIX forward slashes as separators and break when handling Windows host filesystem paths (such as os.Args[0] or Windows directory paths).

Related to: #25165

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

Replaces the use of the standard `path` package (`path.Base`, `path.Join`, `path.Dir`) with `path/filepath` in `cmd/quadlet/main.go`.
The `path` package only recognizes `/` (POSIX separator) and does not handle Windows backslash separators properly when manipulating host filesystem paths such as `os.Args[0]`, source paths, or output directories. Switching to `path/filepath` ensures cross-platform compatibility across operating systems.

Related to:  #25165

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
