### PR TITLE
machine/wsl: detect native systemd as running

### DIFF
--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -49,6 +49,15 @@ or type exit. This also means to log out you need to exit twice.
 
 const sysdpid = "SYSDPID=`ps -eo cmd,pid | grep -m 1 ^/lib/systemd/systemd | awk '{print $2}'`"
 
+const systemdRunning = `
+if [ "$(cat /proc/1/comm 2>/dev/null)" = "systemd" ]; then
+    echo 1
+else
+    ` + sysdpid + `
+    echo $SYSDPID
+fi
+`
+
 const profile = sysdpid + `
 if [ ! -z "$SYSDPID" ] && [ "$SYSDPID" != "1" ]; then
     cat /etc/wslmotd

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -520,7 +520,7 @@ func getAllWSLDistros(running bool) (map[string]struct{}, error) {
 
 func isSystemdRunning(dist string) (bool, error) {
 	cmd := wutil.NewWSLCommand("-u", "root", "-d", dist, "sh")
-	cmd.Stdin = strings.NewReader(sysdpid + "\necho $SYSDPID\n")
+	cmd.Stdin = strings.NewReader(systemdRunning)
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
This fixes the way we find systemd for Windows Subsystem for Linux distributions that use systemd.

Now we look for a systemd process that starts with /lib/systemd/systemd.. In my Windows Subsystem for Linux environment systemd is running as the main process and it uses /usr/lib/systemd/systemd. So the current way of checking does not. Podman might think systemd has stopped incorrectly.

This change first checks what process is running as the process. If it is not systemd it goes back to the way of checking. This means that the way it worked before still works.

I tried this out on Windows Subsystem for Linux. I saw that the old way of checking was not working.. When I checked what process was running as the main process I saw that it was systemd. I also tested the fix with go test. It worked fine.

* The change is for Windows Subsystem, for Linux

* It checks for systemd in a way

* The old way of checking still works if the new way does not find systemd

* I tested it. It works fine now

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

-[x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

Fix systemd detection for WSL distros with systemd as the PID 1 process. 

```
