### PR TITLE
libpod: fix PruneBuildContainers early return and size overflow

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1324,7 +1324,8 @@ func (r *Runtime) PruneBuildContainers() ([]*reports.PruneReport, error) {
 	for _, container := range containers {
 		path, err := r.store.ContainerDirectory(container.ID)
 		if err != nil {
-			return stageContainersPruneReports, err
+			logrus.Debugf("Failed to get container directory for %s, skipping: %v", container.ID, err)
+			continue
 		}
 		if err := fileutils.Exists(filepath.Join(path, "buildah.json")); err != nil {
 			continue
@@ -1336,8 +1337,9 @@ func (r *Runtime) PruneBuildContainers() ([]*reports.PruneReport, error) {
 		size, err := r.store.ContainerSize(container.ID)
 		if err != nil {
 			report.Err = err
+		} else {
+			report.Size = uint64(size)
 		}
-		report.Size = uint64(size)
 
 		if err := r.store.DeleteContainer(container.ID); err != nil {
 			report.Err = errors.Join(report.Err, err)


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `PruneBuildContainers()`:

### 1. Early return aborts entire pruning loop

`ContainerDirectory()` failure caused `return`, stopping the loop. One bad container prevented all remaining containers from being pruned.

**Fix**: Changed to `continue` so pruning proceeds past individual failures, matching the existing pattern for `fileutils.Exists()` on line 1329.

### 2. `report.Size` set to garbage on error

`report.Size = uint64(size)` ran unconditionally, even when `ContainerSize()` returned an error. A negative `int64` error value cast to `uint64` silently overflows to a very large number.

**Fix**: Only set `report.Size` when `ContainerSize()` succeeds.

## How was this tested?

- Verified the fix compiles: `GOOS=linux go build -tags containers_image_openpgp ./libpod/...`
- Verified `make binaries` succeeds
- Code review of the 3-line change

Signed-off-by: nishantbkl3345-ship-it <nishantbkl3345-ship-it@users.noreply.github.com>