### PR TITLE
quadlet: add Umask= key to set container umask without PodmanArgs

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -430,6 +430,7 @@ Valid options for `[Container]` are listed below:
 | Tmpfs=/work                          | --tmpfs /work                                        |
 | UIDMap=0:10000:10                    | --uidmap=0:10000:10                                  |
 | Ulimit=nofile=1000:10000             | --ulimit nofile=1000:10000                           |
+| Umask=0077                           | --umask 0077                                         |
 | Unmask=ALL                           | --security-opt unmask=ALL                            |
 | User=bin                             | --user bin                                           |
 | UserNS=keep-id:uid=200,gid=210       | --userns keep-id:uid=200,gid=210                     |
@@ -1030,6 +1031,12 @@ This key can be listed multiple times.
 Ulimit options. Sets the ulimits values inside of the container.
 
 This key can be listed multiple times.
+
+### `Umask=` (defaults to `0022`)
+
+Set the umask inside the container.
+
+This is equivalent to the Podman `--umask` option.
 
 ### `Unmask=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -187,6 +187,7 @@ const (
 	KeyUID                   = "UID"
 	KeyUIDMap                = "UIDMap"
 	KeyUlimit                = "Ulimit"
+	KeyUmask                 = "Umask"
 	KeyUnmask                = "Unmask"
 	KeyUser                  = "User"
 	KeyUserNS                = "UserNS"
@@ -337,6 +338,7 @@ var (
 				KeyTmpfs:                 true,
 				KeyUIDMap:                true,
 				KeyUlimit:                true,
+				KeyUmask:                 true,
 				KeyUnmask:                true,
 				KeyUser:                  true,
 				KeyUserNS:                true,
@@ -703,6 +705,7 @@ func ConvertContainer(container *parser.UnitFile, unitsInfoMap map[string]*UnitI
 		KeyRetry:       "--retry",
 		KeyRetryDelay:  "--retry-delay",
 		KeyImageVolume: "--image-volume",
+		KeyUmask:       "--umask",
 	}
 	lookupAndAddString(container, ContainerGroup, stringKeys, podman)
 

--- a/test/e2e/quadlet/umask.container
+++ b/test/e2e/quadlet/umask.container
@@ -1,0 +1,5 @@
+## assert-podman-args "--umask" "0077"
+
+[Container]
+Image=localhost/imagename
+Umask=0077

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -998,6 +998,7 @@ BOGUS=foo
 		Entry("sysctl.container", "sysctl.container"),
 		Entry("timezone.container", "timezone.container"),
 		Entry("ulimit.container", "ulimit.container"),
+		Entry("umask.container", "umask.container"),
 		Entry("unmask.container", "unmask.container"),
 		Entry("user.container", "user.container"),
 		Entry("userns.container", "userns.container"),


### PR DESCRIPTION
Fixes: #25278

Quadlet had no key for --umask, so the only way to set it was PodmanArgs=--umask=0077.

PodmanArgs is passed through unchecked, and the man page says it is not recommended. A typo there generates fine and fails at boot instead.

Umask= uses the existing stringKeys map, so a wrong key name is caught when the unit is generated.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Quadlet now supports the Umask= key in [Container] units.
```