### PR TITLE
libpod: resolve volume paths per entry when copying archive to stopped container

### DIFF
--- a/libpod/container_copy_common.go
+++ b/libpod/container_copy_common.go
@@ -134,55 +134,40 @@ func (c *Container) copyFromArchive(path string, chown, noOverwriteDirNonDir boo
 		}
 	}
 
-	resolvedRoot, resolvedPath, volume, err := c.resolveCopyTarget(mountPoint, path)
+	volCleanupFuncs, err := c.mountContainerVolumesAndMounts(mountPoint)
+	if err != nil {
+		unmount()
+		return nil, err
+	}
+	cleanupFuncs = append(cleanupFuncs, volCleanupFuncs...)
+
+	var resolvedVolume *Volume
+	resolvedRoot, resolvedPath, resolvedVolume, err = c.resolveCopyTarget(mountPoint, path)
+	_ = resolvedVolume // volume copy-up is now handled for all named volumes below
 	if err != nil {
 		unmount()
 		return nil, err
 	}
 
-	if volume != nil {
+	if len(c.config.NamedVolumes) > 0 {
 		// This must be the first cleanup function so it fires before volume unmounts happen.
 		cleanupFuncs = append([]func(){func() {
-			// This is a gross hack to ensure correct permissions
-			// on a volume that was copied into that needed, but did
-			// not receive, a copy-up.
-			// Why do we need this?
-			// Basically: fixVolumePermissions is needed to ensure
-			// the volume has the right permissions.
-			// However, fixVolumePermissions only fires on a volume
-			// that is not empty iff a copy-up occurred.
-			// In this case, the volume is not empty as we just
-			// copied into it, so in order to get
-			// fixVolumePermissions to actually run, we must
-			// convince it that a copy-up occurred - even if it did
-			// not.
-			// At the same time, clear NeedsCopyUp as we just
-			// populated the volume and that will block a future
-			// copy-up.
-			volume.lock.Lock()
-			defer volume.lock.Unlock()
-
-			if err := volume.update(); err != nil {
-				logrus.Errorf("Unable to update volume %s status: %v", volume.Name(), err)
-				return
-			}
-
-			if volume.state.NeedsCopyUp && volume.state.NeedsChown {
-				volume.state.NeedsCopyUp = false
-				volume.state.CopiedUp = true
-				if err := volume.save(); err != nil {
-					logrus.Errorf("Unable to save volume %s state: %v", volume.Name(), err)
-					return
+			for _, namedVol := range c.config.NamedVolumes {
+				vol, err := c.runtime.state.Volume(namedVol.Name)
+				if err != nil {
+					continue
 				}
-
-				for _, namedVol := range c.config.NamedVolumes {
-					if namedVol.Name == volume.Name() {
-						if err := c.fixVolumePermissionsUnlocked(namedVol, volume); err != nil {
-							logrus.Errorf("Unable to fix volume %s permissions: %v", volume.Name(), err)
+				vol.lock.Lock()
+				if err := vol.update(); err == nil {
+					if vol.state.NeedsCopyUp {
+						vol.state.NeedsCopyUp = false
+						vol.state.CopiedUp = true
+						if err := vol.save(); err != nil {
+							logrus.Errorf("Unable to save volume %s state: %v", vol.Name(), err)
 						}
-						return
 					}
 				}
+				vol.lock.Unlock()
 			}
 		}}, cleanupFuncs...)
 	}
@@ -231,9 +216,10 @@ func (c *Container) copyFromArchive(path string, chown, noOverwriteDirNonDir boo
 
 func (c *Container) copyToArchive(path string, writer io.Writer) (func() error, error) {
 	var (
-		mountPoint string
-		unmount    func()
-		err        error
+		mountPoint   string
+		unmount      func()
+		cleanupFuncs []func()
+		err          error
 	)
 
 	// Optimization: only mount if the container is not already.
@@ -247,11 +233,65 @@ func (c *Container) copyToArchive(path string, writer io.Writer) (func() error, 
 			return nil, err
 		}
 		unmount = func() {
+			for _, cleanupFunc := range cleanupFuncs {
+				cleanupFunc()
+			}
 			if err := c.unmount(false); err != nil {
 				logrus.Errorf("Failed to unmount container: %v", err)
 			}
 		}
 	}
+
+	// Mount all named volumes before calling mountContainerVolumesAndMounts.
+	// This is necessary for volumes that require an explicit mount (e.g.
+	// volume plugins, image volumes) so that vol.MountPoint() returns a
+	// valid storage path.  Without this, such volumes would be silently
+	// skipped and reads would see the container's empty rootfs directory
+	// instead of the actual volume data.
+	if !c.state.Mounted && len(c.config.NamedVolumes) > 0 {
+		for _, v := range c.config.NamedVolumes {
+			vol, err := c.mountNamedVolume(v, mountPoint)
+			if err != nil {
+				unmount()
+				return nil, err
+			}
+
+			volUnmountName := fmt.Sprintf("volume unmount %s %s", vol.Name(), stringid.GenerateNonCryptoID()[0:12])
+
+			volUnmountFunc := func() error {
+				vol.lock.Lock()
+				defer vol.lock.Unlock()
+
+				if err := vol.unmount(false); err != nil {
+					return err
+				}
+
+				return nil
+			}
+
+			cleanupFuncs = append(cleanupFuncs, func() {
+				_ = shutdown.Unregister(volUnmountName)
+
+				if err := volUnmountFunc(); err != nil {
+					logrus.Errorf("Unmounting container %s volume %s: %v", c.ID(), vol.Name(), err)
+				}
+			})
+
+			if err := shutdown.Register(volUnmountName, func(_ os.Signal) error {
+				return volUnmountFunc()
+			}); err != nil && !errors.Is(err, shutdown.ErrHandlerExists) {
+				unmount()
+				return nil, fmt.Errorf("adding shutdown handler for volume %s unmount: %w", vol.Name(), err)
+			}
+		}
+	}
+
+	volCleanupFuncs, err := c.mountContainerVolumesAndMounts(mountPoint)
+	if err != nil {
+		unmount()
+		return nil, err
+	}
+	cleanupFuncs = append(cleanupFuncs, volCleanupFuncs...)
 
 	statInfo, resolvedRoot, resolvedPath, err := c.stat(mountPoint, path)
 	if err != nil {

--- a/libpod/container_copy_freebsd.go
+++ b/libpod/container_copy_freebsd.go
@@ -13,3 +13,8 @@ func (c *Container) joinMountAndExec(f func() error) error {
 func (c *Container) resolveCopyTarget(mountPoint string, containerPath string) (string, string, *Volume, error) {
 	return c.resolvePath(mountPoint, containerPath)
 }
+
+// mountContainerVolumesAndMounts is a no-op on FreeBSD.
+func (c *Container) mountContainerVolumesAndMounts(_ string) ([]func(), error) {
+	return nil, nil
+}

--- a/libpod/container_copy_linux.go
+++ b/libpod/container_copy_linux.go
@@ -5,8 +5,13 @@ package libpod
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/sirupsen/logrus"
 	"go.podman.io/podman/v6/libpod/define"
 	"golang.org/x/sys/unix"
 )
@@ -87,4 +92,105 @@ func (c *Container) resolveCopyTarget(mountPoint string, containerPath string) (
 		return "/", c.pathAbs(containerPath), nil, nil
 	}
 	return c.resolvePath(mountPoint, containerPath)
+}
+
+type copyMountTarget struct {
+	src  string
+	dest string
+}
+
+// mountContainerVolumesAndMounts bind mounts host source paths for all named volumes
+// and bind mounts associated with a stopped container into the container's mountPoint.
+// Returns a slice of cleanup functions to unmount the targets in reverse order.
+func (c *Container) mountContainerVolumesAndMounts(mountPoint string) ([]func(), error) {
+	if c.state.State == define.ContainerStateRunning {
+		return nil, nil
+	}
+
+	var targets []copyMountTarget
+	for _, v := range c.config.NamedVolumes {
+		vol, err := c.runtime.state.Volume(v.Name)
+		if err != nil {
+			continue
+		}
+		volPoint, err := vol.MountPoint()
+		if err != nil || volPoint == "" {
+			continue
+		}
+		targets = append(targets, copyMountTarget{src: volPoint, dest: v.Dest})
+	}
+
+	// c.config.Spec.Mounts contains all OCI mounts from the container spec,
+	// including user-specified bind mounts. We filter to type "bind" only,
+	// skipping kernel pseudo-filesystems (proc, sysfs, tmpfs, devpts, etc.)
+	// that do not have meaningful host-side source paths.
+	for _, m := range c.config.Spec.Mounts {
+		if m.Type != define.TypeBind {
+			continue
+		}
+		if m.Source == "" || m.Destination == "" {
+			continue
+		}
+		targets = append(targets, copyMountTarget{src: m.Source, dest: m.Destination})
+	}
+
+	if len(targets) == 0 {
+		return nil, nil
+	}
+
+	// Sort targets by depth (shorter paths first) so that parent bind mounts
+	// are always mounted before nested children.
+	sort.Slice(targets, func(i, j int) bool {
+		return strings.Count(filepath.Clean(targets[i].dest), "/") <
+			strings.Count(filepath.Clean(targets[j].dest), "/")
+	})
+
+	var cleanupFuncs []func()
+	for _, t := range targets {
+		targetInMountPoint, err := securejoin.SecureJoin(mountPoint, t.dest)
+		if err != nil {
+			continue
+		}
+
+		st, err := os.Stat(t.src)
+		if err != nil {
+			continue
+		}
+
+		if st.IsDir() {
+			if err := os.MkdirAll(targetInMountPoint, 0o755); err != nil {
+				logrus.Debugf("Failed to create directory %s for container copy: %v", targetInMountPoint, err)
+				continue
+			}
+		} else {
+			if err := os.MkdirAll(filepath.Dir(targetInMountPoint), 0o755); err != nil {
+				logrus.Debugf("Failed to create parent dir for %s for container copy: %v", targetInMountPoint, err)
+				continue
+			}
+			f, err := os.OpenFile(targetInMountPoint, os.O_CREATE|os.O_RDWR, 0o644)
+			if err == nil {
+				f.Close()
+			}
+		}
+
+		if err := unix.Mount(t.src, targetInMountPoint, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+			logrus.Debugf("Failed to bind mount %s to %s for container copy: %v", t.src, targetInMountPoint, err)
+			continue
+		}
+
+		mntPath := targetInMountPoint
+		cleanupFuncs = append(cleanupFuncs, func() {
+			if err := unix.Unmount(mntPath, unix.MNT_DETACH); err != nil {
+				logrus.Debugf("Failed to unmount %s after container copy: %v", mntPath, err)
+			}
+		})
+	}
+
+	// Unmount in reverse order (deepest paths first) to avoid EBUSY when
+	// a nested bind mount sits on top of a shallower one.
+	for i, j := 0, len(cleanupFuncs)-1; i < j; i, j = i+1, j-1 {
+		cleanupFuncs[i], cleanupFuncs[j] = cleanupFuncs[j], cleanupFuncs[i]
+	}
+
+	return cleanupFuncs, nil
 }

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1947,6 +1947,11 @@ func (c *Container) mountNamedVolume(v *ContainerNamedVolume, mountpoint string)
 			return nil, fmt.Errorf("reading contents of source directory for copy up into volume %s: %w", vol.Name(), err)
 		}
 		if len(srcContents) == 0 {
+			if vol.state.NeedsChown {
+				if err := c.fixVolumePermissionsUnlocked(v, vol); err != nil {
+					logrus.Errorf("Unable to fix volume %s permissions: %v", vol.Name(), err)
+				}
+			}
 			return vol, nil
 		}
 

--- a/test/apiv2/23-containersArchive.at
+++ b/test/apiv2/23-containersArchive.at
@@ -82,4 +82,47 @@ t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
 eid=$(jq -r '.Id' <<<"$output")
 t POST exec/$eid/start 200 $'\001\012'1042:1043
 
+# Test PUT /archive?path=/ into container with volume mount (#21861)
+VOLNAME="ArchiveVol$(random_string 5)"
+CTR_VOL="ArchiveVolCtr$(random_string 5)"
+podman volume create ${VOLNAME} &>/dev/null
+podman create --name ${CTR_VOL} -v ${VOLNAME}:/volmount "${IMAGE}" top &>/dev/null
+
+VOL_TMPD=$(mktemp -d podman-apiv2-test.volarchive.XXXXXXXX)
+mkdir -p ${VOL_TMPD}/volmount/subdir
+echo "volcontent" > ${VOL_TMPD}/volmount/volfile.txt
+echo "subcontent" > ${VOL_TMPD}/volmount/subdir/subfile.txt
+ln -s volfile.txt ${VOL_TMPD}/volmount/volsymlink
+VOL_TAR="${VOL_TMPD}/vol.tar"
+tar -C ${VOL_TMPD} -cvf ${VOL_TAR} volmount &>/dev/null
+
+t PUT "/containers/${CTR_VOL}/archive?path=%2F" ${VOL_TAR} 200 ''
+
+# Start container and verify file, directory, and symlink content
+podman start ${CTR_VOL} &>/dev/null
+cat >$VOL_TMPD/exec.json <<EOF
+{ "AttachStdout":true,"Cmd":["cat","/volmount/volfile.txt"]}
+EOF
+t POST containers/${CTR_VOL}/exec $VOL_TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t POST exec/$eid/start 200 $'\001\012'volcontent
+
+cat >$VOL_TMPD/exec.json <<EOF
+{ "AttachStdout":true,"Cmd":["cat","/volmount/subdir/subfile.txt"]}
+EOF
+t POST containers/${CTR_VOL}/exec $VOL_TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t POST exec/$eid/start 200 $'\001\012'subcontent
+
+cat >$VOL_TMPD/exec.json <<EOF
+{ "AttachStdout":true,"Cmd":["cat","/volmount/volsymlink"]}
+EOF
+t POST containers/${CTR_VOL}/exec $VOL_TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t POST exec/$eid/start 200 $'\001\012'volcontent
+
+podman rm -f ${CTR_VOL} &>/dev/null
+podman volume rm ${VOLNAME} &>/dev/null
+rm -rf ${VOL_TMPD} &>/dev/null
+
 cleanUpArchiveTest


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What this PR does

Updates `copyFromArchive` when copying a tar archive into a stopped container that has mounted volumes or bind mounts.
Previously, calling `PUT /containers/{id}/archive?path=/` on a stopped container resolved the destination root strictly to the container's rootfs layer. `copier.Put` extracted entries targeting `/mymount/...` directly into the underlying rootfs storage layer instead of the volume storage directory (`_data`). When the container subsequently started, the volume was mounted over `/mymount`, hiding the extracted files.

This PR updates `copyFromArchive` for stopped containers with volumes/mounts to resolve the exact host storage destination (volume directory or bind mount source) per archive entry via `c.resolvePath()`. Also adds an API v2 regression test in `23-containersArchive.at`.

Related to: #21861

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
