### PR TITLE
docs: Build Volume= only supports host directories

### DIFF
--- a/docs/source/markdown/options/volume.image.md
+++ b/docs/source/markdown/options/volume.image.md
@@ -9,12 +9,13 @@
 << endif >>
 
 Mount a host directory into containers when executing RUN instructions during
-the build.
+the build. Unlike container and pod mounts, only a host directory is supported
+here — named volumes and `.volume` Quadlet units are not accepted by
+`podman build`.
 
 << if is_quadlet >>
-Special case:
-
-* If `SOURCE-VOLUME` ends with `.volume`, Quadlet will look for the corresponding `.volume` Quadlet unit. If found, Quadlet will use the name of the Volume set in the Unit, otherwise, `systemd-$name` is used. The generated systemd service contains a dependency on the service unit generated for that `.volume` unit, or on `$name-volume.service` if the `.volume` unit is not found. Note: the corresponding `.volume` file must exist.
+If `HOST-DIR` starts with `.`, Quadlet resolves the path relative to the
+location of the unit file.
 << endif >>
 
 The `OPTIONS` are a comma-separated list and can be one or more of:

--- a/docs/source/markdown/podman-build.unit.5.md.in
+++ b/docs/source/markdown/podman-build.unit.5.md.in
@@ -136,7 +136,7 @@ also been provided.
 
 @@option quadlet:variant.build
 
-@@option quadlet:volume
+@@option quadlet:volume.image
 
 
 # EXAMPLES

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -2068,15 +2068,14 @@ This is equivalent to the `--variant` option of `podman build`.
 
 ### `Volume=`
 
-Mount a volume to containers when executing RUN instructions during the build. This is equivalent to
-the `--volume` option of `podman build`, and generally has the form
-`[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]`.
+Mount a host directory into containers when executing RUN instructions during
+the build. This is equivalent to the `--volume` option of `podman build`, and
+has the form `[HOST-DIR:]CONTAINER-DIR[:OPTIONS]`.
 
-If `SOURCE-VOLUME` starts with `.`, Quadlet resolves the path relative to the location of the unit file.
-
-Special case:
-
-* If `SOURCE-VOLUME` ends with `.volume`, Quadlet will look for the corresponding `.volume` Quadlet unit. If found, Quadlet will use the name of the Volume set in the Unit, otherwise, `systemd-$name` is used. The generated systemd service contains a dependency on the service unit generated for that `.volume` unit, or on `$name-volume.service` if the `.volume` unit is not found. Note: the corresponding `.volume` file must exist.
+Unlike container and pod mounts, only a host directory is supported here —
+named volumes and `.volume` Quadlet units are not accepted by `podman build`.
+`HOST-DIR` and `CONTAINER-DIR` must be absolute paths. If `HOST-DIR` starts
+with `.`, Quadlet resolves it relative to the location of the unit file.
 
 This key can be listed multiple times.
 


### PR DESCRIPTION
The `[Build] Volume=` docs were copied from the container form and claimed you could use named volumes / `.volume` units. `podman build --volume` only takes host paths, so that wording was wrong (see #25514).

This points the build unit man page at `volume.image` and trims the named-volume special case so it matches `podman-build(1)`.

Fixes #25514