### PR TITLE
libpod: fix batched lock handling in HTTPAttach and WaitForExit

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -433,8 +433,10 @@ func (c *Container) HTTPAttach(r *http.Request, w http.ResponseWriter, streams *
 	}
 
 	// We are NOT holding the lock for the duration of the function.
-	locked = false
-	c.lock.Unlock()
+	if locked {
+		locked = false
+		c.lock.Unlock()
+	}
 
 	logrus.Infof("Performing HTTP Hijack attach to container %s", c.ID())
 
@@ -662,9 +664,13 @@ func (c *Container) WaitForExit(ctx context.Context, pollInterval time.Duration)
 	}
 
 	// we cannot wait locked as we would hold the lock forever, so we unlock and then lock again
-	c.lock.Unlock()
+	if !c.batched {
+		c.lock.Unlock()
+	}
 	err := waitForConmonExit(ctx, conmonPID, conmonPidFd, pollInterval)
-	c.lock.Lock()
+	if !c.batched {
+		c.lock.Lock()
+	}
 	if err != nil {
 		return -1, fmt.Errorf("failed to wait for conmon to exit: %w", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
