### PR TITLE
libpod: fix Batch sharing container state with the original container

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -232,6 +232,23 @@ type ContainerState struct {
 	Restored         bool      `json:"restored,omitempty"`
 }
 
+// copy returns a copy of the container state that can be modified without
+// affecting the original state.
+// The maps and slices it contains are cloned, so entries can be added and
+// removed independently of the original - the values they hold are shared and
+// must not be modified in place.
+func (s *ContainerState) copy() *ContainerState {
+	newState := *s
+	newState.ExecSessions = maps.Clone(s.ExecSessions)
+	newState.NetworkStatus = maps.Clone(s.NetworkStatus)
+	newState.BindMounts = maps.Clone(s.BindMounts)
+	newState.ExtensionStageHooks = maps.Clone(s.ExtensionStageHooks)
+	newState.NetInterfaceDescriptions = maps.Clone(s.NetInterfaceDescriptions)
+	newState.Service.Pods = slices.Clone(s.Service.Pods)
+
+	return &newState
+}
+
 // ContainerNamedVolume is a named volume that will be mounted into the
 // container. Each named volume is a libpod Volume present in the state.
 type ContainerNamedVolume struct {

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -901,13 +901,18 @@ func (c *Container) Cleanup(ctx context.Context, onlyStopped bool) error {
 // As Batch normally disables updating the current state of the container, the
 // Sync() function is provided to enable container state to be updated and
 // checked within Batch.
+// The container given to the batch function holds a copy of the state, so state
+// changes made during the batch operation are not reflected in the container
+// Batch was invoked on.
 func (c *Container) Batch(batchFunc func(*Container) error) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	newCtr := new(Container)
 	newCtr.config = c.config
-	newCtr.state = c.state
+	// Copy the state, so modifications made by the batch function do not leak
+	// back into the container Batch was called on.
+	newCtr.state = c.state.copy()
 	newCtr.runtime = c.runtime
 	newCtr.ociRuntime = c.ociRuntime
 	newCtr.lock = c.lock

--- a/libpod/container_api_test.go
+++ b/libpod/container_api_test.go
@@ -1,0 +1,60 @@
+//go:build !remote && (linux || freebsd)
+
+package libpod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/podman/v6/libpod/define"
+	"go.podman.io/podman/v6/libpod/lock"
+)
+
+func TestBatchDoesNotModifyOriginalState(t *testing.T) {
+	manager, err := lock.NewInMemoryManager(1)
+	require.NoError(t, err)
+	ctrLock, err := manager.AllocateLock()
+	require.NoError(t, err)
+
+	ctr := &Container{
+		config: &ContainerConfig{ID: "test"},
+		state: &ContainerState{
+			State:      define.ContainerStateRunning,
+			PID:        1234,
+			BindMounts: map[string]string{"/etc/hosts": "/run/hosts"},
+			Service:    Service{Pods: []string{"pod1"}},
+		},
+		lock:  ctrLock,
+		valid: true,
+	}
+
+	err = ctr.Batch(func(batchCtr *Container) error {
+		batchCtr.state.State = define.ContainerStateStopped
+		batchCtr.state.PID = 0
+		batchCtr.state.BindMounts["/etc/resolv.conf"] = "/run/resolv.conf"
+		delete(batchCtr.state.BindMounts, "/etc/hosts")
+		batchCtr.state.Service.Pods = append(batchCtr.state.Service.Pods, "pod2")
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, define.ContainerStateRunning, ctr.state.State)
+	assert.Equal(t, 1234, ctr.state.PID)
+	assert.Equal(t, map[string]string{"/etc/hosts": "/run/hosts"}, ctr.state.BindMounts)
+	assert.Equal(t, []string{"pod1"}, ctr.state.Service.Pods)
+}
+
+func TestContainerStateCopyKeepsNilMaps(t *testing.T) {
+	state := &ContainerState{State: define.ContainerStateConfigured}
+
+	newState := state.copy()
+
+	assert.Nil(t, newState.ExecSessions)
+	assert.Nil(t, newState.NetworkStatus)
+	assert.Nil(t, newState.BindMounts)
+	assert.Nil(t, newState.ExtensionStageHooks)
+	assert.Nil(t, newState.NetInterfaceDescriptions)
+	assert.Nil(t, newState.Service.Pods)
+	assert.Equal(t, state, newState)
+}


### PR DESCRIPTION
`Batch()` builds a new `Container` so the batch function operates on a copy, but it assigned the state pointer directly:

```go
newCtr.state = c.state
```

Both containers therefore pointed at the same `ContainerState`, so every state change made inside the batch function was applied to the container `Batch()` was called on, defeating the copy.

This copies the state instead. A plain struct copy is not enough, because libpod modifies the maps held by the state in place (adding/removing exec sessions, dropping bind mounts, ...) and those would still be shared. `ContainerState.copy()` clones the maps and the service pod slice; the values stored in the maps remain shared, which is fine as libpod replaces rather than mutates them.

A regression test covers both the plain fields and the in-place map/slice modifications.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [ ] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [ ] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
