### PR TITLE
systemd: set /run/podman mode via DirectoryMode instead of tmpfiles

### DIFF
--- a/contrib/systemd/system/podman.socket
+++ b/contrib/systemd/system/podman.socket
@@ -5,6 +5,7 @@ Documentation=man:podman-system-service(1)
 [Socket]
 ListenStream=%t/podman/podman.sock
 SocketMode=0660
+DirectoryMode=0700
 
 [Install]
 WantedBy=sockets.target

--- a/contrib/tmpfile/podman.conf
+++ b/contrib/tmpfile/podman.conf
@@ -12,7 +12,6 @@ R! /tmp/containers-user-*
 x /tmp/run-*/libpod
 R! /tmp/run-*/libpod
 D! /var/lib/containers/storage/tmp 0700 root root
-D! /run/podman 0700 root root
 # Remove /var/tmp/container_images* podman temporary directories on each
 # boot which are created when pulling or saving images.
 R! /var/tmp/container_images*


### PR DESCRIPTION
Fixes: #27145

The tmpfiles rule creates `/run/podman` at boot, so `DirectoryMode=` on `podman.socket` never applies and a drop-in silently does nothing. Moving the mode into the socket unit keeps the same 0700 default and makes it overridable.

Tested with the drop-in from the issue. `DirectoryMode=0755` plus `SocketGroup=` gives a 755 directory and a 660 socket with that group. Without a drop-in it stays 0700, same as before.

Two notes:

`contrib/systemd/user/podman.socket` is a symlink to this file, so the rootless socket gets `DirectoryMode=0700` too. `$XDG_RUNTIME_DIR` is already 0700 and `resolveAPIURI()` also uses 0700, so this just makes systemd match podman.

`nv-proxy.sock` shares the directory, so netavark would need the same change in its own repo.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
```release-note
None
```