### PR TITLE
libpod/events: use filepath.Dir for filesystem path

### DIFF
--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -287,7 +286,7 @@ func truncate(filePath string) error {
 	size := origFinfo.Size()
 	threshold := size / 2
 
-	tmp, err := os.CreateTemp(path.Dir(filePath), "")
+	tmp, err := os.CreateTemp(filepath.Dir(filePath), "")
 	if err != nil {
 		// Retry in /tmp in case creating a tmp file in the same
 		// directory has failed.


### PR DESCRIPTION
## Description

Small fix for one of the path vs path/filepath cases from #25165.

In libpod/events/logfile.go, the truncate() function used path.Dir on a filesystem path. The file is Linux/FreeBSD only per its build tag, so this isn't about Windows correctness — it's about internal consistency: the same file already uses filepath.Dir at line 32 for the same kind of path handling, and filepath is idiomatic for filesystem operations. Also drops the now-unused "path" import.

Testing

go build ./libpod/events/ passes. No tests in the package to run.

Release note

```release-note
NONE
```