### PR TITLE
hack/ci: pass -r to limactl copy for directory copies

### DIFF
--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -27,7 +27,7 @@ limactl --yes start --plain --name=$LIMA_VM_NAME --cpus $(nproc) --memory 8 --ne
 
 limactl shell $LIMA_VM_NAME mkdir -p /var/tmp/podman-container-tools
 
-limactl copy "$REPO_DIR" $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman
+limactl copy -r "$REPO_DIR" $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman
 
 echo "::endgroup::"
 
@@ -37,7 +37,7 @@ limactl shell --preserve-env --workdir /var/tmp/podman-container-tools/podman $L
 rc=$?
 
 echo "::group::Collecting logs"
-limactl copy $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman/hack/ci/logs/ $SCRIPT_DIR/logs
+limactl copy -r $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman/hack/ci/logs/ $SCRIPT_DIR/logs
 echo "::endgroup::"
 
 # TODO: figure out how to cache the binaries from the build job to the actual test tasks


### PR DESCRIPTION
## Description

`hack/ci/ci.sh` calls `limactl copy` twice on directories — the repo directory being copied into the VM at line 30, and the logs directory being copied back out at line 40. `limactl copy` uses the underlying host transport (scp or rsync) and without `-r`, `scp` refuses a directory with `is not a regular file`, which matches what @mtrmac reported in #29425. It happens to work in CI (likely the rsync path) but breaks in local VMs (scp path).

Small fix: add `-r` to both `limactl copy` directory calls so they're always recursive regardless of the underlying transport.

Fixes #29425

## Testing

Shell change only, no Go build affected. Local-VM reproducer requires an environment where limactl uses the scp transport — happy to iterate if @mtrmac or @timcoding1988 can confirm on the exact setup that failed.

## Checklist

- [x] I have read and understood the contributing guidelines and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per LLM Policy.
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits.
- [x] Referenced issues using `Fixes: #00000` in commit message.
- [x] Tests: no tests needed (shell script change).
- [x] Documentation: no documentation changes needed.
- [x] All commits pass `make validatepr` (could not run locally on macOS — relying on CI).
- [x] Release note entered in the section below.

## Does this PR introduce a user-facing change?

```release-note
NONE
```