### PR TITLE
Re-enable pesto IPv6 forwarding tests

### DIFF
--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1096,8 +1096,6 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 					if forwarder == "rootlessport" {
 						Skip("rootlessport does not support native IPv6 port forwarding")
 					}
-					// TODO: enable once pasta ships the IPv6 local-mode fix (https://github.com/containers/podman/issues/29268)
-					Skip("pasta IPv6 forwarding requires unreleased pasta patch")
 					SkipIfNoIPv6Route("pesto IPv6 forwarding requires routable IPv6 on the host")
 				}
 				configurePortForwarder(forwarder)
@@ -1195,8 +1193,6 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 		It(fmt.Sprintf("podman run bridge dual-stack network IPv4 and IPv6 port forwarding with %s", forwarder), Serial, func() {
 			SkipIfNotRootless("netavark does not support IPv6 port forwarding")
-			// TODO: enable once pasta ships the IPv6 local-mode fix (https://github.com/containers/podman/issues/29268)
-			Skip("pasta IPv6 forwarding requires unreleased pasta patch")
 			SkipIfNoIPv6Route("pesto IPv6 forwarding requires routable IPv6 on the host")
 			configurePortForwarder(forwarder)
 
@@ -1229,8 +1225,6 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 	// https://github.com/containers/podman/issues/28771
 	It("podman run bridge dual-stack same port IPv4 and IPv6 route to different containers", func() {
-		// TODO: enable once pasta ships the IPv6 local-mode fix (https://github.com/containers/podman/issues/29268)
-		Skip("pasta IPv6 forwarding requires unreleased pasta patch")
 		SkipIfNoIPv6Route("pesto IPv6 forwarding requires routable IPv6 on the host")
 		configurePortForwarder("pasta")
 		subnet4 := "172.45.0.0/24"
@@ -1367,8 +1361,6 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 	// https://github.com/containers/podman/issues/28771
 	It("podman run bridge container with multiple port mappings on different addresses", func() {
-		// TODO: enable once pasta ships the IPv6 local-mode fix (https://github.com/containers/podman/issues/29268)
-		Skip("pasta IPv6 forwarding requires unreleased pasta patch")
 		SkipIfNoIPv6Route("pesto IPv6 forwarding requires routable IPv6 on the host")
 		configurePortForwarder("pasta")
 		subnet4 := "172.46.0.0/24"
@@ -1406,8 +1398,6 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 	// https://github.com/containers/podman/issues/28771
 	It("podman run bridge different host and container ports on dual-stack network with pesto", func() {
-		// TODO: enable once pasta ships the IPv6 local-mode fix (https://github.com/containers/podman/issues/29268)
-		Skip("pasta IPv6 forwarding requires unreleased pasta patch")
 		SkipIfNoIPv6Route("pesto IPv6 forwarding requires routable IPv6 on the host")
 		configurePortForwarder("pasta")
 		subnet4 := "172.47.0.0/24"


### PR DESCRIPTION
The pasta IPv6 local-mode fix has been released upstream.

Fixes: https://github.com/podman-container-tools/podman/issues/29268

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [ ] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
