### PR TITLE
cmd/podman: add autocompletion for --tz/--timezone flag

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -2045,3 +2045,57 @@ func AutocompleteSysctl(_ *cobra.Command, _ []string, toComplete string) ([]stri
 
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
+
+// AutocompleteTimezone - autocomplete timezone names from system zoneinfo directories or "local".
+func AutocompleteTimezone(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	completions := []string{}
+	if strings.HasPrefix("local", toComplete) {
+		completions = append(completions, "local")
+	}
+
+	zoneDirs := []string{
+		"/usr/share/zoneinfo",
+		"/usr/lib/zoneinfo",
+		"/usr/share/lib/zoneinfo",
+	}
+
+	for _, zoneDir := range zoneDirs {
+		st, err := os.Stat(zoneDir)
+		if err != nil || !st.IsDir() {
+			continue
+		}
+
+		_ = filepath.WalkDir(zoneDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			if !d.IsDir() {
+				rel, err := filepath.Rel(zoneDir, path)
+				if err != nil {
+					return nil
+				}
+				tzName := filepath.ToSlash(rel)
+				if strings.HasPrefix(tzName, "posix/") || strings.HasPrefix(tzName, "right/") || strings.HasSuffix(tzName, ".tab") || strings.HasSuffix(tzName, ".list") {
+					return nil
+				}
+
+				if strings.HasPrefix(tzName, toComplete) {
+					completions = append(completions, tzName)
+				}
+			}
+
+			return nil
+		})
+
+		if len(completions) > 1 || (len(completions) == 1 && completions[0] != "local") {
+			break
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+

--- a/cmd/podman/common/completion_test.go
+++ b/cmd/podman/common/completion_test.go
@@ -205,3 +205,10 @@ func TestAutocompleteFormat(t *testing.T) {
 		assert.Equal(t, test.expected, completion, test.name)
 	}
 }
+
+func TestAutocompleteTimezone(t *testing.T) {
+	completions, directive := common.AutocompleteTimezone(nil, nil, "loc")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	assert.Contains(t, completions, "local")
+}
+

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -430,7 +430,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			timezoneFlagName, cf.Timezone,
 			"Set timezone in container",
 		)
-		_ = cmd.RegisterFlagCompletionFunc(timezoneFlagName, completion.AutocompleteNone) // TODO: add timezone completion
+		_ = cmd.RegisterFlagCompletionFunc(timezoneFlagName, AutocompleteTimezone)
 
 		umaskFlagName := "umask"
 		createFlags.StringVar(


### PR DESCRIPTION
### Summary
This PR implements shell autocompletion for the `--tz` / `--timezone` flag when creating containers (`podman create` / `podman run`).

### Changes
1. Added `AutocompleteTimezone` in `cmd/podman/common/completion.go` which autocompletes `"local"` and dynamically scans system zoneinfo directories (`/usr/share/zoneinfo`, `/usr/lib/zoneinfo`, `/usr/share/lib/zoneinfo`).
2. Updated flag completion registration in `cmd/podman/common/create.go` replacing `completion.AutocompleteNone` with `AutocompleteTimezone` (resolving `// TODO: add timezone completion`).
3. Added unit test `TestAutocompleteTimezone` in `cmd/podman/common/completion_test.go`.

### Verification
Passed unit test `TestAutocompleteTimezone`.
