### PR TITLE
test/utils: handle empty image output

### DIFF
--- a/test/utils/podmansession_test.go
+++ b/test/utils/podmansession_test.go
@@ -53,6 +53,12 @@ var _ = Describe("PodmanSession test", func() {
 		Expect(session.LineInOutputContainsTag("busybox", "latest")).To(Not(BeTrue()))
 	})
 
+	It("Test LineInOutputContainsTag with empty output", func() {
+		session = StartFakeCmdSession([]string{})
+		session.WaitWithDefaultTimeout()
+		Expect(session.LineInOutputContainsTag("docker.io/library/busybox", "latest")).To(Not(BeTrue()))
+	})
+
 	It("Test IsJSONOutputValid", func() {
 		session = StartFakeCmdSession([]string{`{"page":1,"fruits":["apple","peach","pear"]}`})
 		session.WaitWithDefaultTimeout()

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -371,6 +371,11 @@ func StartSystemExec(command string, args []string) *PodmanSession {
 // be skipped as it's considered to be the header.
 func tagOutputToMap(imagesOutput []string) map[string]map[string]bool {
 	m := make(map[string]map[string]bool)
+	// imagesOutput[1:] panics (slice bounds out of range) when imagesOutput
+	// is empty, since there is no header line to skip in that case.
+	if len(imagesOutput) == 0 {
+		return m
+	}
 	// iterate over output but skip the header
 	for _, i := range imagesOutput[1:] {
 		tmp := []string{}


### PR DESCRIPTION
Handle empty image output before skipping the header row in tagOutputToMap. This prevents a slice bounds panic when imagesOutput is empty and adds coverage for the empty-output case.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
