### PR TITLE
Use ClientContextDirectory for prepareSecrets on Windows clients

### DIFF
--- a/internal/localapi/utils.go
+++ b/internal/localapi/utils.go
@@ -189,6 +189,7 @@ func CheckIfImageBuildPathsOnRunningMachine(ctx context.Context, containerFiles 
 		logrus.Debugf("Path %q is not available on the running machine", options.ContextDirectory)
 		return nil, options, false
 	}
+	options.ClientContextDirectory = mapping.ClientPath
 	options.ContextDirectory = mapping.RemotePath
 
 	// Containerfiles

--- a/internal/localapi/utils_test.go
+++ b/internal/localapi/utils_test.go
@@ -3,6 +3,7 @@
 package localapi
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,6 +149,7 @@ func TestIsPathAvailableOnMachine_Unix(t *testing.T) {
 
 			if tt.wantFound {
 				require.NotNil(t, result, "result should not be nil when found is true")
+				assert.Equal(t, filepath.Clean(tt.localPath), result.ClientPath, "ClientPath mismatch")
 				assert.Equal(t, tt.wantRemotePath, result.RemotePath, "RemotePath mismatch")
 			} else {
 				assert.Nil(t, result, "result should be nil when found is false")

--- a/internal/localapi/utils_windows_test.go
+++ b/internal/localapi/utils_windows_test.go
@@ -3,6 +3,7 @@
 package localapi
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -159,6 +160,7 @@ func TestIsPathAvailableOnMachine_Windows(t *testing.T) {
 
 			if tt.wantFound {
 				require.NotNil(t, result, "result should not be nil when found is true")
+				assert.Equal(t, filepath.Clean(tt.localPath), result.ClientPath, "ClientPath mismatch")
 				assert.Equal(t, tt.wantRemotePath, result.RemotePath, "RemotePath mismatch")
 			} else {
 				assert.Nil(t, result, "result should be nil when found is false")

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -1059,7 +1059,11 @@ func build(ctx context.Context, containerFiles []string, options types.BuildOpti
 
 	// build secrets are usually absolute host path or relative to context dir on host
 	// in any case move secret to current context and ship the tar.
-	secretsForRemote, secretsTarContent, err := prepareSecrets(options.CommonBuildOpts.Secrets, options.ContextDirectory, tempManager)
+	secretsContextDir := options.ContextDirectory
+	if options.ClientContextDirectory != "" {
+		secretsContextDir = options.ClientContextDirectory
+	}
+	secretsForRemote, secretsTarContent, err := prepareSecrets(options.CommonBuildOpts.Secrets, secretsContextDir, tempManager)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/build_windows_test.go
+++ b/pkg/bindings/images/build_windows_test.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package images
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/podman/v6/internal/remote_build_helpers"
+	"go.podman.io/podman/v6/pkg/domain/entities/types"
+)
+
+func TestPrepareSecretsWithLocalAPIContext(t *testing.T) {
+	hostContext := t.TempDir()
+	options := types.BuildOptions{ClientContextDirectory: hostContext}
+	options.ContextDirectory = "/mnt/c/context"
+	t.Setenv("PODMAN_TEST_BUILD_SECRET", "secret content")
+
+	manager := remote_build_helpers.NewTempFileManager()
+	defer manager.Cleanup()
+
+	secrets, tarContent, err := prepareSecrets(
+		[]string{"id=test,env=PODMAN_TEST_BUILD_SECRET"},
+		options.ClientContextDirectory,
+		manager,
+	)
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	require.Len(t, tarContent, 1)
+
+	assert.Equal(t, hostContext, filepath.Dir(tarContent[0]))
+	assert.Equal(t, "id=test,src="+filepath.Base(tarContent[0]), secrets[0])
+	contents, err := os.ReadFile(tarContent[0])
+	require.NoError(t, err)
+	assert.Equal(t, "secret content", string(contents))
+}

--- a/pkg/domain/entities/types/types.go
+++ b/pkg/domain/entities/types/types.go
@@ -64,6 +64,9 @@ type BuildOptions struct {
 	buildahDefine.BuildOptions
 	ContainerFiles []string
 	FarmBuildOptions
+	// ClientContextDirectory is the original context directory on the client before
+	// localapi translates ContextDirectory to a path available on the machine.
+	ClientContextDirectory string `json:"-"`
 	// Files that need to be closed after the build
 	// so need to pass this to the main build functions
 	LogFileToClose *os.File


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

This fixes Windows remote builds with `--secret` when localapi maps the build context to a Linux path for a Podman machine.

`prepareSecrets` previously used `ContextDirectory` to create temporary secret files on the Windows client. After localapi translated that field, it contained the machine-visible Linux path instead of the original Windows path. Windows therefore could not create the temporary secret file.

The change preserves the original client path in `ClientContextDirectory` before replacing `ContextDirectory` with the machine-visible path. `prepareSecrets` uses the client path for local temporary files, while `ContextDirectory` remains the path used by the machine.

Regression tests cover the localapi path mapping and temporary secret-file placement.

Testing:

- `make validatepr`
- All GitHub RPM and Testing Farm checks passed

Fixes #29223

Translated with an LLM from Chinese.

#### Does this PR introduce a user-facing change?

```release-note
Fix `podman build --secret` on Windows clients when localapi maps the build context to a Podman machine path.
```