### PR TITLE
test/system: fix SELinux issue in volume quotas test

### DIFF
--- a/test/system/161-volume-quotas.bats
+++ b/test/system/161-volume-quotas.bats
@@ -40,11 +40,6 @@ function teardown() {
     skip_if_rootless "Quotas are only possible with root"
     skip_if_remote "Requires --root flag, not possible w/ remote"
 
-    OS_RELEASE_ID="${OS_RELEASE_ID:-$(source /etc/os-release; echo $ID)}"
-    if [[ "$OS_RELEASE_ID" == "fedora" ]]; then
-        skip "FIXME #27759: There is a selinux problem with this test"
-    fi
-
     # Minimum XFS filesystem size is 300mb
     loop=$PODMAN_TMPDIR/disk.img
     fallocate -l 300m  ${loop}
@@ -72,7 +67,12 @@ function teardown() {
 
     ctrname="testctr"
     # pull never to ensure the prefetch works correctly
-    run_podman $safe_opts run -d --pull=never --name=$ctrname -i -v $vol_one:/one -v $vol_two:/two $IMAGE top
+    # #27759: Disable SELinux labeling: custom --root (via podman_isolation_opts)
+    # places the container rootfs under /tmp which gets labeled as
+    # container_var_run_t instead of container_file_t, causing the
+    # container process (container_t) to be denied access to its own
+    # binaries. This test is about XFS quotas, not SELinux.
+    run_podman $safe_opts run -d --pull=never --security-opt label=disable --name=$ctrname -i -v $vol_one:/one -v $vol_two:/two $IMAGE top
 
     run_podman $safe_opts exec $ctrname dd if=/dev/zero of=/one/oneMB bs=1M count=1
     run_podman 1 $safe_opts exec $ctrname dd if=/dev/zero of=/one/twoMB bs=1M count=1


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #27759` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
