### PR TITLE
libpod/events: support network filter for events

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1606,6 +1606,7 @@ func AutocompleteEventFilter(cmd *cobra.Command, _ []string, toComplete string) 
 		"container=": func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeDefault) },
 		"image=":     func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) },
 		"artifact=":  func(s string) ([]string, cobra.ShellCompDirective) { return getArtifacts(cmd, s) },
+		"network=":   func(s string) ([]string, cobra.ShellCompDirective) { return getNetworks(cmd, s, completeDefault) },
 		"pod=":       func(s string) ([]string, cobra.ShellCompDirective) { return getPods(cmd, s, completeDefault) },
 		"volume=":    func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
 		"event=":     event,

--- a/libpod/events/filters.go
+++ b/libpod/events/filters.go
@@ -67,6 +67,16 @@ func generateEventFilter(filter, filterValue string) (func(e *Event) bool, error
 			// Prefix match with name for consistency with docker
 			return strings.HasPrefix(e.Name, filterValue)
 		}, nil
+	case "NETWORK":
+		return func(e *Event) bool {
+			if e.Type != Network {
+				return false
+			}
+			if e.Name == filterValue {
+				return true
+			}
+			return strings.HasPrefix(e.ID, filterValue)
+		}, nil
 	case "TYPE":
 		return func(e *Event) bool {
 			return string(e.Type) == filterValue

--- a/libpod/events/filters_test.go
+++ b/libpod/events/filters_test.go
@@ -1,0 +1,40 @@
+//go:build linux || freebsd
+
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateEventFilterNetwork(t *testing.T) {
+	filterFunc, err := generateEventFilter("network", "mynet")
+	require.NoError(t, err)
+
+	netEventMatch := &Event{
+		Type: Network,
+		Name: "mynet",
+		ID:   "1234567890abcdef",
+	}
+	netEventMismatch := &Event{
+		Type: Network,
+		Name: "othernet",
+		ID:   "9876543210fedcba",
+	}
+	nonNetEvent := &Event{
+		Type: Container,
+		Name: "mynet",
+		ID:   "1234567890abcdef",
+	}
+
+	assert.True(t, filterFunc(netEventMatch))
+	assert.False(t, filterFunc(netEventMismatch))
+	assert.False(t, filterFunc(nonNetEvent))
+
+	// Test prefix ID match for network filter
+	filterFuncID, err := generateEventFilter("network", "12345")
+	require.NoError(t, err)
+	assert.True(t, filterFuncID(netEventMatch))
+}


### PR DESCRIPTION
<!-- Description of the changes -->
### Description
This PR resolves an oversight in the event filtering logic where `network` event filters were not supported, causing `podman events --filter network=...` to unconditionally fail.

**Changes introduced:**
1. **Filter Support:** Added the `NETWORK` case in `generateEventFilter` (`libpod/events/filters.go`) to match network events by network name or ID prefix.
2. **Shell Completion:** Added the `network=` option to the `keyValueCompletion` map in `AutocompleteEventFilter` (`cmd/podman/common/completion.go`) to enable shell autocompletion for network filters.
3. **Tests:** Created `libpod/events/filters_test.go` to cover the new network event filtering logic.

Fixes: #29387

### Checklist
- [x] Commits are signed off with Developer Certificate of Origin (DCO)
- [x] Unit tests have been added and verified

### How this was tested
I ran unit tests inside a WSL2 Ubuntu environment to verify the new filter matching behavior:
```bash
$ go test -v ./libpod/events/...
=== RUN   TestGenerateEventFilterNetwork
--- PASS: TestGenerateEventFilterNetwork (0.00s)
=== RUN   TestRotateLog
--- PASS: TestRotateLog (0.00s)
=== RUN   TestTruncationOutput
--- PASS: TestTruncationOutput (0.00s)
=== RUN   TestRenameLog
--- PASS: TestRenameLog (0.00s)
PASS
ok  	go.podman.io/podman/v6/libpod/events	0.011s
