### PR TITLE
Removed '--help' command line argument from man page documentation.

### DIFF
--- a/docs/source/locale/ja/LC_MESSAGES/markdown.po
+++ b/docs/source/locale/ja/LC_MESSAGES/markdown.po
@@ -2853,9 +2853,6 @@ msgstr ""
 #: ../../source/markdown/podman-volume-exists.1.md:18
 #: ../../source/markdown/podman-wait.1.md:30
 #: ../../source/markdown/podman.1.md:50
-msgid "**--help**, **-h**"
-msgstr ""
-
 #: ../../source/markdown/podman-build.1.md:528
 #: ../../source/markdown/podman-container-runlabel.1.md:75
 #: ../../source/markdown/podman-create.1.md:766
@@ -2896,9 +2893,6 @@ msgstr ""
 #: ../../source/markdown/podman-volume-rm.1.md:30
 #: ../../source/markdown/podman-wait.1.md:32
 #: ../../source/markdown/podman.1.md:52
-msgid "Print usage statement"
-msgstr ""
-
 #: ../../source/markdown/podman-build.1.md:530
 #: ../../source/markdown/podman.1.md:54
 msgid "**--hooks-dir**=*path*"
@@ -6876,7 +6870,7 @@ msgid ""
 msgstr ""
 
 #: ../../source/markdown/podman-container-prune.1.md:38
-msgid "Print usage statement.\\ The default is **false**."
+msgid "The default is **false**."
 msgstr ""
 
 #: ../../source/markdown/podman-container-prune.1.md:42
@@ -9031,9 +9025,6 @@ msgstr ""
 #: ../../source/markdown/podman-volume-ls.1.md:66
 #: ../../source/markdown/podman-volume-prune.1.md:41
 #: ../../source/markdown/podman-volume-rm.1.md:28
-msgid "**--help**"
-msgstr ""
-
 #: ../../source/markdown/podman-create.1.md:770
 #: ../../source/markdown/podman-run.1.md:812
 msgid "**--hostname**, **-h**=*name*"
@@ -12717,9 +12708,6 @@ msgstr ""
 #: ../../source/markdown/podman-secret-rm.1.md:28
 #: ../../source/markdown/podman-system-service.1.md:87
 #: ../../source/markdown/podman-volume-ls.1.md:68
-msgid "Print usage statement."
-msgstr ""
-
 #: ../../source/markdown/podman-events.1.md:124
 #: ../../source/markdown/podman-history.1.md:48
 #: ../../source/markdown/podman-images.1.md:110

--- a/docs/source/markdown/options/help.md
+++ b/docs/source/markdown/options/help.md
@@ -2,6 +2,3 @@
 ####>   podman build, farm build
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--help**, **-h**
-
-Print usage statement

--- a/docs/source/markdown/podman-artifact-pull.1.md.in
+++ b/docs/source/markdown/podman-artifact-pull.1.md.in
@@ -29,11 +29,6 @@ $ podman artifact pull quay.io/foobar/artifact:special
 
 @@option decryption-key
 
-
-#### **--help**, **-h**
-
-Print the usage statement.
-
 @@option quiet
 
 @@option retry

--- a/docs/source/markdown/podman-container-exists.1.md
+++ b/docs/source/markdown/podman-container-exists.1.md
@@ -16,11 +16,6 @@ of `0` when the container is found.  A `1` is returned otherwise. An exit code o
 Check for external *containers* as well as Podman *containers*. These external *containers* are generally created via other container technology such as `Buildah` or `CRI-O`.\
 The default is **false**.
 
-**-h**, **--help**
-
-Prints usage statement.\
-The default is **false**.
-
 ## EXAMPLES
 
 Check if a container called "webclient" exists in local storage. Here, the container does exist.

--- a/docs/source/markdown/podman-container-prune.1.md
+++ b/docs/source/markdown/podman-container-prune.1.md
@@ -35,11 +35,6 @@ The `until` *filter* can be Unix timestamps, date formatted timestamps, or Go du
 Do not provide an interactive prompt for container removal.\
 The default is **false**.
 
-**-h**, **--help**
-
-Print usage statement.\
-The default is **false**.
-
 ## EXAMPLES
 Remove all stopped containers from local storage:
 ```

--- a/docs/source/markdown/podman-container-runlabel.1.md.in
+++ b/docs/source/markdown/podman-container-runlabel.1.md.in
@@ -40,9 +40,6 @@ Will be replaced with the current working directory.
 
 Display the label's value of the image having populated its environment variables.  The runlabel command is not executed if --display is specified.
 
-#### **--help**, **-h**
-Print usage statement
-
 #### **--name**, **-n**=*name*
 
 Use this name for creating content for the container.  If not specified, name defaults to the name of the image.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -200,10 +200,6 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 @@option health-timeout
 
-#### **--help**
-
-Print usage statement
-
 @@option hostname.container
 
 @@option hosts-file

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -141,10 +141,6 @@ Format the output to JSON Lines or using the given Go template.
 | .TimeNano             | Event timestamp with nanosecond precision (int64)                    |
 | .Type                 | Event type (e.g., image, container, pod, ...)                        |
 
-#### **--help**
-
-Print usage statement.
-
 #### **--no-trunc**
 
 Do not truncate the output (default *true*).

--- a/docs/source/markdown/podman-export.1.md
+++ b/docs/source/markdown/podman-export.1.md
@@ -26,10 +26,6 @@ Note: `:` is a restricted character and cannot be part of the file name.
 
 ## OPTIONS
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--output**, **-o**
 
 Write to a file, default is STDOUT

--- a/docs/source/markdown/podman-healthcheck-run.1.md
+++ b/docs/source/markdown/podman-healthcheck-run.1.md
@@ -21,9 +21,6 @@ Possible errors that can occur during the healthcheck are:
 * container is not running
 
 ## OPTIONS
-#### **--help**
-
-Print usage statement
 
 #### **--ignore-result**
 

--- a/docs/source/markdown/podman-history.1.md
+++ b/docs/source/markdown/podman-history.1.md
@@ -36,10 +36,6 @@ Valid placeholders for the Go template are listed below:
 | .Size                  | Size of layer on disk                                                     |
 | .Tags                  | Image tags                                                                |
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--human**, **-H**
 
 Display sizes and dates in human readable format (default *true*).

--- a/docs/source/markdown/podman-image-exists.1.md
+++ b/docs/source/markdown/podman-image-exists.1.md
@@ -12,12 +12,6 @@ of the image may be used as input.  Podman returns an exit code
 of `0` when the image is found.  A `1` is returned otherwise. An exit code of `125` indicates there
 was an issue accessing the local storage.
 
-## OPTIONS
-
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLES
 
 Check if an image called `webclient` exists in local storage (the image does actually exist):

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -47,10 +47,6 @@ The `until` *filter* can be Unix timestamps, date formatted timestamps or Go dur
 
 Do not provide an interactive prompt for container removal.
 
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLES
 
 Remove all dangling images from local storage:

--- a/docs/source/markdown/podman-image-scp.1.md
+++ b/docs/source/markdown/podman-image-scp.1.md
@@ -28,10 +28,6 @@ Format passed to **podman save** when creating the transfer archive. Allowed val
 
 Only the **oci-archive** and **docker-archive** archive (tar) formats are supported. Directory formats (**oci-dir**, **docker-dir**) are not supported because the transfer sends a single file; the remote path does not support directory layouts.
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--quiet**, **-q**
 
 Suppress the output

--- a/docs/source/markdown/podman-image-sign.1.md.in
+++ b/docs/source/markdown/podman-image-sign.1.md.in
@@ -27,10 +27,6 @@ Sign all the manifests of the multi-architecture image (default false).
 
 Store the signatures in the specified directory.  Default: /var/lib/containers/sigstore
 
-#### **--help**, **-h**
-
-Print usage statement.
-
 #### **--sign-by**=*identity*
 
 Override the default identity of the signature.

--- a/docs/source/markdown/podman-image-tree.1.md
+++ b/docs/source/markdown/podman-image-tree.1.md
@@ -13,10 +13,6 @@ If no *tag* is provided, Podman defaults to `latest` for the *image*.
 Layers are indicated with image tags as `Top Layer of`, when the tag is known locally.
 ## OPTIONS
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--whatrequires**
 
 Show all child images and layers of the specified image

--- a/docs/source/markdown/podman-image-trust.1.md.in
+++ b/docs/source/markdown/podman-image-trust.1.md.in
@@ -45,8 +45,6 @@ Require a sigstore signature ("sigstoreSigned").
 Trust may be updated using the command **podman image trust set** for an existing trust scope.
 
 ## OPTIONS
-#### **--help**, **-h**
-  Print usage statement.
 
 ### set OPTIONS
 

--- a/docs/source/markdown/podman-import.1.md
+++ b/docs/source/markdown/podman-import.1.md
@@ -33,10 +33,6 @@ Apply the following possible instructions to the created image:
 
 Can be set multiple times
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--message**, **-m**=*message*
 
 Set commit message for imported image

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -225,10 +225,6 @@ Use *path* as the build context directory for each image. Requires --build optio
 
 Tear down the volumes linked to the PersistentVolumeClaims as part of --down
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--ip**=*IP address*
 
 Assign a static ip address to the pod. This option can be specified several times when kube play creates more than one pod.

--- a/docs/source/markdown/podman-load.1.md
+++ b/docs/source/markdown/podman-load.1.md
@@ -21,10 +21,6 @@ Note: `:` is a restricted character and cannot be part of the file name.
 
 ## OPTIONS
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--input**, **-i**=*input*
 
 Load the specified input file or URL instead of reading from stdin. The input can be one of:

--- a/docs/source/markdown/podman-login.1.md.in
+++ b/docs/source/markdown/podman-login.1.md.in
@@ -38,10 +38,6 @@ For more details about format and configurations of the auth.json file, see cont
 
 Return the logged-in user for the registry.  Return error if no login is found.
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--password**, **-p**=*password*
 
 Password for registry

--- a/docs/source/markdown/podman-logout.1.md.in
+++ b/docs/source/markdown/podman-logout.1.md.in
@@ -29,10 +29,6 @@ Remove the cached credentials for all registries in the auth file
 
 @@option compat-auth-file
 
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLES
 
 Remove login credentials for the docker.io registry from the authentication file:

--- a/docs/source/markdown/podman-machine-cp.1.md
+++ b/docs/source/markdown/podman-machine-cp.1.md
@@ -19,10 +19,6 @@ files and directories.
 
 ## OPTIONS
 
-#### **--help**
-
-Print usage statement.
-
 #### **--quiet**, **-q**
 
 Suppress copy status output.

--- a/docs/source/markdown/podman-machine-info.1.md
+++ b/docs/source/markdown/podman-machine-info.1.md
@@ -28,10 +28,6 @@ Change output format to "json" or a Go template.
 | .Host ...           | Host information for local machine|
 | .Version ...        | Version of the machine            |
 
-#### **--help**
-
-Print usage statement.
-
 ## EXAMPLES
 
 Display default Podman machine info.

--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -63,10 +63,6 @@ Number of CPUs.
 
 Size of the disk for the guest VM in GiB.
 
-#### **--help**
-
-Print usage statement.
-
 #### **--ignition-path**
 
 Fully qualified path of the ignition file.

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -37,10 +37,6 @@ Print results with a Go template.
 | .State              | Machine state                                                         |
 | .UserModeNetworking | Whether this machine uses user-mode networking                        |
 
-#### **--help**
-
-Print usage statement.
-
 ## EXAMPLES
 
 Inspect the specified Podman machine.

--- a/docs/source/markdown/podman-machine-list.1.md.in
+++ b/docs/source/markdown/podman-machine-list.1.md.in
@@ -50,10 +50,6 @@ Valid placeholders for the Go template are listed below:
 | .UserModeNetworking | Whether machine uses user-mode networking |
 | .VMType             | VM type                                   |
 
-#### **--help**
-
-Print usage statement.
-
 @@option noheading
 
 #### **--quiet**, **-q**

--- a/docs/source/markdown/podman-machine-os-apply.1.md
+++ b/docs/source/markdown/podman-machine-os-apply.1.md
@@ -40,10 +40,6 @@ then the OS changes will be applied to `podman-machine-default`.
 
 ## OPTIONS
 
-#### **--help**
-
-Print usage statement.
-
 #### **--restart**
 
 Restart VM after applying changes.

--- a/docs/source/markdown/podman-machine-os-upgrade.1.md
+++ b/docs/source/markdown/podman-machine-os-upgrade.1.md
@@ -50,10 +50,6 @@ cannot be used with --restart
 Define a structured output format.  The only valid value for this is `json`.  Using this option
 imples a dry-run. This option cannot be used with --restart.
 
-#### **--help**
-
-Print usage statement.
-
 #### **--restart**
 
 Restart VM after applying changes.

--- a/docs/source/markdown/podman-machine-reset.1.md
+++ b/docs/source/markdown/podman-machine-reset.1.md
@@ -19,11 +19,6 @@ this command is run, all of your Podman machines will have been deleted.
 
 Reset without confirmation.
 
-#### **--help**
-
-Print usage statement.
-
-
 ## EXAMPLES
 
 ```

--- a/docs/source/markdown/podman-machine-restart.1.md
+++ b/docs/source/markdown/podman-machine-restart.1.md
@@ -20,10 +20,6 @@ virtual machine just starts it from a stopped state.
 
 ## OPTIONS
 
-#### **--help**
-
-Print usage statement.
-
 #### **--no-info**
 
 Suppress informational tips.

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -27,10 +27,6 @@ Rootless only.
 
 Stop and delete without confirmation.
 
-#### **--help**
-
-Print usage statement.
-
 #### **--save-ignition**
 
 Do not delete the generated ignition file.

--- a/docs/source/markdown/podman-machine-set.1.md.in
+++ b/docs/source/markdown/podman-machine-set.1.md.in
@@ -29,10 +29,6 @@ Only supported for QEMU machines.
 Size of the disk for the guest VM in GB.
 Can only be increased. Only supported for QEMU machines.
 
-#### **--help**
-
-Print usage statement.
-
 #### **--import-native-ca**
 
 Import the host's trusted CA certificates into the machine.

--- a/docs/source/markdown/podman-machine-ssh.1.md
+++ b/docs/source/markdown/podman-machine-ssh.1.md
@@ -23,10 +23,6 @@ Rootless only.
 
 ## OPTIONS
 
-#### **--help**
-
-Print usage statement.
-
 #### **--username**=*name*
 
 Username to use when SSH-ing into the VM.

--- a/docs/source/markdown/podman-machine-start.1.md.in
+++ b/docs/source/markdown/podman-machine-start.1.md.in
@@ -27,10 +27,6 @@ Only one Podman managed VM can be active at a time. If a VM is already running,
 
 ## OPTIONS
 
-#### **--help**
-
-Print usage statement.
-
 #### **--no-info**
 
 Suppress informational tips.

--- a/docs/source/markdown/podman-machine-stop.1.md
+++ b/docs/source/markdown/podman-machine-stop.1.md
@@ -24,10 +24,6 @@ but can be optionally used on Linux.
 
 ## OPTIONS
 
-#### **--help**
-
-Print usage statement.
-
 ## EXAMPLES
 
 Stop a podman machine named myvm.

--- a/docs/source/markdown/podman-manifest-exists.1.md
+++ b/docs/source/markdown/podman-manifest-exists.1.md
@@ -13,12 +13,6 @@ returned otherwise.
 An exit code of `125` indicates there was another issue.
 
 
-## OPTIONS
-
-#### **--help**, **-h**
-
-Print usage statement.
-
 ## EXAMPLE
 
 Check if a manifest list called `list1` exists (the manifest list does actually exist):

--- a/docs/source/markdown/podman-network-exists.1.md
+++ b/docs/source/markdown/podman-network-exists.1.md
@@ -12,13 +12,6 @@ of the network may be used as input.  Podman returns an exit code
 of `0` when the network is found.  A `1` is returned otherwise. An exit code of
 `125` indicates there was another issue.
 
-
-## OPTIONS
-
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLE
 
 Check if specified network exists (the network does actually exist):

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -43,10 +43,6 @@ Note: the pod implements devices by storing the initial configuration passed by 
 
 @@option gpus
 
-#### **--help**, **-h**
-
-Print usage statement.
-
 @@option hostname.pod
 
 @@option infra-command

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -82,10 +82,6 @@ Set the exit policy of the pod when the last container exits.  Supported policie
 
 @@option gpus
 
-#### **--help**, **-h**
-
-Print usage statement.
-
 @@option hostname.pod
 
 @@option hosts-file

--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -65,10 +65,6 @@ Valid placeholders for the Go template are listed below:
 | .Restarts           | Show the total number of container restarts in a pod |
 | .Status             | Status of pod                                        |
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--latest**, **-l**
 
 Show the latest pod created (all states) (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/podman-pod-top.1.md.in
+++ b/docs/source/markdown/podman-pod-top.1.md.in
@@ -11,14 +11,6 @@ Display the running processes of containers in a pod. The *format-descriptors* a
 descriptors but extended to print additional information, such as the seccomp mode or the effective capabilities
 of a given process. The descriptors can either be passed as separate arguments or as a single comma-separated argument.
 
-## OPTIONS
-
-#### **--help**, **-h**
-
-  Print usage statement
-
-@@option latest
-
 ## FORMAT DESCRIPTORS
 
 For a full list of available descriptors, see podman-top(1)

--- a/docs/source/markdown/podman-ps.1.md.in
+++ b/docs/source/markdown/podman-ps.1.md.in
@@ -78,10 +78,6 @@ Valid placeholders for the Go template are listed below:
 | .State             | Human-friendly description of ctr state      |
 | .Status            | Status of container                          |
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--last**, **-n**
 
 Print the n last created containers (all states)

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -58,10 +58,6 @@ $ podman pull oci-archive:/tmp/myimage
 
 @@option disable-content-trust
 
-#### **--help**, **-h**
-
-Print the usage statement.
-
 @@option os.pull
 
 @@option platform

--- a/docs/source/markdown/podman-remote.1.md
+++ b/docs/source/markdown/podman-remote.1.md
@@ -31,10 +31,6 @@ Remote connection name
 
 Overrides environment variable `CONTAINER_CONNECTION` if set.
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--identity**=*path*
 
 Path to ssh identity file. If the identity file has been encrypted, Podman prompts the user for the passphrase.

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -234,10 +234,6 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 @@option health-timeout
 
-#### **--help**
-
-Print usage statement
-
 @@option hostname.container
 
 @@option hosts-file

--- a/docs/source/markdown/podman-save.1.md.in
+++ b/docs/source/markdown/podman-save.1.md.in
@@ -36,9 +36,6 @@ An image format to produce, one of:
 | **docker-dir**     | **dir** transport (see **containers-transports(5)**) with v2s2 manifest type |
 
 Note: **oci-dir** and **docker-dir** cannot be loaded with **podman load** on Podman remote clients (including macOS and Windows, excluding WSL2)
-#### **--help**, **-h**
-
-Print usage statement
 
 #### **--multi-image-archive**, **-m**
 

--- a/docs/source/markdown/podman-search.1.md.in
+++ b/docs/source/markdown/podman-search.1.md.in
@@ -61,10 +61,6 @@ Valid placeholders for the Go template are listed below:
 
 Note: use .Tag only if the --list-tags is set.
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--limit**=*limit*
 
 Limit the number of results (default 25).

--- a/docs/source/markdown/podman-secret-create.1.md
+++ b/docs/source/markdown/podman-secret-create.1.md
@@ -34,10 +34,6 @@ Specify driver specific options.
 
 Read secret data from environment variable.
 
-#### **--help**
-
-Print usage statement.
-
 #### **--ignore**=*false*
 
 If a secret with the same name already exists, do not return an error and return the existing secret's ID instead of creating a new one.

--- a/docs/source/markdown/podman-secret-exists.1.md
+++ b/docs/source/markdown/podman-secret-exists.1.md
@@ -14,9 +14,6 @@ of `0` when the secret is found. A `1` is returned otherwise. An exit code of
 
 ## OPTIONS
 
-#### **--help**, **-h**
-
-Print usage statement
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-secret-inspect.1.md
+++ b/docs/source/markdown/podman-secret-inspect.1.md
@@ -32,10 +32,6 @@ Format secret output using Go template.
 | .Spec.Name               | Name of secret                                                    |
 | .UpdatedAt ...           | When secret was last updated (relative timestamp, human-readable) |
 
-#### **--help**
-
-Print usage statement.
-
 #### **--pretty**
 
 Print inspect output in human-readable format. Ignores fields from **--format**.

--- a/docs/source/markdown/podman-secret-rm.1.md
+++ b/docs/source/markdown/podman-secret-rm.1.md
@@ -22,10 +22,6 @@ the old secret value still remains.
 
 Remove all existing secrets.
 
-#### **--help**
-
-Print usage statement.
-
 #### **--ignore**, **-i**
 Ignore errors when specified secrets are not present.
 

--- a/docs/source/markdown/podman-system-prune.1.md
+++ b/docs/source/markdown/podman-system-prune.1.md
@@ -55,10 +55,6 @@ The `until` *filter* can be Unix timestamps, date formatted timestamps, or Go du
 
 Do not prompt for confirmation
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--volumes**
 
 Prune volumes currently unused by any container

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -26,10 +26,6 @@ of the relevant configurations. If the administrator modified the configuration 
 
 Do not prompt for confirmation
 
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLES
 
 Reset all storage back to a clean initialized state.

--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -82,10 +82,6 @@ If a *tcp* URL must be used without TLS, using the *--cors* option is recommende
 
 CORS headers to inject to the HTTP response. The default value is empty string which disables CORS headers.
 
-#### **--help**, **-h**
-
-Print usage statement.
-
 #### **--time**, **-t**
 
 The time until the session expires in _seconds_. The default is 5

--- a/docs/source/markdown/podman-tag.1.md
+++ b/docs/source/markdown/podman-tag.1.md
@@ -14,12 +14,6 @@ image name, including the optional *tag* after the `:`.  If there is no *tag*
 provided, then Podman defaults to `latest` for both the *image* and the
 *target-name*.
 
-## OPTIONS
-
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLES
 
 Tag specified image with an image name defaulting to :latest.

--- a/docs/source/markdown/podman-top.1.md.in
+++ b/docs/source/markdown/podman-top.1.md.in
@@ -20,9 +20,6 @@ to display the PID and user of the processes in the host context.
 
 ## OPTIONS
 
-#### **--help**, **-h**
-
-Print usage statement
 
 @@option latest
 

--- a/docs/source/markdown/podman-unshare.1.md
+++ b/docs/source/markdown/podman-unshare.1.md
@@ -28,10 +28,6 @@ The unshare session defines two environment variables:
 
 ## OPTIONS
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--rootless-netns**
 
 Join the rootless network namespace used for netavark networking. It can be used to

--- a/docs/source/markdown/podman-untag.1.md
+++ b/docs/source/markdown/podman-untag.1.md
@@ -11,12 +11,6 @@ podman\-untag - Remove one or more names from a locally-stored image
 ## DESCRIPTION
 Remove one or more names from an image in the local storage.  The image can be referred to by ID or reference.  If no name is specified, all names are removed from the image.  If a specified name is a short name and does not include a registry, `localhost/` is prefixed (e.g., `fedora` -> `localhost/fedora`). If a specified name does not include a tag, `:latest` is appended (e.g., `localhost/fedora` -> `localhost/fedora:latest`).
 
-## OPTIONS
-
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLES
 
 Remove all tags from the specified image.

--- a/docs/source/markdown/podman-version.1.md
+++ b/docs/source/markdown/podman-version.1.md
@@ -43,10 +43,6 @@ $ podman version --format '{{.Client.Version}}'
 2.0.0
 ```
 
-#### **--help**, **-h**
-
-Print usage statement
-
 ## SEE ALSO
 **[podman(1)](podman.1.md)**
 

--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -32,10 +32,6 @@ Such plugins must be defined in the **volume_plugins** section of the **[contain
 
 Set the GID that the volume will be created as. Differently than `--opt o=gid=*gid*`, the specified value is not passed to the mount operation. The specified GID will own the volume's mount point directory and affects the volume chown operation.
 
-#### **--help**
-
-Print usage statement
-
 #### **--ignore**
 
 Don't fail if the named volume already exists, instead just print the name. Note that the new options are not applied to the existing volume.
@@ -158,7 +154,6 @@ $ doas dnf install s3fs-fuse
 
 **Simple usage:**
 ```shell
-$ s3fs --help
 $ s3fs -o use_xattr,endpoint=aq-central-1 bucket:/prefix /mnt
 ```
 

--- a/docs/source/markdown/podman-volume-exists.1.md
+++ b/docs/source/markdown/podman-volume-exists.1.md
@@ -11,13 +11,6 @@ podman\-volume\-exists - Check if the given volume exists
 of `0` when the volume is found. A `1` is returned otherwise. An exit code of
 `125` indicates there was another issue.
 
-
-## OPTIONS
-
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLE
 
 Check if a volume called `myvol` exists (the volume does actually exist).

--- a/docs/source/markdown/podman-volume-export.1.md
+++ b/docs/source/markdown/podman-volume-export.1.md
@@ -16,10 +16,6 @@ redirected to a file using the `--output` flag.
 
 ## OPTIONS
 
-#### **--help**
-
-Print usage statement
-
 #### **--output**, **-o**=*file*
 
 Write to a file, default is STDOUT

--- a/docs/source/markdown/podman-volume-import.1.md
+++ b/docs/source/markdown/podman-volume-import.1.md
@@ -14,10 +14,6 @@ The contents of the volume is merged with the content of the tarball with the la
 
 The given volume must already exist and is not created by podman volume import.
 
-#### **--help**
-
-Print usage statement
-
 ## EXAMPLES
 
 Import named volume content from the specified file.

--- a/docs/source/markdown/podman-volume-inspect.1.md
+++ b/docs/source/markdown/podman-volume-inspect.1.md
@@ -46,10 +46,6 @@ Valid placeholders for the Go template are listed below:
 | .Timeout            | Timeout of the volume                                                       |
 | .UID                | UID the volume was created with                                             |
 
-#### **--help**
-
-Print usage statement
-
 
 ## EXAMPLES
 

--- a/docs/source/markdown/podman-volume-ls.1.md.in
+++ b/docs/source/markdown/podman-volume-ls.1.md.in
@@ -44,9 +44,6 @@ Valid placeholders for the Go template are listed below:
 | .UID                      | UID of volume                                |
 | .VolumeConfigResponse ... | Don't use                                    |
 
-#### **--help**
-
-Print usage statement.
 
 @@option noheading
 

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -57,11 +57,6 @@ The `until` *filter* can be Unix timestamps, date formatted timestamps, or Go du
 
 Do not prompt for confirmation.
 
-#### **--help**
-
-Print usage statement
-
-
 ## EXAMPLES
 
 Prune only anonymous unused volumes (default).

--- a/docs/source/markdown/podman-volume-rm.1.md
+++ b/docs/source/markdown/podman-volume-rm.1.md
@@ -24,10 +24,6 @@ Remove all volumes.
 Remove a volume by force.
 If it is being used by containers, the containers are removed first.
 
-#### **--help**
-
-Print usage statement
-
 #### **--time**, **-t**=*seconds*
 
 Seconds to wait before forcibly stopping running containers that are using the specified volume. The --force option must be specified to use the --time option. Use -1 for infinite wait.

--- a/docs/source/markdown/podman-wait.1.md.in
+++ b/docs/source/markdown/podman-wait.1.md.in
@@ -33,11 +33,6 @@ Container state or condition to wait for.  Can be specified multiple times where
 #### **--exit-first-match**
 Wait for exit of first container which matches conditions, ignore other ones.
 
-#### **--help**, **-h**
-
- Print usage statement
-
-
 #### **--ignore**
 Ignore errors when a specified container is missing and mark its return code as -1.
 

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -55,10 +55,6 @@ Backend to use for storing events. Allowed values are **file**, **journald**, an
 **none**. When *file* is specified, the events are stored under
 `<tmpdir>/events/events.log` (see **--tmpdir** below).
 
-#### **--help**, **-h**
-
-Print usage statement
-
 #### **--hooks-dir**=*path*
 
 Each `*.json` file in the path configures a hook for Podman containers.  For more details on the syntax of the JSON files and the semantics of hook injection, see `oci-hooks(5)`.  Podman and libpod currently support both the 1.0.0 and 0.1.0 hook schemas, although the 0.1.0 schema is deprecated.


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Removed '--help' command line argument from man page documentation.
-->

```release-note
Removed '--help' command line argument from man page documentation.
```
