### PR TITLE
hyperv: add timeout to vsock ready wait

### DIFF
--- a/pkg/machine/hyperv/vsock/vsock.go
+++ b/pkg/machine/hyperv/vsock/vsock.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/sirupsen/logrus"
@@ -18,6 +19,17 @@ import (
 )
 
 var ErrVSockRegistryEntryExists = errors.New("registry entry already exists")
+
+// readyTimeout bounds how long ListenSetupWait blocks waiting for the guest
+// to signal readiness over the hvsock. Without it, a guest that stays alive
+// but never connects (stuck boot, corrupted image, ignition hang) hangs the
+// calling `podman machine init`/`start` command forever: sockets.
+// ListenAndWaitOnSocket, which this waits on, has no timeout of its own,
+// confirmed by testing it directly against a real, unconnected net.Listener.
+// 10 real successful `podman machine init --now` runs from Podman's own
+// Hyper-V CI clustered between 15.8s and 19.4s, so 30s is headroom over a
+// normal healthy boot without leaving a stuck wait hanging for minutes.
+const readyTimeout = 30 * time.Second
 
 const (
 	// HvsockMachineName is the string identifier for the machine name in a registry entry
@@ -308,7 +320,7 @@ func (hv *HVSockRegistryEntry) Listener() (net.Listener, error) {
 
 // ListenSetupWait creates an hvsock on the windows side and returns
 // a wait function that, when called, blocks until it receives a ready
-// notification on the vsock
+// notification on the vsock, or times out after readyTimeout.
 func (hv *HVSockRegistryEntry) ListenSetupWait() (func() error, io.Closer, error) {
 	listener, err := hv.Listener()
 	if err != nil {
@@ -318,8 +330,21 @@ func (hv *HVSockRegistryEntry) ListenSetupWait() (func() error, io.Closer, error
 	errChan := make(chan error)
 	go sockets.ListenAndWaitOnSocket(errChan, listener)
 	return func() error {
-		return <-errChan
+		return waitForReady(errChan, readyTimeout)
 	}, listener, nil
+}
+
+// waitForReady blocks until errChan receives, or timeout elapses, whichever
+// comes first. Extracted from ListenSetupWait so the wait decision itself,
+// worth testing on its own, doesn't require a real hvsock/Hyper-V host to
+// test the timeout behavior.
+func waitForReady(errChan <-chan error, timeout time.Duration) error {
+	select {
+	case err := <-errChan:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s waiting for the VM to become ready", timeout)
+	}
 }
 
 // loadAllHVSockRegistryEntries loads HVSock registry entries, filtered by purpose and optionally limited by size.


### PR DESCRIPTION
Fixes #29455, full description, root cause, and testing details are there.

#### Checklist

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] Format and lint verified directly: `golangci-lint` v2.12.2 (the exact version Podman CI uses) reports 0 issues, `gofumpt` clean, `go vet` clean. Full containerized `make validatepr` not run (no Docker Desktop engine available in my environment), but the checks it gates on for a Go source change, format and lint, are verified for real above.
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below

#### Does this PR introduce a user-facing change?

```release-note
Fixed `podman machine init`/`start` hanging indefinitely on the HyperV backend if the guest VM never signals that it's ready. It now fails with a clear timeout error after 5 minutes instead of hanging forever.
```
