### PR TITLE
libpod/events: support secret filter for events

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1607,6 +1607,7 @@ func AutocompleteEventFilter(cmd *cobra.Command, _ []string, toComplete string) 
 		"image=":     func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) },
 		"artifact=":  func(s string) ([]string, cobra.ShellCompDirective) { return getArtifacts(cmd, s) },
 		"pod=":       func(s string) ([]string, cobra.ShellCompDirective) { return getPods(cmd, s, completeDefault) },
+		"secret=":    func(s string) ([]string, cobra.ShellCompDirective) { return getSecrets(cmd, s, completeDefault) },
 		"volume=":    func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
 		"event=":     event,
 		"label=":     nil,

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -114,6 +114,7 @@ filters are supported:
 | image      | [Name or ID] Image name or ID       |
 | label      | [key] or [key=value] label          |
 | pod        | [Name or ID] Pod name or ID         |
+| secret     | [Name or ID] Secret name or ID      |
 | volume     | [Name or ID] Volume name or ID      |
 | type       | Event_type (described above)        |
 

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -195,9 +195,10 @@ func (v *Volume) newVolumeEvent(status events.Status) {
 }
 
 // NewSecretEvent creates a new event for a libpod secret
-func (r *Runtime) NewSecretEvent(status events.Status, secretID string) {
+func (r *Runtime) NewSecretEvent(status events.Status, secretID string, name string) {
 	e := events.NewEvent(status)
 	e.ID = secretID
+	e.Name = name
 	e.Type = events.Secret
 	if err := r.eventer.Write(e); err != nil {
 		logrus.Errorf("Unable to write secret event: %q", err)

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -93,7 +93,7 @@ func (e *Event) ToHumanReadable(truncate bool) string {
 	case Machine, Volume:
 		humanFormat = fmt.Sprintf("%s %s %s %s", e.Time, e.Type, e.Status, e.Name)
 	case Secret:
-		humanFormat = fmt.Sprintf("%s %s %s %s", e.Time, e.Type, e.Status, id)
+		humanFormat = fmt.Sprintf("%s %s %s %s %s", e.Time, e.Type, e.Status, id, e.Name)
 	}
 	return humanFormat
 }

--- a/libpod/events/filters.go
+++ b/libpod/events/filters.go
@@ -67,6 +67,16 @@ func generateEventFilter(filter, filterValue string) (func(e *Event) bool, error
 			// Prefix match with name for consistency with docker
 			return strings.HasPrefix(e.Name, filterValue)
 		}, nil
+	case "SECRET":
+		return func(e *Event) bool {
+			if e.Type != Secret {
+				return false
+			}
+			if e.Name == filterValue {
+				return true
+			}
+			return strings.HasPrefix(e.ID, filterValue)
+		}, nil
 	case "TYPE":
 		return func(e *Event) bool {
 			return string(e.Type) == filterValue

--- a/libpod/events/filters_test.go
+++ b/libpod/events/filters_test.go
@@ -1,0 +1,47 @@
+//go:build linux || freebsd
+
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateEventFilterSecret(t *testing.T) {
+	t.Parallel()
+
+	filterFunc, err := generateEventFilter("secret", "my-secret")
+	require.NoError(t, err)
+	require.NotNil(t, filterFunc)
+
+	// Matching secret event by name
+	secretEvent := &Event{
+		Type: Secret,
+		Name: "my-secret",
+		ID:   "1234567890abcdef",
+	}
+	assert.True(t, filterFunc(secretEvent))
+
+	// Matching secret event by ID prefix
+	filterFuncByID, err := generateEventFilter("secret", "12345")
+	require.NoError(t, err)
+	assert.True(t, filterFuncByID(secretEvent))
+
+	// Non-matching secret event
+	otherSecretEvent := &Event{
+		Type: Secret,
+		Name: "other-secret",
+		ID:   "9876543210fedcba",
+	}
+	assert.False(t, filterFunc(otherSecretEvent))
+
+	// Non-secret event type with same name
+	containerEvent := &Event{
+		Type: Container,
+		Name: "my-secret",
+		ID:   "1234567890abcdef",
+	}
+	assert.False(t, filterFunc(containerEvent))
+}

--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -58,7 +58,7 @@ func (ic *ContainerEngine) SecretCreate(_ context.Context, name string, reader i
 		return nil, err
 	}
 
-	ic.Libpod.NewSecretEvent(events.Create, secretID)
+	ic.Libpod.NewSecretEvent(events.Create, secretID, name)
 
 	return &entities.SecretCreateReport{
 		ID: secretID,
@@ -145,13 +145,18 @@ func (ic *ContainerEngine) SecretRm(_ context.Context, nameOrIDs []string, optio
 		}
 	}
 	for _, nameOrID := range toRemove {
+		var secretName string
+		secr, _ := manager.Lookup(nameOrID)
+		if secr != nil {
+			secretName = secr.Name
+		}
 		deletedID, err := manager.Delete(nameOrID)
 		if options.Ignore && errors.Is(err, secrets.ErrNoSuchSecret) {
 			continue
 		}
 		reports = append(reports, &entities.SecretRmReport{Err: err, ID: deletedID})
 		if err == nil {
-			ic.Libpod.NewSecretEvent(events.Remove, deletedID)
+			ic.Libpod.NewSecretEvent(events.Remove, deletedID, secretName)
 		}
 	}
 

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -5,6 +5,8 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
@@ -59,6 +61,24 @@ var _ = Describe("Podman events", func() {
 		events = resultPrefix.OutputToStringArray()
 		Expect(events).To(HaveLen(1), "number of events")
 		Expect(events[0]).To(ContainSubstring(vname), "event log includes volume name")
+	})
+
+	It("podman events with a secret filter", func() {
+		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
+		Expect(err).ToNot(HaveOccurred())
+
+		sname := "testsecretname"
+		session := podmanTest.Podman([]string{"secret", "create", sname, secretFilePath})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", fmt.Sprintf("secret=%s", sname)})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitCleanly())
+		events := result.OutputToStringArray()
+		Expect(events).To(HaveLen(1), "number of events")
+		Expect(events[0]).To(ContainSubstring(sname), "event log includes secret name")
 	})
 
 	It("podman events with an event filter and container=cid", func() {


### PR DESCRIPTION
### Description
This PR adds support for filtering events by `secret` in `podman events --filter secret=...`.

`events.Secret` is a core event type defined in `libpod/events/config.go`, and secret operations record events with `e.Type = events.Secret`. However, `generateEventFilter` previously lacked a `case "SECRET":` block, causing `podman events --filter secret=<name>` to fail with `Error: SECRET is an invalid filter`.

**Changes included:**
1. Added `case "SECRET":` to `generateEventFilter` (`libpod/events/filters.go`) to match secret events by name or ID prefix.
2. Added `"secret="` key to `keyValueCompletion` in `AutocompleteEventFilter` (`cmd/podman/common/completion.go`) to support shell tab-autocompletion.
3. Added unit tests in `libpod/events/filters_test.go` covering secret event filter matching.

Fixes: #29462

### Checklist
- [x] Commits are signed off with Developer Certificate of Origin (DCO)
- [x] Unit tests have been added and verified

### How this was tested
Verified unit tests locally inside a WSL2 Ubuntu development environment:
```bash
$ go test -v ./libpod/events/...
=== RUN   TestGenerateEventFilterSecret
--- PASS: TestGenerateEventFilterSecret (0.00s)
PASS
ok  	go.podman.io/podman/v6/libpod/events	0.013s
