### PR TITLE
libpod/events: support machine filter for events

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1599,13 +1599,14 @@ func AutocompleteEventFilter(cmd *cobra.Command, _ []string, toComplete string) 
 		return []string{
 			events.Container.String(), events.Image.String(), events.Network.String(),
 			events.Pod.String(), events.System.String(), events.Volume.String(), events.Secret.String(),
-			events.Artifact.String(),
+			events.Artifact.String(), events.Machine.String(),
 		}, cobra.ShellCompDirectiveNoFileComp
 	}
 	kv := keyValueCompletion{
 		"container=": func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeDefault) },
 		"image=":     func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) },
 		"artifact=":  func(s string) ([]string, cobra.ShellCompDirective) { return getArtifacts(cmd, s) },
+		"machine=":   nil,
 		"pod=":       func(s string) ([]string, cobra.ShellCompDirective) { return getPods(cmd, s, completeDefault) },
 		"volume=":    func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
 		"event=":     event,

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -113,6 +113,7 @@ filters are supported:
 | event      | event_status (described above)      |
 | image      | [Name or ID] Image name or ID       |
 | label      | [key] or [key=value] label          |
+| machine    | [Name or ID] Machine name or ID     |
 | pod        | [Name or ID] Pod name or ID         |
 | volume     | [Name or ID] Volume name or ID      |
 | type       | Event_type (described above)        |

--- a/libpod/events/filters.go
+++ b/libpod/events/filters.go
@@ -67,6 +67,16 @@ func generateEventFilter(filter, filterValue string) (func(e *Event) bool, error
 			// Prefix match with name for consistency with docker
 			return strings.HasPrefix(e.Name, filterValue)
 		}, nil
+	case "MACHINE":
+		return func(e *Event) bool {
+			if e.Type != Machine {
+				return false
+			}
+			if e.Name == filterValue {
+				return true
+			}
+			return strings.HasPrefix(e.ID, filterValue)
+		}, nil
 	case "TYPE":
 		return func(e *Event) bool {
 			return string(e.Type) == filterValue

--- a/libpod/events/filters_test.go
+++ b/libpod/events/filters_test.go
@@ -1,0 +1,47 @@
+//go:build linux || freebsd
+
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateEventFilterMachine(t *testing.T) {
+	t.Parallel()
+
+	filterFunc, err := generateEventFilter("machine", "podman-machine-default")
+	require.NoError(t, err)
+	require.NotNil(t, filterFunc)
+
+	// Matching machine event by name
+	machineEvent := &Event{
+		Type: Machine,
+		Name: "podman-machine-default",
+		ID:   "1234567890abcdef",
+	}
+	assert.True(t, filterFunc(machineEvent))
+
+	// Matching machine event by ID prefix
+	filterFuncByID, err := generateEventFilter("machine", "12345")
+	require.NoError(t, err)
+	assert.True(t, filterFuncByID(machineEvent))
+
+	// Non-matching machine event
+	otherMachineEvent := &Event{
+		Type: Machine,
+		Name: "other-machine",
+		ID:   "9876543210fedcba",
+	}
+	assert.False(t, filterFunc(otherMachineEvent))
+
+	// Non-machine event type with same name
+	containerEvent := &Event{
+		Type: Container,
+		Name: "podman-machine-default",
+		ID:   "1234567890abcdef",
+	}
+	assert.False(t, filterFunc(containerEvent))
+}

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -61,6 +61,12 @@ var _ = Describe("Podman events", func() {
 		Expect(events[0]).To(ContainSubstring(vname), "event log includes volume name")
 	})
 
+	It("podman events with a machine filter", func() {
+		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "machine=podman-machine-default"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitCleanly())
+	})
+
 	It("podman events with an event filter and container=cid", func() {
 		_, ec, cid := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))


### PR DESCRIPTION
### Description
This PR adds support for filtering events by `machine` in `podman events --filter machine=...`.

`events.Machine` is a core event type defined in `libpod/events/config.go`, representing Podman Machine VM lifecycle events (start, stop, init, remove). However, `generateEventFilter` previously lacked a `case "MACHINE":` block, causing `podman events --filter machine=<name>` to fail with `Error: MACHINE is an invalid filter`.

**Changes included:**
1. Added `case "MACHINE":` to `generateEventFilter` (`libpod/events/filters.go`) matching machine events by name or ID prefix.
2. Added `events.Machine.String()` and `"machine="` key in `AutocompleteEventFilter` (`cmd/podman/common/completion.go`).
3. Updated `podman-events.1.md` manpage to document the `machine` filter option.
4. Added unit tests with `//go:build linux || freebsd` build tag in `libpod/events/filters_test.go` and Ginkgo E2E test in `test/e2e/events_test.go`.

Fixes: #<your-issue-number-here>

### Checklist
- [x] Commits are signed off with Developer Certificate of Origin (DCO)
- [x] Unit tests have been added and verified

### How this was tested
Verified unit tests locally inside a WSL2 Ubuntu development environment:
```bash
$ go test -v ./libpod/events/...
=== RUN   TestGenerateEventFilterMachine
--- PASS: TestGenerateEventFilterMachine (0.00s)
PASS
ok  	go.podman.io/podman/v6/libpod/events	0.014s
