### PR TITLE
pkg/specgen: fix volume string splitting for destination drive letter

### DIFF
--- a/pkg/machine/vmconfigs/volumes_windows.go
+++ b/pkg/machine/vmconfigs/volumes_windows.go
@@ -6,11 +6,17 @@ import (
 )
 
 func pathsFromVolume(volume string) []string {
-	paths := strings.SplitN(volume, ":", 3)
+	paths := strings.Split(volume, ":")
 	driveLetterMatcher := regexp.MustCompile(`^(?:\\\\[.?]\\)?[a-zA-Z]$`)
 	if len(paths) > 1 && driveLetterMatcher.MatchString(paths[0]) {
-		paths = strings.SplitN(volume, ":", 4)
-		paths = append([]string{paths[0] + ":" + paths[1]}, paths[2:]...)
+		first := paths[0] + ":" + paths[1]
+		paths = paths[1:]
+		paths[0] = first
+		if len(paths) > 2 && driveLetterMatcher.MatchString(paths[1]) {
+			second := paths[1] + ":" + paths[2]
+			paths = append(paths[:1], paths[2:]...)
+			paths[1] = second
+		}
 	}
 	return paths
 }

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -258,11 +259,16 @@ func SplitVolumeString(vol string) []string {
 		return parts
 	}
 
-	// Case: Windows absolute path (e.g., "C:/Users:/mnt:ro")
+	// Case: Windows absolute path (e.g., "C:/Users:/mnt:ro" or "C:/Users:D:/mnt:ro")
 	if hasWinDriveScheme(vol, n) {
 		first := parts[0] + ":" + parts[1]
 		parts = parts[1:]
 		parts[0] = first
+		if len(parts) > 2 && len(parts[1]) == 1 && unicode.IsLetter(rune(parts[1][0])) {
+			second := parts[1] + ":" + parts[2]
+			parts = append(parts[:1], parts[2:]...)
+			parts[1] = second
+		}
 	}
 
 	return parts

--- a/pkg/specgen/volumes_linux_test.go
+++ b/pkg/specgen/volumes_linux_test.go
@@ -60,6 +60,22 @@ func TestSplitVolumeString(t *testing.T) {
 			volume: "a:/container:ro",
 			expect: []string{"a", "/container", "ro"},
 		},
+		// identical source and destination paths
+		{
+			name:   "identical source and dest absolute path",
+			volume: "/Users/foo/bar:/Users/foo/bar",
+			expect: []string{"/Users/foo/bar", "/Users/foo/bar"},
+		},
+		{
+			name:   "identical source and dest absolute path with ro",
+			volume: "/Users/foo/bar:/Users/foo/bar:ro",
+			expect: []string{"/Users/foo/bar", "/Users/foo/bar", "ro"},
+		},
+		{
+			name:   "identical source and dest absolute path with rw",
+			volume: "/Users/foo/bar:/Users/foo/bar:rw",
+			expect: []string{"/Users/foo/bar", "/Users/foo/bar", "rw"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/specgen/volumes_windows_test.go
+++ b/pkg/specgen/volumes_windows_test.go
@@ -65,6 +65,21 @@ func TestSplitVolumeString(t *testing.T) {
 			volume: "a:/container:ro",
 			expect: []string{"a", "/container", "ro"},
 		},
+		{
+			name:   "windows source and destination drive letter with option",
+			volume: "C:\\hello:C:\\hello:ro",
+			expect: []string{"C:\\hello", "C:\\hello", "ro"},
+		},
+		{
+			name:   "windows source and different destination drive letter with option",
+			volume: "C:\\hello:D:\\container:ro",
+			expect: []string{"C:\\hello", "D:\\container", "ro"},
+		},
+		{
+			name:   "windows source and destination drive letter without option",
+			volume: "C:\\hello:C:\\hello",
+			expect: []string{"C:\\hello", "C:\\hello"},
+		},
 	}
 
 	t.Run("shouldResolveWinPaths() returns true", func(t *testing.T) {


### PR DESCRIPTION
#### Description

When volume strings contain Windows-style drive letters in both the source and destination paths (e.g. C:\src:C:\dst:ro or C:\src:C:\src), SplitVolumeString in pkg/specgen and pathsFromVolume in pkg/machine/vmconfigs previously only recombined the drive letter scheme for the source path (parts[0] + parts[1]). This left the destination drive letter split across separate array elements, resulting in volume parsing errors or destination path corruption.

This patch updates both functions to check whether the destination path segment also begins with a single-letter Windows drive scheme and recombines parts[1] and parts[2] accordingly.

Fixes #29386

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a volume parsing bug where volume strings with Windows drive letters in both source and destination paths failed to parse correctly.
```
