### PR TITLE
hack/ci: fix the CI failure summary for non-int suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ help: ## Print this help message
 	hack/ci/pr-removes-fixed-skips.t
 	hack/ci/pr-should-include-tests.t
 	hack/ci/logformatter.t
+	hack/ci/github_log_summary_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/hack/ci/github_log_summary.py
+++ b/hack/ci/github_log_summary.py
@@ -1,8 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from html.parser import HTMLParser
-import html
+import os
 import sys
+
+# The classes logformatter only ever emits for its ginkgo layout. Its bats
+# layout marks failures with 'bats-' classes instead.
+GINKGO_CLASS = 'log-failed'
+GINKGO_CLASS_PREFIX = 'ginkgo-'
+
+# Only ginkgo run under -p puts the [FAILED] marker on the line logformatter
+# reads the test status from, so a suite run without it - bindings, for one -
+# heads every test with 'log-passed' and leaves the stack trace as the sole
+# mark of a failure. Match that on the element rather than the class alone:
+# logformatter wraps the trace in a div, while the logrus lines and summary
+# links sharing the class are spans, and those appear in passing tests too.
+FAILURE_BLOCK_TAG = 'div'
+FAILURE_BLOCK_CLASS = 'log-error'
 
 class GinkgoLogFilterParser(HTMLParser):
     def __init__(self):
@@ -11,6 +25,8 @@ class GinkgoLogFilterParser(HTMLParser):
         self.stack = []
         # Store the raw HTML strings of matching 'tt' elements
         self.results = []
+        # Set once a class only the ginkgo layout emits has been seen
+        self.is_ginkgo = False
 
     def _get_classes(self, attrs):
         """Helper to extract classes from an attribute list."""
@@ -19,12 +35,27 @@ class GinkgoLogFilterParser(HTMLParser):
                 return value.split()
         return []
 
+    def _detect_ginkgo(self, classes):
+        """Note the classes logformatter only emits for the ginkgo layout."""
+        if any(c == GINKGO_CLASS or c.startswith(GINKGO_CLASS_PREFIX)
+               for c in classes):
+            self.is_ginkgo = True
+
+    def _marks_failure(self, tag, classes):
+        """Whether this element marks the block around it as a failure."""
+        if GINKGO_CLASS in classes:
+            return True
+        # Deliberately not fed to _detect_ginkgo: bats logs carry this class
+        # too, on any logrus line logged at error level.
+        return tag == FAILURE_BLOCK_TAG and FAILURE_BLOCK_CLASS in classes
+
     def handle_starttag(self, tag, attrs):
         classes = self._get_classes(attrs)
         is_tt = 'tt' in classes
-        is_failed = 'log-failed' in classes
+        is_failed = self._marks_failure(tag, classes)
+        self._detect_ginkgo(classes)
 
-        # If we see a 'log-failed' class, flag all 'tt' ancestors in the stack
+        # If we see a failure mark, flag all 'tt' ancestors in the stack
         if is_failed:
             for node in self.stack:
                 if node['is_tt']:
@@ -41,7 +72,8 @@ class GinkgoLogFilterParser(HTMLParser):
     def handle_startendtag(self, tag, attrs):
         # Handle self-closing tags just to check for the failure class
         classes = self._get_classes(attrs)
-        if 'log-failed' in classes:
+        self._detect_ginkgo(classes)
+        if self._marks_failure(tag, classes):
             for node in self.stack:
                 if node['is_tt']:
                     node['keep'] = True
@@ -64,7 +96,7 @@ class GinkgoLogFilterParser(HTMLParser):
                     # Trim down the spaces for the ginkgo long indentation.
                     node_text = node_text.removeprefix(' ' * 9)
 
-                    # If this is a 'tt' element and it contains a 'log-failed' child, save the text
+                    # If this is a 'tt' element holding a failure mark, save the text
                     if node['is_tt'] and node['keep']:
                         self.results.append(node_text)
 
@@ -105,24 +137,53 @@ class BatsLogFilterParser(HTMLParser):
 
 
 def filter_html_file(file_path):
-    # Read the HTML content
-    with open(file_path, 'r', encoding='utf-8') as f:
+    # Read the HTML content. logformatter passes its input through ':utf8',
+    # which does not validate, so a test that wrote raw bytes leaves us with a
+    # log we must not choke on.
+    with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
         html_content = f.read()
 
-    if 'int-' in file_path:
-        parser = GinkgoLogFilterParser()
-        parser.feed(html_content)
-        return parser.results
+    # logformatter picks the ginkgo or bats layout from the log contents, so
+    # tell them apart the same way here. The file name is no guide: int is not
+    # the only ginkgo suite, bindings is one too.
+    ginkgo_parser = GinkgoLogFilterParser()
+    ginkgo_parser.feed(html_content)
+    if ginkgo_parser.is_ginkgo:
+        return ginkgo_parser.results
 
-    parser = BatsLogFilterParser()
-    parser.feed(html_content)
-    return [parser.data]
+    bats_parser = BatsLogFilterParser()
+    bats_parser.feed(html_content)
+    return [bats_parser.data]
 
 
-# Running the filter
-matching_elements = filter_html_file(sys.argv[1])
+def main(file_paths):
+    if not file_paths:
+        print(f"usage: {os.path.basename(sys.argv[0])} LOGFILE.html...", file=sys.stderr)
+        return 2
 
-for element in matching_elements:
-    print(f"```")
-    print(element)
-    print("```")
+    with_headings = len(file_paths) > 1
+
+    for file_path in file_paths:
+        try:
+            matching_elements = filter_html_file(file_path)
+        except OSError as e:
+            # The caller passes a glob, which the shell hands over unexpanded
+            # when a job produced no html log at all.
+            print(f"skipping {file_path}: {e}", file=sys.stderr)
+            continue
+
+        if with_headings:
+            print(f"### {os.path.basename(file_path)}")
+
+        for element in matching_elements:
+            if not element.strip():
+                continue
+            print("```")
+            print(element)
+            print("```")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/hack/ci/github_log_summary_test.py
+++ b/hack/ci/github_log_summary_test.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+
+"""
+Verify github_log_summary.py picks the right parser and reports every log
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from github_log_summary import GINKGO_CLASS, GINKGO_CLASS_PREFIX
+
+# Assumes directory structure of this file relative to repo.
+SCRIPT_DIRPATH = os.path.dirname(os.path.realpath(__file__))
+SCRIPT = os.path.join(SCRIPT_DIRPATH, 'github_log_summary.py')
+LOGFORMATTER = os.path.join(SCRIPT_DIRPATH, 'logformatter')
+
+# The stylesheet logformatter writes into every log names all the classes, so a
+# summary that looked for them in the raw html would call any log a ginkgo one.
+STYLE = """<style type="text/css">
+.log-failed   { color: #F00; font-weight: bold; font-size: 150%; }
+.log-passed   { color: #393; }
+.log-error    { background: #fee; color: #900; font-weight: bold; }
+.ginkgo-timeline   { margin-top: 1ex; margin-bottom: 1ex; }
+.bats-failed    { color: #F00; font-weight: bold; }
+.bats-log-failblock { color: #b00; background-color: #fee; }
+</style>"""
+
+GINKGO_FAILURE = "Expected error to be nil, got: exit status 125"
+GINKGO_LOG = f"""<html><head>{STYLE}</head><body>
+<div class='tt'>
+<span class="timestamp">[+0298s] </span><span class="log-failed">[FAILED]</span>
+<span class="timestamp">         </span><a name='t--Podman-pod-create--1' /><h2 class="log-failed">  Podman pod create</h2>
+<span class="timestamp">         </span>  {GINKGO_FAILURE}
+</div>
+</body></html>"""
+
+BATS_FAILURE = "# #| FAIL: exit code is 1; expected 0"
+BATS_LOG = f"""<html><head>{STYLE}</head><body>
+<div class='tt'>
+<span class="timestamp">[+0017s] </span>time=<span class='log-error'>2026-09-11T10:00:00Z</span> level=<span class='log-error'>error</span> msg=<span class='log-error'>cannot remove container: in use</span>
+<span class="timestamp">[+0018s] </span><span class='bats-failed'><a name='t--00002'>not ok 2 podman images</a></span>
+<span class="timestamp">         </span><span class='bats-log-failblock'>{BATS_FAILURE}</span>
+</div>
+</body></html>"""
+
+# Shape of a suite run without -p, where ginkgo reports the status too late for
+# logformatter to pick it up, so every test heads 'log-passed' and only the
+# stack trace div tells the failure apart. Taken from ginkgo 2.32.1 output run
+# under the flags `make testbindings` uses.
+PASSING_TEST_NOISE = "level=error msg=cannot connect, retrying"
+NO_PARALLEL_LOG = f"""<html><head>{STYLE}</head><body>
+<div class='tt'>
+<span class="timestamp">[+0000s] </span><h2 class="log-passed">Podman containers podman inspect a container</h2>
+<span class="timestamp">         </span><span class='log-error'>{PASSING_TEST_NOISE}</span>
+</div>
+<hr />
+<div class='tt'>
+<span class="timestamp">[+0000s] </span><h2 class="log-passed">Podman containers podman start a container</h2>
+<div class='log-error'>
+<span class="timestamp">         </span><h2 class="log-passed">  [FAILED] in [It] - containers_test.go:23</h2>
+<span class="timestamp">         </span>  {GINKGO_FAILURE}
+</div>
+</div>
+<hr />
+<div class='tt'>
+<span class="ginkgo-final-fail">FAIL!</span> -- <span class="bats-passed"><b>1</b> Passed</span> | <span class="bats-failed"><b>1</b> Failed</span>
+</div>
+</body></html>"""
+
+# logformatter nests the stack trace div inside another and does not always
+# close them, which the real bindings logs show two levels deep.
+FIRST_NESTED = "first failure, two divs deep"
+SECOND_NESTED = "second failure, also nested"
+NESTED_FAILURES_LOG = f"""<html><head>{STYLE}</head><body>
+<div class='tt'>
+<h2 class="log-passed">Podman info podman info</h2>
+<div class='log-error'>
+<div class='log-error'>
+<span class="timestamp">         </span>  {FIRST_NESTED}
+</div>
+</div>
+<hr />
+<div class='tt'>
+<h2 class="log-passed">Podman info podman info container counts</h2>
+<div class='log-error'>
+<div class='log-error'>
+<span class="timestamp">         </span>  {SECOND_NESTED}
+</div>
+<hr />
+<div class='tt'>
+<span class="ginkgo-final-fail">FAIL!</span> -- <span class="bats-failed"><b>2</b> Failed</span>
+</div>
+</body></html>"""
+
+# A job that died before any test ran carries neither layout's markers.
+UNMARKED_LOG = f"""<html><head>{STYLE}</head><body>
+<div class='tt'>
+<span class="timestamp">[+0004s] </span>make: *** [Makefile:1: binaries] Error 2
+</div>
+</body></html>"""
+
+
+class TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def write_log(self, name, content):
+        path = os.path.join(self.tmpdir.name, name)
+        with open(path, 'w') as log:
+            log.write(content)
+        return path
+
+    def summarize(self, *args):
+        return subprocess.run([sys.executable, SCRIPT, *args],
+                              capture_output=True, text=True)
+
+    def test_ginkgo_log_not_named_int(self):
+        """bindings is a ginkgo suite too, its failures must be reported"""
+        log = self.write_log('bindings-root-fedora-current.log.html', GINKGO_LOG)
+        result = self.summarize(log)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(GINKGO_FAILURE, result.stdout)
+
+    def test_bats_log(self):
+        log = self.write_log('sys-local-root-fedora-current.log.html', BATS_LOG)
+        result = self.summarize(log)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(BATS_FAILURE, result.stdout)
+
+    def test_all_given_logs_are_summarized(self):
+        """the workflow passes a glob, none of the matches may be dropped"""
+        result = self.summarize(
+            self.write_log('int-local-root-fedora-current.log.html', GINKGO_LOG),
+            self.write_log('sys-local-root-fedora-current.log.html', BATS_LOG))
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(GINKGO_FAILURE, result.stdout)
+        self.assertIn(BATS_FAILURE, result.stdout)
+        self.assertLess(result.stdout.index(GINKGO_FAILURE),
+                        result.stdout.index(BATS_FAILURE),
+                        msg="logs must be reported in the order given")
+
+    def test_logs_are_named_only_when_there_is_more_than_one(self):
+        """a single log needs no heading, several would run into each other"""
+        one = self.write_log('int-local-root-fedora-current.log.html', GINKGO_LOG)
+        self.assertNotIn('###', self.summarize(one).stdout)
+
+        two = self.write_log('sys-local-root-fedora-current.log.html', BATS_LOG)
+        stdout = self.summarize(one, two).stdout
+        self.assertIn(f"### {os.path.basename(one)}", stdout)
+        self.assertIn(f"### {os.path.basename(two)}", stdout)
+
+    def test_ginkgo_suite_run_without_parallel(self):
+        """without -p the stack trace div is the only mark of a failure"""
+        log = self.write_log('bindings-root-fedora-current.log.html', NO_PARALLEL_LOG)
+        result = self.summarize(log)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(GINKGO_FAILURE, result.stdout)
+
+    def test_logrus_error_does_not_mark_a_passing_test(self):
+        """that class also lands on error-level logrus lines, as a span"""
+        log = self.write_log('bindings-root-fedora-current.log.html', NO_PARALLEL_LOG)
+        self.assertNotIn(PASSING_TEST_NOISE, self.summarize(log).stdout)
+
+    def test_bats_log_holding_a_logrus_error(self):
+        """that class must not pull a bats log over to the ginkgo parser"""
+        log = self.write_log('sys-local-root-fedora-current.log.html', BATS_LOG)
+        result = self.summarize(log)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(BATS_FAILURE, result.stdout)
+
+    def test_nested_and_unclosed_failure_divs(self):
+        """logformatter nests the trace div and leaves some of them open"""
+        log = self.write_log('bindings-root-fedora-current.log.html',
+                             NESTED_FAILURES_LOG)
+        result = self.summarize(log)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(FIRST_NESTED, result.stdout)
+        self.assertIn(SECOND_NESTED, result.stdout)
+
+    def test_an_unreadable_log_between_two_good_ones(self):
+        """one bad path must not cost us the logs listed after it"""
+        first = self.write_log('int-local-root-fedora-current.log.html', GINKGO_LOG)
+        empty = self.write_log('unit-fedora-current.log.html', '')
+        last = self.write_log('sys-local-root-fedora-current.log.html', BATS_LOG)
+        result = self.summarize(first, os.path.join(self.tmpdir.name, '*.html'),
+                                empty, last)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(GINKGO_FAILURE, result.stdout)
+        self.assertIn(BATS_FAILURE, result.stdout)
+        self.assertLess(result.stdout.index(GINKGO_FAILURE),
+                        result.stdout.index(BATS_FAILURE))
+        self.assertIn('skipping', result.stderr)
+
+    def test_every_failure_block_is_reported(self):
+        """ginkgo logs hold one block per failing test, not just one in total"""
+        second = GINKGO_FAILURE.replace('125', '126')
+        log = self.write_log('int-local-root-fedora-current.log.html',
+                             GINKGO_LOG + GINKGO_LOG.replace(GINKGO_FAILURE, second))
+        result = self.summarize(log)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(GINKGO_FAILURE, result.stdout)
+        self.assertIn(second, result.stdout)
+
+    def test_log_without_failures_says_nothing(self):
+        """an empty code fence is noise, the step summary is better off blank"""
+        log = self.write_log('build-fedora-current.log.html', UNMARKED_LOG)
+        result = self.summarize(log)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout, '')
+
+    def test_log_holding_invalid_utf8(self):
+        """logformatter reads through ':utf8', which lets raw bytes past"""
+        path = os.path.join(self.tmpdir.name, 'int-local-root-fedora-current.log.html')
+        with open(path, 'wb') as log:
+            log.write(GINKGO_LOG.encode().replace(b'exit status 125',
+                                                  b'exit status \xff\xfe125'))
+        result = self.summarize(path)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn('Expected error to be nil', result.stdout)
+
+    def test_logformatter_still_emits_the_classes_we_look_for(self):
+        """the layout is detected by classes logformatter has to keep emitting"""
+        with open(LOGFORMATTER) as source:
+            body = source.read()
+        self.assertIn(GINKGO_CLASS, body)
+        self.assertIn(GINKGO_CLASS_PREFIX, body)
+
+    def test_unreadable_log_is_skipped(self):
+        """jobs without any html log hand over an unexpanded glob"""
+        result = self.summarize(
+            os.path.join(self.tmpdir.name, '*.html'),
+            self.write_log('sys-local-root-fedora-current.log.html', BATS_LOG))
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn(BATS_FAILURE, result.stdout)
+        self.assertIn('skipping', result.stderr)
+
+    def test_no_logs_given(self):
+        result = self.summarize()
+        self.assertEqual(result.returncode, 2)
+        self.assertIn('usage', result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The step summary for a failed CI job is useless when the failing suite is `bindings`: it carries a bare failure count and never the failure itself.

Two reasons stack up. `github_log_summary.py` picks the parser from the log filename, treating only `int-` logs as Ginkgo, so the Ginkgo-based `bindings` log goes to the Bats parser and finds nothing past Ginkgo's summary count. Fixing that alone leaves the summary empty instead, because the existing failure filter only looks for `log-failed`, while `make testbindings` does not pass `-p` and records the actual failures as `div.log-error`.

* Pick the parser from the log contents, the way `logformatter` decides its own layout
* Treat a `log-error` div as a failure mark, which covers suites run without `-p`
* Read every path given rather than only `argv[1]`, since the workflow passes a glob
* Skip logs that cannot be opened or decoded instead of raising

Matching the div rather than the class alone matters: `logformatter` gives `log-error` to the error-level logrus lines that passing tests emit too, but those are spans. The last two issues were masked by the `|| true` on the workflow step.

## Tests

Ten of the fifteen cases in the new `hack/ci/github_log_summary_test.py` fail against the current implementation; the remaining cases guard the span/div distinction and the Ginkgo/Bats class detection.

The fixtures match a real run: podman built from this branch, one assertion in `pkg/bindings/test/info_test.go` broken on purpose, `bindings` run under the flags `make testbindings` uses. That log carries no `log-failed` at all, and the summary now reports both failing specs with their stack traces.


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```



