### PR TITLE
quadlet: handle missing HOME in rootless configuration lookup

### DIFF
--- a/pkg/systemd/quadlet/unitdirs.go
+++ b/pkg/systemd/quadlet/unitdirs.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"go.podman.io/podman/v6/pkg/logiface"
+	"go.podman.io/podman/v6/pkg/util"
 )
 
 // This returns whether a file has an extension recognized as a valid Quadlet unit type.
@@ -230,6 +231,12 @@ func getRootlessDirs(paths *searchPaths, nonNumericFilter, userLevelFilter func(
 	}
 
 	configDir, err := os.UserConfigDir()
+	if os.Getenv("XDG_CONFIG_HOME") == "" {
+		home, found := os.LookupEnv("HOME")
+		if !found || home == "" || home == string(os.PathSeparator) {
+			configDir, err = util.GetRootlessConfigHomeDir()
+		}
+	}
 	if err != nil {
 		logiface.Errorf("Warning: %v", err)
 		return

--- a/pkg/util/utils_linux_test.go
+++ b/pkg/util/utils_linux_test.go
@@ -1,8 +1,30 @@
 package util
 
 import (
+	"os/user"
+	"path/filepath"
 	"testing"
 )
+
+func TestGetRootlessConfigHomeDirWithRootHome(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "/")
+
+	configDir, err := GetRootlessConfigHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := filepath.Join(u.HomeDir, ".config")
+	if configDir != expected {
+		t.Fatalf("expected %q, got %q", expected, configDir)
+	}
+}
 
 func TestIsVirtualConsoleDevice(t *testing.T) {
 	testcases := []struct {

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -6,7 +6,10 @@ package util
 //  should work to take darwin from this
 
 import (
+	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 
 	"go.podman.io/podman/v6/pkg/rootless"
 	"go.podman.io/storage/pkg/homedir"
@@ -22,6 +25,13 @@ func GetRootlessRuntimeDir() (string, error) {
 
 // GetRootlessConfigHomeDir returns the config home directory when running as non root
 func GetRootlessConfigHomeDir() (string, error) {
+	if os.Getenv("XDG_CONFIG_HOME") == "" && os.Getenv("HOME") == string(os.PathSeparator) {
+		u, err := user.LookupId(strconv.Itoa(rootless.GetRootlessUID()))
+		if err == nil && u.HomeDir != "" {
+			return filepath.Join(u.HomeDir, ".config"), nil
+		}
+	}
+
 	return homedir.GetConfigHome()
 }
 


### PR DESCRIPTION
## Summary

This addresses [#29284](https://github.com/podman-container-tools/podman/issues/29284), where rootless Quadlet files can be discovered by
`podman quadlet list` but are not loaded by the systemd user generator in the
reproduced `systemd-homed` setup.

I reproduced the issue on Fedora CoreOS 44 using a disposable user created with
`homectl`. The actual user-generator environment was:

```text
HOME=/
XDG_CONFIG_HOME=
XDG_RUNTIME_DIR=/run/user/60104
```

Rootless Quadlet uses `os.UserConfigDir()` to determine the user's configuration
directory. With `HOME=/` and no `XDG_CONFIG_HOME`, this resolves to `/.config`,
so the user's actual `~/.config/containers/systemd` directory is not searched.

User lookup still returns the correct home directory:

```text
quadtest:x:60104:60104:quadtest:/home/quadtest:/bin/bash
```

The change reuses Podman's existing `GetRootlessConfigHomeDir()` path when the
rootless home environment is unusable. For the reproduced `HOME=/` case, the
helper resolves the rootless user's UID using `rootless.GetRootlessUID()` and
uses the home directory returned by the user database.

Normal Quadlet lookup continues to use `os.UserConfigDir()`, and explicit
`XDG_CONFIG_HOME` behavior remains unchanged.

Fixes: #29284

## Reproduction

I created a disposable `systemd-homed` user and placed `pgsql.container` and
`pgsql.pod` under:

```text
/var/home/quadtest/.config/containers/systemd/
```

Before the fix:

- `podman quadlet list` discovered both files but reported them as `Not loaded`.
- `/usr/libexec/podman/quadlet -dryrun -user` from the user's normal login environment generated both units correctly.
- `systemctl --user daemon-reload` generated neither unit.

The actual environment observed for `podman-user-generator` was:

```text
uid=60104
user=quadtest
home=/
xdg_config_home=
xdg_runtime_dir=/run/user/60104
```

Running Quadlet manually with the same `HOME=/` environment reproduced the
discovery failure, narrowing the issue to rootless config-directory resolution
in the generator environment.

## Testing

Added `TestGetRootlessConfigHomeDirWithRootHome` in the Linux util tests to
cover the `HOME=/` regression.

The relevant package tests pass:

```text
$ go test ./pkg/util ./pkg/systemd/quadlet -count=1
ok      go.podman.io/podman/v6/pkg/util
ok      go.podman.io/podman/v6/pkg/systemd/quadlet
```

`git diff --check` also passes.

During the original reproduction, I also built the patched Quadlet binary and
exercised the systemd user-generator path. After:

```text
systemctl --user daemon-reload
```

the previously missing units were generated:

```text
/run/user/60104/systemd/generator/pgsql.service
/run/user/60104/systemd/generator/pgsql-pod.service
```

`make validatepr` was also attempted, but `golangci-lint` was killed with exit
137 on the 2 GB validation VM, so the full validation did not complete.

## Scope

The change is limited to rootless Quadlet source-directory lookup when the
systemd user generator does not receive a usable home directory.

It does not change:

- normal `HOME` handling
- explicit `XDG_CONFIG_HOME` handling
- rootful Quadlet discovery
- `podman quadlet install`