### PR TITLE
feat: Add output format: podman artifact ls --format=json

### DIFF
--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -1,6 +1,7 @@
 package artifact
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -41,6 +42,7 @@ type artifactListOutput struct {
 	Digest       string
 	Repository   string
 	Size         string
+	sizeBytes    int64
 	Tag          string
 	created      time.Time
 	VirtualSize  string
@@ -84,13 +86,8 @@ func list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return outputTemplate(cmd, reports)
-}
-
-func outputTemplate(cmd *cobra.Command, lrs []*entities.ArtifactListReport) error {
-	var err error
 	artifacts := make([]artifactListOutput, 0)
-	for _, lr := range lrs {
+	for _, lr := range reports {
 		var tag string
 		artifactName, err := lr.Artifact.GetName()
 		if err != nil {
@@ -130,12 +127,55 @@ func outputTemplate(cmd *cobra.Command, lrs []*entities.ArtifactListReport) erro
 			Digest:       artifactHash,
 			Repository:   named.Name(),
 			Size:         units.HumanSize(float64(lr.Artifact.TotalSizeBytes())),
+			sizeBytes:    lr.Artifact.TotalSizeBytes(),
 			Tag:          tag,
 			created:      createdTime,
 			VirtualSize:  fmt.Sprintf("%d", lr.Artifact.TotalSizeBytes()),
 			virtualBytes: lr.Artifact.TotalSizeBytes(),
 		})
 	}
+
+	switch {
+	case report.IsJSON(listFlag.format):
+		return writeJSON(artifacts)
+	default:
+		return writeTemplate(cmd, artifacts)
+	}
+}
+
+func writeJSON(artifacts []artifactListOutput) error {
+	type artifact struct {
+		Repository string `json:"Repository,omitempty"`
+		CreatedAt  string
+		Size       int64
+		Tag        string `json:"Tag,omitempty"`
+		Digest     string
+	}
+
+	arti := make([]artifact, 0, len(artifacts))
+
+	for _, e := range artifacts {
+		var a artifact
+		a.Repository = e.Repository
+		a.CreatedAt = e.created.Format(time.RFC3339Nano)
+		a.Size = e.sizeBytes
+		a.Repository = e.Repository
+		a.Tag = e.Tag
+		a.Digest = e.Digest
+
+		arti = append(arti, a)
+	}
+
+	prettyJSON, err := json.MarshalIndent(arti, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(prettyJSON))
+	return nil
+}
+
+func writeTemplate(cmd *cobra.Command, artifacts []artifactListOutput) error {
+	var err error
 
 	headers := report.Headers(artifactListOutput{}, map[string]string{
 		"REPOSITORY": "REPOSITORY",

--- a/docs/source/markdown/podman-artifact-ls.1.md.in
+++ b/docs/source/markdown/podman-artifact-ls.1.md.in
@@ -62,6 +62,19 @@ ab609fad386d 2.097GB
 cd734b558ceb 12.58MB
 ```
 
+List artifact details in json format
+```
+$ podman artifact ls --format json"
+[
+    {
+        "Repository": "quay.io/artifact/foobar1",
+        "CreatedAt": "2026-06-16T00:00:57Z",
+        "Size": 12580000,
+        "Tag": "special",
+        "Digest": "cd734b558ceb"
+    }
+]
+```
 
 
 ## SEE ALSO

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,6 +51,24 @@ var _ = Describe("Podman artifact", func() {
 		// Make sure the names are what we expect
 		Expect(output).To(ContainElement(artifact1Name))
 		Expect(output).To(ContainElement(artifact2Name))
+
+		// --format=json should work, produce valid json
+		listFormatJsonSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "json")
+		Expect(listFormatJsonSession).Should(ExitCleanly())
+		jsonOutput := listFormatJsonSession.OutputToString()
+		Expect(jsonOutput).To(BeValidJSON())
+
+		// --format=json should contain repository and tag fields
+		jsonArtifactsList := []map[string]any{}
+		jsonUnmarshalErr := json.Unmarshal([]byte(jsonOutput), &jsonArtifactsList)
+
+		Expect(jsonUnmarshalErr).ToNot(HaveOccurred())
+		Expect(jsonArtifactsList).ToNot(BeEmpty())
+
+		for _, image := range jsonArtifactsList {
+			Expect(image).To(HaveKey("Repository"))
+			Expect(image).To(HaveKey("Tag"))
+		}
 
 		// Check default digest length (should be 12)
 		defaultFormatSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.Digest}}")


### PR DESCRIPTION
The 'podman artifact ls' command supports a --format flag accepting a go template string. Some commands (eg 'podman image ls') accept a --format=json parameter, and export pure json object to stdout.

This change adds a `--format=json` output mode to artifact lists too.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

Yes, adds a `--format=json` flag. `podman artifact ls --format=json`

```release-note

```
