### PR TITLE
Compat v1.46: support HostConfig.Mounts.TmpfsOptions for containers/create

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -253,8 +253,12 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 			}
 		case mount.TypeTmpfs:
 			if m.TmpfsOptions != nil {
-				addField(&builder, "tmpfs-size", strconv.FormatInt(m.TmpfsOptions.SizeBytes, 10))
-				addField(&builder, "tmpfs-mode", strconv.FormatUint(uint64(m.TmpfsOptions.Mode), 8))
+				if m.TmpfsOptions.SizeBytes != 0 {
+					addField(&builder, "tmpfs-size", strconv.FormatInt(m.TmpfsOptions.SizeBytes, 10))
+				}
+				if m.TmpfsOptions.Mode != 0 {
+					addField(&builder, "tmpfs-mode", strconv.FormatUint(uint64(m.TmpfsOptions.Mode), 8))
+				}
 			}
 		case mount.TypeVolume:
 			if m.VolumeOptions != nil {

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -259,6 +259,19 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 				if m.TmpfsOptions.Mode != 0 {
 					addField(&builder, "tmpfs-mode", strconv.FormatUint(uint64(m.TmpfsOptions.Mode), 8))
 				}
+				for _, opt := range m.TmpfsOptions.Options {
+					switch len(opt) {
+					case 1:
+						if builder.Len() > 0 {
+							builder.WriteRune(',')
+						}
+						builder.WriteString(opt[0])
+					case 2:
+						addField(&builder, opt[0], opt[1])
+					default:
+						return nil, nil, fmt.Errorf("invalid tmpfs format %q,", opt)
+					}
+				}
 			}
 		case mount.TypeVolume:
 			if m.VolumeOptions != nil {

--- a/test/apiv2/44-mounts.at
+++ b/test/apiv2/44-mounts.at
@@ -58,3 +58,18 @@ like "$(tr -d \\0 <$WORKDIR/curl.result.out)" ".*hello1$" "compat mount subpath 
 
 t DELETE containers/${cid}?v=true 204
 podman volume rm "$subpath_vol"
+
+# Compat API: HostConfig.Mounts with TmpfsOptions.Options (Docker API v1.46)
+tmpfs_name2="/mytmpfs2"
+t POST containers/create?name=compat_tmpfs_options_test \
+  Image=$IMAGE \
+  Cmd='["mount"]' \
+  HostConfig='{"Mounts":[{"Type":"tmpfs","Target":"/mytmpfs2","TmpfsOptions":{"Options":[["noexec"],["ro"],["tmpfs-size","67"]]}}]}' \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+
+t GET containers/${cid}/json 200 \
+  .HostConfig.Tmpfs.[\"$tmpfs_name2\"]="noexec,ro,size=67,rprivate,nosuid,nodev,tmpcopyup"
+
+t DELETE containers/${cid}?v=true 204


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [ ] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a bug where setting tmpfs size using the compat create api automatically set mode to 0000
Compat containers/create api now takes Options as part of HostConfig.Mounts.TmpfsOptions to set options for tmpfs mounts.

```
