### PR TITLE
docs: Specify resource_limits shape for CPU quota 

### DIFF
--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -576,6 +576,10 @@ type ContainerResourceConfig struct {
 	// Can only be set as root on cgroups v1 systems, but can be set as
 	// rootless as well for cgroups v2.
 	// Optional.
+	// This follows the OCI runtime-spec LinuxResources layout, e.g. set a
+	// CPU quota with "resource_limits": {"cpu": {"quota": 100000}}.
+	// The Docker-compatible /containers/create endpoint instead takes a
+	// flat "cpu_quota" field - the two are not interchangeable.
 	ResourceLimits *spec.LinuxResources `json:"resource_limits,omitempty"`
 	// Rlimits are POSIX rlimits to apply to the container.
 	// Optional.


### PR DESCRIPTION
… API

Reporter posted "cpu_quota" in the create body for /libpod/containers/create, following the naming of the --cpu-quota CLI flag, and it got silently ignored.

The container was created fine, but the quota was never applied.

There's no top-level cpu_quota field on this endpoint at all. The flat "cpu_quota" field only exists on the separate Docker-compatible /containers/create endpoint, so it's an easy mix-up if you're going off the CLI flag name.

Verified this issue still exists: The flat field is silently dropped, the nested one works as expected (see screenshot below)
<img width="1633" height="188" alt="image" src="https://github.com/user-attachments/assets/11c60333-682a-40b7-b816-2828e5a0458e" />

Added the correct shape as a comment on ResourceLimits in specgen.go, since that's what the libpod create endpoint's generated Swagger docs are sourced from.

Fixes: #19764

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [X] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [X] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [X] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [X] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [X] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [X] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [X] All commits pass `make validatepr` (format/lint checks)
- [X] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
None
```release-note

```
