### PR TITLE
events: fix goroutine leak with until flag in file backend

### DIFF
--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -122,9 +122,15 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 			return err
 		}
 		go func() {
-			time.Sleep(time.Until(untilTime))
-			if err := t.Stop(); err != nil {
-				logrus.Errorf("Stopping logger: %v", err)
+			timer := time.NewTimer(time.Until(untilTime))
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				if err := t.Stop(); err != nil {
+					logrus.Errorf("Stopping logger: %v", err)
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.
-->

**- What I did**
Fixed a goroutine and memory leak in the file events backend when using the `--until` flag. 

Previously, `libpod/events/logfile.go` spawned an unmanaged goroutine using `time.Sleep(time.Until(untilTime))` that ignored `context.Context` cancellation. If a client disconnected early (e.g. dropped API connection or `Ctrl+C`), the goroutine was orphaned and continued sleeping in the background.

I replaced the blocking `time.Sleep` with a `time.NewTimer` and a `select` block that listens for `ctx.Done()`. This ensures the goroutine exits immediately if the client cancels the request, properly freeing system resources and preventing an API denial-of-service vector.

**- How I did it**
- Replaced `time.Sleep` with `time.NewTimer`.
- Added a `select` statement listening to `<-ctx.Done()` and `<-timer.C`.

**- How to verify it**
1. Run `podman system service`
2. Fetch events via the API with a far-future until parameter: `curl -v --unix-socket /run/user/1000/podman/podman.sock "http://d/v4.0.0/libpod/events?until=9999h"`
3. Terminate the curl request (`Ctrl+C`).
4. Verify via pprof or logging that the background routine is destroyed and no longer sleeping.

**- Description for the changelog**
```release-note
Fixed a goroutine leak in the event logger that occurred when an event stream using the `--until` flag was prematurely cancelled by the client.

**- Fixes** 
Fixes #29491