### PR TITLE
compat: Add status for runtimes to GET /info

### DIFF
--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -118,10 +118,11 @@ type ConmonInfo struct {
 // OCIRuntimeInfo describes the runtime (crun or runc) being
 // used with podman
 type OCIRuntimeInfo struct {
-	Name    string `json:"name"`
-	Package string `json:"package"`
-	Path    string `json:"path"`
-	Version string `json:"version"`
+	Name     string `json:"name"`
+	Package  string `json:"package"`
+	Path     string `json:"path"`
+	Version  string `json:"version"`
+	Features string `json:"features,omitempty"`
 }
 
 // StoreInfo describes the container storage and its

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -164,6 +164,10 @@ type OCIRuntime interface { //nolint:interfacebloat
 	// RuntimeInfo returns verbose information about the runtime.
 	RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeInfo, error)
 
+	// RuntimeFeatures returns the raw output of the runtime's "features"
+	// command. It returns an empty string if not supported.
+	RuntimeFeatures() string
+
 	// UpdateContainer updates the given container's cgroup configuration.
 	UpdateContainer(ctr *Container, res *specs.LinuxResources) error
 }

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -5,6 +5,7 @@ package libpod
 import (
 	"bufio"
 	"bytes"
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -66,6 +67,7 @@ type ConmonOCIRuntime struct {
 	supportsNoCgroups bool
 	enableKeyring     bool
 	persistDir        string
+	featuresProvider  func() string
 }
 
 // Make a new Conmon-based OCI runtime with the given options.
@@ -137,6 +139,22 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 		return nil, fmt.Errorf("no valid executable found for OCI runtime %s: %w", name, define.ErrInvalidArg)
 	}
 
+	// Exec the "features" command lazily once.
+	runtime.featuresProvider = sync.OnceValue(func() string {
+		features, err := utils.ExecCmd(runtime.path, "features")
+		if err != nil {
+			logrus.Debugf("Failed to get features for OCI runtime %s: %v", name, err)
+			return ""
+		}
+		// Remove new lines and whitespace to match Docker output.
+		var buf bytes.Buffer
+		if err := stdjson.Compact(&buf, []byte(features)); err != nil {
+			logrus.Debugf("Failed to compact features output for OCI runtime %s: %v", name, err)
+			return ""
+		}
+		return buf.String()
+	})
+
 	runtime.exitsDir = filepath.Join(runtime.tmpDir, "exits")
 	// The persist-dir is where conmon writes the exit file and oom file (if oom killed), we join the container ID to this path later on
 	runtime.persistDir = filepath.Join(runtime.tmpDir, "persist")
@@ -159,6 +177,12 @@ func (r *ConmonOCIRuntime) Name() string {
 // Path returns the path of the OCI runtime being wrapped by Conmon.
 func (r *ConmonOCIRuntime) Path() string {
 	return r.path
+}
+
+// RuntimeFeatures returns the raw output of the runtime's "features"
+// command or an empty string if the runtime does not support it.
+func (r *ConmonOCIRuntime) RuntimeFeatures() string {
+	return r.featuresProvider()
 }
 
 // hasCurrentUserMapped checks whether the current user is mapped inside the container user namespace
@@ -877,10 +901,11 @@ func (r *ConmonOCIRuntime) RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntime
 		Version: conmonVersion,
 	}
 	ocirt := define.OCIRuntimeInfo{
-		Name:    r.name,
-		Path:    r.path,
-		Package: runtimePackage,
-		Version: runtimeVersion,
+		Name:     r.name,
+		Path:     r.path,
+		Package:  runtimePackage,
+		Version:  runtimeVersion,
+		Features: r.featuresProvider(),
 	}
 	return &conmon, &ocirt, nil
 }

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -244,6 +244,11 @@ func (r *MissingRuntime) RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeIn
 	return nil, &ocirt, nil
 }
 
+// RuntimeFeatures returns an empty string on the missing runtime.
+func (r *MissingRuntime) RuntimeFeatures() string {
+	return ""
+}
+
 // Return an error indicating the runtime is missing
 func (r *MissingRuntime) printError() error {
 	return fmt.Errorf("runtime %s is missing: %w", r.name, define.ErrOCIRuntimeNotFound)

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1051,6 +1051,17 @@ func (r *Runtime) DefaultOCIRuntime() OCIRuntime {
 	return r.defaultOCIRuntime
 }
 
+// RuntimeFeatures returns the raw output of an OCI runtime's
+// "features" command by its name.
+// It returns an empty string if the runtime doesn't exist or
+// does not support the command.
+func (r *Runtime) RuntimeFeatures(name string) string {
+	if ociRuntime, ok := r.ociRuntimes[name]; ok {
+		return ociRuntime.RuntimeFeatures()
+	}
+	return ""
+}
+
 // StorageConfig retrieves the storage options for the container runtime
 func (r *Runtime) StorageConfig() storage.StoreOptions {
 	return r.storageConfig

--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -28,6 +28,11 @@ import (
 	"go.podman.io/podman/v6/pkg/rootless"
 )
 
+// ociRuntimeFeaturesKey is the key used for an OCI runtime's
+// status: features.
+// Described in https://github.com/opencontainers/runtime-spec/blob/main/features.md
+const ociRuntimeFeaturesKey = "org.opencontainers.runtime-spec.features"
+
 func GetInfo(w http.ResponseWriter, r *http.Request) {
 	// 200 ok
 	// 500 internal
@@ -111,7 +116,7 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 			ProductLicense:  "Apache-2.0",
 			RegistryConfig:  getServiceConfig(runtime),
 			RuncCommit:      dockerSystem.Commit{},
-			Runtimes:        getRuntimes(configInfo),
+			Runtimes:        getRuntimes(runtime, configInfo),
 			SecurityOptions: getSecOpts(sysInfo, configInfo),
 			ServerVersion:   versionInfo.Version,
 			SwapLimit:       sysInfo.SwapLimit,
@@ -131,6 +136,13 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 		SwapTotal:          infoData.Host.SwapTotal,
 		Uptime:             infoData.Host.Uptime,
 	}
+	// The Status field on runtimes was introduced in the Docker API v1.44.
+	if _, err := utils.SupportedVersion(r, "<1.44.0"); err == nil {
+		for k, rt := range info.Runtimes {
+			info.Runtimes[k] = dockerSystem.RuntimeWithStatus{Runtime: rt.Runtime}
+		}
+	}
+
 	utils.WriteResponse(w, http.StatusOK, info)
 }
 
@@ -204,15 +216,18 @@ func getSecOpts(sysInfo *sysinfo.SysInfo, c *config.Config) []string {
 	return secOpts
 }
 
-func getRuntimes(configInfo *config.Config) map[string]dockerSystem.RuntimeWithStatus {
+func getRuntimes(runtime *libpod.Runtime, configInfo *config.Config) map[string]dockerSystem.RuntimeWithStatus {
 	runtimes := map[string]dockerSystem.RuntimeWithStatus{}
 	for name, paths := range configInfo.Engine.OCIRuntimes {
 		if len(paths) == 0 {
 			continue
 		}
-		runtime := dockerSystem.RuntimeWithStatus{}
-		runtime.Runtime = dockerSystem.Runtime{Path: paths[0], Args: nil}
-		runtimes[name] = runtime
+		rt := dockerSystem.RuntimeWithStatus{}
+		rt.Runtime = dockerSystem.Runtime{Path: paths[0], Args: nil}
+		if features := runtime.RuntimeFeatures(name); features != "" {
+			rt.Status = map[string]string{ociRuntimeFeaturesKey: features}
+		}
+		runtimes[name] = rt
 	}
 	return runtimes
 }

--- a/test/apiv2/45-system.at
+++ b/test/apiv2/45-system.at
@@ -117,4 +117,22 @@ t POST 'libpod/system/prune?volumes=true' params='' 200 .VolumePruneReports[0].I
 
 # TODO add other system prune tests for pods / images
 
+# Default OCI runtime for tests.
+runtime=crun
+
+# Get libpod/info and check OCI runtime status (known fields).
+t GET libpod/info 200 \
+    .host.ociRuntime.name=$runtime \
+    ".host.ociRuntime.features | fromjson | has(\"ociVersionMin\")=true" \
+    ".host.ociRuntime.features | fromjson | has(\"ociVersionMax\")=true"
+
+# Get compat /info (v1.44+) - OCI runtime status.
+t GET info 200 \
+    ".Runtimes.$runtime.status[\"org.opencontainers.runtime-spec.features\"] | fromjson | has(\"ociVersionMin\")=true" \
+    ".Runtimes.$runtime.status[\"org.opencontainers.runtime-spec.features\"] | fromjson | has(\"ociVersionMax\")=true"
+
+# GET compat /info API versions older than v1.44 omit the status field.
+t GET /v1.43/info 200 \
+    ".Runtimes.$runtime | has(\"status\")=false"
+
 # vim: filetype=sh

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -10,7 +10,8 @@ buildahVersion: *[0-9.]\\\+
 conmon:\\\s\\\+package:
 distribution:
 logDriver:
-ociRuntime:\\\s\\\+name:
+ociRuntime:\\\s\\\+features:
+ociRuntime:.* name: [a-z0-9]
 os:
 rootless:
 registries:


### PR DESCRIPTION
Docker [API v1.44](https://docs.docker.com/reference/api/engine/version-history/#v144-api-changes) now includes status properties
in `Runtimes` for the `GET /info endpoint`.

- Read output of `{oci_runtime_cmd} features` command
during lazily and expose the JSON
output as-is (with removed new lines and
whitespace) as the status field in 
`GET /info` for `v1.44+`.
- Add status to libpod `GET /info` as `ociRuntime.features` and `podman info` (shared).
- Add API tests for both endpoints.

Fixes: https://redhat.atlassian.net/browse/RUN-3319

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Add status properties in Runtimes for the compat GET /info endpoint (1.44+).
Add status (features) to libpod GET /info in ociRuntime.Features.
```

### Compat /info Output
```json
 "Runtimes": {
    "crun": {
      "path": "/usr/bin/crun",
      "status": {
        "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",\"ociVersionMax\":\"1.1.0+dev\",\"hooks\":[\"prestart\",\"createRuntime\",\"createContainer\",\"startContainer\",\"poststart\",\"poststop\"],\"mountOptions\":[\"rw\",\"rrw\",\"ro\",\"rro\",\"rdirsync\",\"rdiratime\",\"rnodev\",\"rnorelatime\",\"nodiratime\",\"rnodiratime\",\"dirsync\",\"rnosuid\",\"ratime\",\"diratime\",\"rnoatime\",\"strictatime\",\"rstrictatime\",\"noatime\",\"rnostrictatime\",\"rnomand\",\"rprivate\",\"nostrictatime\",\"rnoexec\",\"nodev\",\"rmand\",\"norelatime\",\"mand\",\"idmap\",\"atime\",\"nomand\",\"rsuid\",\"rbind\",\"suid\",\"bind\",\"rslave\",\"nosuid\",\"defaults\",\"rrelatime\",\"rsync\",\"remount\",\"dest-nofollow\",\"dev\",\"rdev\",\"private\",\"noexec\",\"src-nofollow\",\"sync\",\"relatime\",\"async\",\"rasync\",\"tmpcopyup\",\"shared\",\"rshared\",\"slave\",\"rexec\",\"unbindable\",\"runbindable\",\"exec\",\"copy-symlink\"],\"linux\":{\"namespaces\":[\"cgroup\",\"ipc\",\"mount\",\"network\",\"pid\",\"user\",\"uts\"],\"capabilities\":[\"CAP_CHOWN\",\"CAP_DAC_OVERRIDE\",\"CAP_DAC_READ_SEARCH\",\"CAP_FOWNER\",\"CAP_FSETID\",\"CAP_KILL\",\"CAP_SETGID\",\"CAP_SETUID\",\"CAP_SETPCAP\",\"CAP_LINUX_IMMUTABLE\",\"CAP_NET_BIND_SERVICE\",\"CAP_NET_BROADCAST\",\"CAP_NET_ADMIN\",\"CAP_NET_RAW\",\"CAP_IPC_LOCK\",\"CAP_IPC_OWNER\",\"CAP_SYS_MODULE\",\"CAP_SYS_RAWIO\",\"CAP_SYS_CHROOT\",\"CAP_SYS_PTRACE\",\"CAP_SYS_PACCT\",\"CAP_SYS_ADMIN\",\"CAP_SYS_BOOT\",\"CAP_SYS_NICE\",\"CAP_SYS_RESOURCE\",\"CAP_SYS_TIME\",\"CAP_SYS_TTY_CONFIG\",\"CAP_MKNOD\",\"CAP_LEASE\",\"CAP_AUDIT_WRITE\",\"CAP_AUDIT_CONTROL\",\"CAP_SETFCAP\",\"CAP_MAC_OVERRIDE\",\"CAP_MAC_ADMIN\",\"CAP_SYSLOG\",\"CAP_WAKE_ALARM\",\"CAP_BLOCK_SUSPEND\",\"CAP_AUDIT_READ\",\"CAP_PERFMON\",\"CAP_BPF\",\"CAP_CHECKPOINT_RESTORE\"],\"cgroup\":{\"v1\":true,\"v2\":true,\"systemd\":true,\"systemdUser\":true},\"seccomp\":{\"enabled\":true,\"actions\":[\"SCMP_ACT_ALLOW\",\"SCMP_ACT_ERRNO\",\"SCMP_ACT_KILL\",\"SCMP_ACT_KILL_PROCESS\",\"SCMP_ACT_KILL_THREAD\",\"SCMP_ACT_LOG\",\"SCMP_ACT_NOTIFY\",\"SCMP_ACT_TRACE\",\"SCMP_ACT_TRAP\"],\"operators\":[\"SCMP_CMP_NE\",\"SCMP_CMP_LT\",\"SCMP_CMP_LE\",\"SCMP_CMP_EQ\",\"SCMP_CMP_GE\",\"SCMP_CMP_GT\",\"SCMP_CMP_MASKED_EQ\"]},\"apparmor\":{\"enabled\":true},\"selinux\":{\"enabled\":true},\"mountExtensions\":{\"idmap\":{\"enabled\":true}},\"intelRdt\":{\"enabled\":true},\"netDevices\":{\"enabled\":true},\"memoryPolicy\":{\"modes\":[\"MPOL_DEFAULT\",\"MPOL_PREFERRED\",\"MPOL_BIND\",\"MPOL_INTERLEAVE\",\"MPOL_LOCAL\",\"MPOL_PREFERRED_MANY\",\"MPOL_WEIGHTED_INTERLEAVE\"],\"flags\":[\"MPOL_F_NUMA_BALANCING\",\"MPOL_F_RELATIVE_NODES\",\"MPOL_F_STATIC_NODES\"]}},\"annotations\":{\"io.github.seccomp.libseccomp.version\":\"2.6.0\",\"org.opencontainers.runc.checkpoint.enabled\":\"true\",\"run.oci.crun.checkpoint.enabled\":\"true\",\"run.oci.crun.commit\":\"3ec076b3b6714ec2f1a10533cf18d5605a6de637\",\"run.oci.crun.version\":\"1.27.1\",\"run.oci.crun.wasm\":\"true\"},\"potentiallyUnsafeConfigAnnotations\":[\"module.wasm.image/variant\",\"io.kubernetes.cri.container-type\",\"run.oci.\",\"org.criu.\",\"krun.\"]}"
      }
    },
    "crun-vm": {
      "path": "/usr/bin/crun-vm"
    },
    "crun-wasm": {
      "path": "/usr/bin/crun-wasm"
    },
    "kata": {
      "path": "/usr/bin/kata-runtime"
    },
    "krun": {
      "path": "/usr/bin/krun"
    },
    "ocijail": {
      "path": "/usr/local/bin/ocijail"
    },
    "runc": {
      "path": "/usr/bin/runc",
      "status": {
        "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",\"ociVersionMax\":\"1.3.0\",\"hooks\":[\"prestart\",\"createRuntime\",\"createContainer\",\"startContainer\",\"poststart\",\"poststop\"],\"mountOptions\":[\"async\",\"atime\",\"bind\",\"defaults\",\"dev\",\"diratime\",\"dirsync\",\"exec\",\"iversion\",\"lazytime\",\"loud\",\"mand\",\"noatime\",\"nodev\",\"nodiratime\",\"noexec\",\"noiversion\",\"nolazytime\",\"nomand\",\"norelatime\",\"nostrictatime\",\"nosuid\",\"nosymfollow\",\"private\",\"ratime\",\"rbind\",\"rdev\",\"rdiratime\",\"relatime\",\"remount\",\"rexec\",\"rnoatime\",\"rnodev\",\"rnodiratime\",\"rnoexec\",\"rnorelatime\",\"rnostrictatime\",\"rnosuid\",\"rnosymfollow\",\"ro\",\"rprivate\",\"rrelatime\",\"rro\",\"rrw\",\"rshared\",\"rslave\",\"rstrictatime\",\"rsuid\",\"rsymfollow\",\"runbindable\",\"rw\",\"shared\",\"silent\",\"slave\",\"strictatime\",\"suid\",\"symfollow\",\"sync\",\"tmpcopyup\",\"unbindable\"],\"linux\":{\"namespaces\":[\"cgroup\",\"ipc\",\"mount\",\"network\",\"pid\",\"time\",\"user\",\"uts\"],\"capabilities\":[\"CAP_CHOWN\",\"CAP_DAC_OVERRIDE\",\"CAP_DAC_READ_SEARCH\",\"CAP_FOWNER\",\"CAP_FSETID\",\"CAP_KILL\",\"CAP_SETGID\",\"CAP_SETUID\",\"CAP_SETPCAP\",\"CAP_LINUX_IMMUTABLE\",\"CAP_NET_BIND_SERVICE\",\"CAP_NET_BROADCAST\",\"CAP_NET_ADMIN\",\"CAP_NET_RAW\",\"CAP_IPC_LOCK\",\"CAP_IPC_OWNER\",\"CAP_SYS_MODULE\",\"CAP_SYS_RAWIO\",\"CAP_SYS_CHROOT\",\"CAP_SYS_PTRACE\",\"CAP_SYS_PACCT\",\"CAP_SYS_ADMIN\",\"CAP_SYS_BOOT\",\"CAP_SYS_NICE\",\"CAP_SYS_RESOURCE\",\"CAP_SYS_TIME\",\"CAP_SYS_TTY_CONFIG\",\"CAP_MKNOD\",\"CAP_LEASE\",\"CAP_AUDIT_WRITE\",\"CAP_AUDIT_CONTROL\",\"CAP_SETFCAP\",\"CAP_MAC_OVERRIDE\",\"CAP_MAC_ADMIN\",\"CAP_SYSLOG\",\"CAP_WAKE_ALARM\",\"CAP_BLOCK_SUSPEND\",\"CAP_AUDIT_READ\",\"CAP_PERFMON\",\"CAP_BPF\",\"CAP_CHECKPOINT_RESTORE\"],\"cgroup\":{\"v1\":true,\"v2\":true,\"systemd\":true,\"systemdUser\":true,\"rdma\":true},\"seccomp\":{\"enabled\":true,\"actions\":[\"SCMP_ACT_ALLOW\",\"SCMP_ACT_ERRNO\",\"SCMP_ACT_KILL\",\"SCMP_ACT_KILL_PROCESS\",\"SCMP_ACT_KILL_THREAD\",\"SCMP_ACT_LOG\",\"SCMP_ACT_NOTIFY\",\"SCMP_ACT_TRACE\",\"SCMP_ACT_TRAP\"],\"operators\":[\"SCMP_CMP_EQ\",\"SCMP_CMP_GE\",\"SCMP_CMP_GT\",\"SCMP_CMP_LE\",\"SCMP_CMP_LT\",\"SCMP_CMP_MASKED_EQ\",\"SCMP_CMP_NE\"],\"archs\":[\"SCMP_ARCH_AARCH64\",\"SCMP_ARCH_ARM\",\"SCMP_ARCH_LOONGARCH64\",\"SCMP_ARCH_MIPS\",\"SCMP_ARCH_MIPS64\",\"SCMP_ARCH_MIPS64N32\",\"SCMP_ARCH_MIPSEL\",\"SCMP_ARCH_MIPSEL64\",\"SCMP_ARCH_MIPSEL64N32\",\"SCMP_ARCH_PPC\",\"SCMP_ARCH_PPC64\",\"SCMP_ARCH_PPC64LE\",\"SCMP_ARCH_RISCV64\",\"SCMP_ARCH_S390\",\"SCMP_ARCH_S390X\",\"SCMP_ARCH_X32\",\"SCMP_ARCH_X86\",\"SCMP_ARCH_X86_64\"],\"knownFlags\":[\"SECCOMP_FILTER_FLAG_TSYNC\",\"SECCOMP_FILTER_FLAG_SPEC_ALLOW\",\"SECCOMP_FILTER_FLAG_LOG\"],\"supportedFlags\":[\"SECCOMP_FILTER_FLAG_TSYNC\",\"SECCOMP_FILTER_FLAG_SPEC_ALLOW\",\"SECCOMP_FILTER_FLAG_LOG\"]},\"apparmor\":{\"enabled\":true},\"selinux\":{\"enabled\":true},\"intelRdt\":{\"enabled\":true,\"schemata\":true,\"monitoring\":true},\"memoryPolicy\":{\"modes\":[\"MPOL_BIND\",\"MPOL_DEFAULT\",\"MPOL_INTERLEAVE\",\"MPOL_LOCAL\",\"MPOL_PREFERRED\",\"MPOL_PREFERRED_MANY\",\"MPOL_WEIGHTED_INTERLEAVE\"],\"flags\":[\"MPOL_F_NUMA_BALANCING\",\"MPOL_F_RELATIVE_NODES\",\"MPOL_F_STATIC_NODES\"]},\"mountExtensions\":{\"idmap\":{\"enabled\":true}},\"netDevices\":{\"enabled\":true}},\"annotations\":{\"io.github.seccomp.libseccomp.version\":\"2.6.0\",\"org.opencontainers.runc.checkpoint.enabled\":\"true\",\"org.opencontainers.runc.commit\":\"\",\"org.opencontainers.runc.version\":\"1.4.2\\n\"},\"potentiallyUnsafeConfigAnnotations\":[\"bundle\",\"org.systemd.property.\",\"org.criu.config\"]}"
      }
    },
    "runj": {
      "path": "/usr/local/bin/runj"
    },
    "runsc": {
      "path": "/usr/bin/runsc"
    },
    "youki": {
      "path": "/usr/local/bin/youki"
    }
  },
```

### Docker Engine /info Output
```json
{
  "Runtimes": {
    "io.containerd.runc.v2": {
      "path": "runc",
      "status": {
        "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",\"ociVersionMax\":\"1.3.0\",\"hooks\":[\"prestart\",\"createRuntime\",\"createContainer\",\"startContainer\",\"poststart\",\"poststop\"],\"mountOptions\":[\"async\",\"atime\",\"bind\",\"defaults\",\"dev\",\"diratime\",\"dirsync\",\"exec\",\"iversion\",\"lazytime\",\"loud\",\"mand\",\"noatime\",\"nodev\",\"nodiratime\",\"noexec\",\"noiversion\",\"nolazytime\",\"nomand\",\"norelatime\",\"nostrictatime\",\"nosuid\",\"nosymfollow\",\"private\",\"ratime\",\"rbind\",\"rdev\",\"rdiratime\",\"relatime\",\"remount\",\"rexec\",\"rnoatime\",\"rnodev\",\"rnodiratime\",\"rnoexec\",\"rnorelatime\",\"rnostrictatime\",\"rnosuid\",\"rnosymfollow\",\"ro\",\"rprivate\",\"rrelatime\",\"rro\",\"rrw\",\"rshared\",\"rslave\",\"rstrictatime\",\"rsuid\",\"rsymfollow\",\"runbindable\",\"rw\",\"shared\",\"silent\",\"slave\",\"strictatime\",\"suid\",\"symfollow\",\"sync\",\"tmpcopyup\",\"unbindable\"],\"linux\":{\"namespaces\":[\"cgroup\",\"ipc\",\"mount\",\"network\",\"pid\",\"time\",\"user\",\"uts\"],\"capabilities\":[\"CAP_CHOWN\",\"CAP_DAC_OVERRIDE\",\"CAP_DAC_READ_SEARCH\",\"CAP_FOWNER\",\"CAP_FSETID\",\"CAP_KILL\",\"CAP_SETGID\",\"CAP_SETUID\",\"CAP_SETPCAP\",\"CAP_LINUX_IMMUTABLE\",\"CAP_NET_BIND_SERVICE\",\"CAP_NET_BROADCAST\",\"CAP_NET_ADMIN\",\"CAP_NET_RAW\",\"CAP_IPC_LOCK\",\"CAP_IPC_OWNER\",\"CAP_SYS_MODULE\",\"CAP_SYS_RAWIO\",\"CAP_SYS_CHROOT\",\"CAP_SYS_PTRACE\",\"CAP_SYS_PACCT\",\"CAP_SYS_ADMIN\",\"CAP_SYS_BOOT\",\"CAP_SYS_NICE\",\"CAP_SYS_RESOURCE\",\"CAP_SYS_TIME\",\"CAP_SYS_TTY_CONFIG\",\"CAP_MKNOD\",\"CAP_LEASE\",\"CAP_AUDIT_WRITE\",\"CAP_AUDIT_CONTROL\",\"CAP_SETFCAP\",\"CAP_MAC_OVERRIDE\",\"CAP_MAC_ADMIN\",\"CAP_SYSLOG\",\"CAP_WAKE_ALARM\",\"CAP_BLOCK_SUSPEND\",\"CAP_AUDIT_READ\",\"CAP_PERFMON\",\"CAP_BPF\",\"CAP_CHECKPOINT_RESTORE\"],\"cgroup\":{\"v1\":true,\"v2\":true,\"systemd\":true,\"systemdUser\":true,\"rdma\":true},\"seccomp\":{\"enabled\":true,\"actions\":[\"SCMP_ACT_ALLOW\",\"SCMP_ACT_ERRNO\",\"SCMP_ACT_KILL\",\"SCMP_ACT_KILL_PROCESS\",\"SCMP_ACT_KILL_THREAD\",\"SCMP_ACT_LOG\",\"SCMP_ACT_NOTIFY\",\"SCMP_ACT_TRACE\",\"SCMP_ACT_TRAP\"],\"operators\":[\"SCMP_CMP_EQ\",\"SCMP_CMP_GE\",\"SCMP_CMP_GT\",\"SCMP_CMP_LE\",\"SCMP_CMP_LT\",\"SCMP_CMP_MASKED_EQ\",\"SCMP_CMP_NE\"],\"archs\":[\"SCMP_ARCH_AARCH64\",\"SCMP_ARCH_ARM\",\"SCMP_ARCH_MIPS\",\"SCMP_ARCH_MIPS64\",\"SCMP_ARCH_MIPS64N32\",\"SCMP_ARCH_MIPSEL\",\"SCMP_ARCH_MIPSEL64\",\"SCMP_ARCH_MIPSEL64N32\",\"SCMP_ARCH_PPC\",\"SCMP_ARCH_PPC64\",\"SCMP_ARCH_PPC64LE\",\"SCMP_ARCH_RISCV64\",\"SCMP_ARCH_S390\",\"SCMP_ARCH_S390X\",\"SCMP_ARCH_X32\",\"SCMP_ARCH_X86\",\"SCMP_ARCH_X86_64\"],\"knownFlags\":[\"SECCOMP_FILTER_FLAG_TSYNC\",\"SECCOMP_FILTER_FLAG_SPEC_ALLOW\",\"SECCOMP_FILTER_FLAG_LOG\"],\"supportedFlags\":[\"SECCOMP_FILTER_FLAG_TSYNC\",\"SECCOMP_FILTER_FLAG_SPEC_ALLOW\",\"SECCOMP_FILTER_FLAG_LOG\"]},\"apparmor\":{\"enabled\":true},\"selinux\":{\"enabled\":true},\"intelRdt\":{\"enabled\":true,\"schemata\":true,\"monitoring\":true},\"memoryPolicy\":{\"modes\":[\"MPOL_BIND\",\"MPOL_DEFAULT\",\"MPOL_INTERLEAVE\",\"MPOL_LOCAL\",\"MPOL_PREFERRED\",\"MPOL_PREFERRED_MANY\",\"MPOL_WEIGHTED_INTERLEAVE\"],\"flags\":[\"MPOL_F_NUMA_BALANCING\",\"MPOL_F_RELATIVE_NODES\",\"MPOL_F_STATIC_NODES\"]},\"mountExtensions\":{\"idmap\":{\"enabled\":true}},\"netDevices\":{\"enabled\":true}},\"annotations\":{\"io.github.seccomp.libseccomp.version\":\"2.6.0\",\"org.opencontainers.runc.checkpoint.enabled\":\"true\",\"org.opencontainers.runc.commit\":\"v1.4.0-0-g8bd78a9\",\"org.opencontainers.runc.version\":\"1.4.0\\n\"},\"potentiallyUnsafeConfigAnnotations\":[\"bundle\",\"org.systemd.property.\",\"org.criu.config\"]}"
      }
    },
    "runc": {
      "path": "runc",
      "status": {
        "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",\"ociVersionMax\":\"1.3.0\",\"hooks\":[\"prestart\",\"createRuntime\",\"createContainer\",\"startContainer\",\"poststart\",\"poststop\"],\"mountOptions\":[\"async\",\"atime\",\"bind\",\"defaults\",\"dev\",\"diratime\",\"dirsync\",\"exec\",\"iversion\",\"lazytime\",\"loud\",\"mand\",\"noatime\",\"nodev\",\"nodiratime\",\"noexec\",\"noiversion\",\"nolazytime\",\"nomand\",\"norelatime\",\"nostrictatime\",\"nosuid\",\"nosymfollow\",\"private\",\"ratime\",\"rbind\",\"rdev\",\"rdiratime\",\"relatime\",\"remount\",\"rexec\",\"rnoatime\",\"rnodev\",\"rnodiratime\",\"rnoexec\",\"rnorelatime\",\"rnostrictatime\",\"rnosuid\",\"rnosymfollow\",\"ro\",\"rprivate\",\"rrelatime\",\"rro\",\"rrw\",\"rshared\",\"rslave\",\"rstrictatime\",\"rsuid\",\"rsymfollow\",\"runbindable\",\"rw\",\"shared\",\"silent\",\"slave\",\"strictatime\",\"suid\",\"symfollow\",\"sync\",\"tmpcopyup\",\"unbindable\"],\"linux\":{\"namespaces\":[\"cgroup\",\"ipc\",\"mount\",\"network\",\"pid\",\"time\",\"user\",\"uts\"],\"capabilities\":[\"CAP_CHOWN\",\"CAP_DAC_OVERRIDE\",\"CAP_DAC_READ_SEARCH\",\"CAP_FOWNER\",\"CAP_FSETID\",\"CAP_KILL\",\"CAP_SETGID\",\"CAP_SETUID\",\"CAP_SETPCAP\",\"CAP_LINUX_IMMUTABLE\",\"CAP_NET_BIND_SERVICE\",\"CAP_NET_BROADCAST\",\"CAP_NET_ADMIN\",\"CAP_NET_RAW\",\"CAP_IPC_LOCK\",\"CAP_IPC_OWNER\",\"CAP_SYS_MODULE\",\"CAP_SYS_RAWIO\",\"CAP_SYS_CHROOT\",\"CAP_SYS_PTRACE\",\"CAP_SYS_PACCT\",\"CAP_SYS_ADMIN\",\"CAP_SYS_BOOT\",\"CAP_SYS_NICE\",\"CAP_SYS_RESOURCE\",\"CAP_SYS_TIME\",\"CAP_SYS_TTY_CONFIG\",\"CAP_MKNOD\",\"CAP_LEASE\",\"CAP_AUDIT_WRITE\",\"CAP_AUDIT_CONTROL\",\"CAP_SETFCAP\",\"CAP_MAC_OVERRIDE\",\"CAP_MAC_ADMIN\",\"CAP_SYSLOG\",\"CAP_WAKE_ALARM\",\"CAP_BLOCK_SUSPEND\",\"CAP_AUDIT_READ\",\"CAP_PERFMON\",\"CAP_BPF\",\"CAP_CHECKPOINT_RESTORE\"],\"cgroup\":{\"v1\":true,\"v2\":true,\"systemd\":true,\"systemdUser\":true,\"rdma\":true},\"seccomp\":{\"enabled\":true,\"actions\":[\"SCMP_ACT_ALLOW\",\"SCMP_ACT_ERRNO\",\"SCMP_ACT_KILL\",\"SCMP_ACT_KILL_PROCESS\",\"SCMP_ACT_KILL_THREAD\",\"SCMP_ACT_LOG\",\"SCMP_ACT_NOTIFY\",\"SCMP_ACT_TRACE\",\"SCMP_ACT_TRAP\"],\"operators\":[\"SCMP_CMP_EQ\",\"SCMP_CMP_GE\",\"SCMP_CMP_GT\",\"SCMP_CMP_LE\",\"SCMP_CMP_LT\",\"SCMP_CMP_MASKED_EQ\",\"SCMP_CMP_NE\"],\"archs\":[\"SCMP_ARCH_AARCH64\",\"SCMP_ARCH_ARM\",\"SCMP_ARCH_MIPS\",\"SCMP_ARCH_MIPS64\",\"SCMP_ARCH_MIPS64N32\",\"SCMP_ARCH_MIPSEL\",\"SCMP_ARCH_MIPSEL64\",\"SCMP_ARCH_MIPSEL64N32\",\"SCMP_ARCH_PPC\",\"SCMP_ARCH_PPC64\",\"SCMP_ARCH_PPC64LE\",\"SCMP_ARCH_RISCV64\",\"SCMP_ARCH_S390\",\"SCMP_ARCH_S390X\",\"SCMP_ARCH_X32\",\"SCMP_ARCH_X86\",\"SCMP_ARCH_X86_64\"],\"knownFlags\":[\"SECCOMP_FILTER_FLAG_TSYNC\",\"SECCOMP_FILTER_FLAG_SPEC_ALLOW\",\"SECCOMP_FILTER_FLAG_LOG\"],\"supportedFlags\":[\"SECCOMP_FILTER_FLAG_TSYNC\",\"SECCOMP_FILTER_FLAG_SPEC_ALLOW\",\"SECCOMP_FILTER_FLAG_LOG\"]},\"apparmor\":{\"enabled\":true},\"selinux\":{\"enabled\":true},\"intelRdt\":{\"enabled\":true,\"schemata\":true,\"monitoring\":true},\"memoryPolicy\":{\"modes\":[\"MPOL_BIND\",\"MPOL_DEFAULT\",\"MPOL_INTERLEAVE\",\"MPOL_LOCAL\",\"MPOL_PREFERRED\",\"MPOL_PREFERRED_MANY\",\"MPOL_WEIGHTED_INTERLEAVE\"],\"flags\":[\"MPOL_F_NUMA_BALANCING\",\"MPOL_F_RELATIVE_NODES\",\"MPOL_F_STATIC_NODES\"]},\"mountExtensions\":{\"idmap\":{\"enabled\":true}},\"netDevices\":{\"enabled\":true}},\"annotations\":{\"io.github.seccomp.libseccomp.version\":\"2.6.0\",\"org.opencontainers.runc.checkpoint.enabled\":\"true\",\"org.opencontainers.runc.commit\":\"v1.4.0-0-g8bd78a9\",\"org.opencontainers.runc.version\":\"1.4.0\\n\"},\"potentiallyUnsafeConfigAnnotations\":[\"bundle\",\"org.systemd.property.\",\"org.criu.config\"]}"
      }
    }
  },
}
```

### Libpod /info Output
```json
{
    "ociRuntime": {
      "name": "crun",
      "package": "crun-1.27.1-1.fc43.aarch64",
      "path": "/usr/bin/crun",
      "version": "crun version 1.27.1\ncommit: 3ec076b3b6714ec2f1a10533cf18d5605a6de637\nrundir: /run/crun\nspec: 1.0.0\n+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +LIBKRUN +WASM:wasmedge +YAJL",
      "features": "{\"ociVersionMin\":\"1.0.0\",\"ociVersionMax\":\"1.1.0+dev\",\"hooks\":[\"prestart\",\"createRuntime\",\"createContainer\",\"startContainer\",\"poststart\",\"poststop\"],\"mountOptions\":[\"rw\",\"rrw\",\"ro\",\"rro\",\"rdirsync\",\"rdiratime\",\"rnodev\",\"rnorelatime\",\"nodiratime\",\"rnodiratime\",\"dirsync\",\"rnosuid\",\"ratime\",\"diratime\",\"rnoatime\",\"strictatime\",\"rstrictatime\",\"noatime\",\"rnostrictatime\",\"rnomand\",\"rprivate\",\"nostrictatime\",\"rnoexec\",\"nodev\",\"rmand\",\"norelatime\",\"mand\",\"idmap\",\"atime\",\"nomand\",\"rsuid\",\"rbind\",\"suid\",\"bind\",\"rslave\",\"nosuid\",\"defaults\",\"rrelatime\",\"rsync\",\"remount\",\"dest-nofollow\",\"dev\",\"rdev\",\"private\",\"noexec\",\"src-nofollow\",\"sync\",\"relatime\",\"async\",\"rasync\",\"tmpcopyup\",\"shared\",\"rshared\",\"slave\",\"rexec\",\"unbindable\",\"runbindable\",\"exec\",\"copy-symlink\"],\"linux\":{\"namespaces\":[\"cgroup\",\"ipc\",\"mount\",\"network\",\"pid\",\"user\",\"uts\"],\"capabilities\":[\"CAP_CHOWN\",\"CAP_DAC_OVERRIDE\",\"CAP_DAC_READ_SEARCH\",\"CAP_FOWNER\",\"CAP_FSETID\",\"CAP_KILL\",\"CAP_SETGID\",\"CAP_SETUID\",\"CAP_SETPCAP\",\"CAP_LINUX_IMMUTABLE\",\"CAP_NET_BIND_SERVICE\",\"CAP_NET_BROADCAST\",\"CAP_NET_ADMIN\",\"CAP_NET_RAW\",\"CAP_IPC_LOCK\",\"CAP_IPC_OWNER\",\"CAP_SYS_MODULE\",\"CAP_SYS_RAWIO\",\"CAP_SYS_CHROOT\",\"CAP_SYS_PTRACE\",\"CAP_SYS_PACCT\",\"CAP_SYS_ADMIN\",\"CAP_SYS_BOOT\",\"CAP_SYS_NICE\",\"CAP_SYS_RESOURCE\",\"CAP_SYS_TIME\",\"CAP_SYS_TTY_CONFIG\",\"CAP_MKNOD\",\"CAP_LEASE\",\"CAP_AUDIT_WRITE\",\"CAP_AUDIT_CONTROL\",\"CAP_SETFCAP\",\"CAP_MAC_OVERRIDE\",\"CAP_MAC_ADMIN\",\"CAP_SYSLOG\",\"CAP_WAKE_ALARM\",\"CAP_BLOCK_SUSPEND\",\"CAP_AUDIT_READ\",\"CAP_PERFMON\",\"CAP_BPF\",\"CAP_CHECKPOINT_RESTORE\"],\"cgroup\":{\"v1\":true,\"v2\":true,\"systemd\":true,\"systemdUser\":true},\"seccomp\":{\"enabled\":true,\"actions\":[\"SCMP_ACT_ALLOW\",\"SCMP_ACT_ERRNO\",\"SCMP_ACT_KILL\",\"SCMP_ACT_KILL_PROCESS\",\"SCMP_ACT_KILL_THREAD\",\"SCMP_ACT_LOG\",\"SCMP_ACT_NOTIFY\",\"SCMP_ACT_TRACE\",\"SCMP_ACT_TRAP\"],\"operators\":[\"SCMP_CMP_NE\",\"SCMP_CMP_LT\",\"SCMP_CMP_LE\",\"SCMP_CMP_EQ\",\"SCMP_CMP_GE\",\"SCMP_CMP_GT\",\"SCMP_CMP_MASKED_EQ\"]},\"apparmor\":{\"enabled\":true},\"selinux\":{\"enabled\":true},\"mountExtensions\":{\"idmap\":{\"enabled\":true}},\"intelRdt\":{\"enabled\":true},\"netDevices\":{\"enabled\":true},\"memoryPolicy\":{\"modes\":[\"MPOL_DEFAULT\",\"MPOL_PREFERRED\",\"MPOL_BIND\",\"MPOL_INTERLEAVE\",\"MPOL_LOCAL\",\"MPOL_PREFERRED_MANY\",\"MPOL_WEIGHTED_INTERLEAVE\"],\"flags\":[\"MPOL_F_NUMA_BALANCING\",\"MPOL_F_RELATIVE_NODES\",\"MPOL_F_STATIC_NODES\"]}},\"annotations\":{\"io.github.seccomp.libseccomp.version\":\"2.6.0\",\"org.opencontainers.runc.checkpoint.enabled\":\"true\",\"run.oci.crun.checkpoint.enabled\":\"true\",\"run.oci.crun.commit\":\"3ec076b3b6714ec2f1a10533cf18d5605a6de637\",\"run.oci.crun.version\":\"1.27.1\",\"run.oci.crun.wasm\":\"true\"},\"potentiallyUnsafeConfigAnnotations\":[\"module.wasm.image/variant\",\"io.kubernetes.cri.container-type\",\"run.oci.\",\"org.criu.\",\"krun.\"]}"
    },
    "os": "linux",
    "remoteSocket": {
      "path": "tcp:localhost:8080",
      "exists": true
    },
    "rootlessNetworkCmd": "pasta",
    "rootlessPortForwarder": "rootlessport",
    "serviceIsRemote": false,
    "security": {
      "apparmorEnabled": false,
      "capabilities": "CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER,CAP_FSETID,CAP_KILL,CAP_NET_BIND_SERVICE,CAP_SETFCAP,CAP_SETGID,CAP_SETPCAP,CAP_SETUID,CAP_SYS_CHROOT",
      "rootless": false,
      "seccompEnabled": true,
      "seccompProfilePath": "",
      "selinuxEnabled": true
    },
    "pasta": {
      "executable": "/usr/sbin/pasta",
      "package": "passt-0^20260120.g386b5f5-1.fc43.aarch64",
      "version": "pasta 0^20260120.g386b5f5-1.fc43.aarch64-pasta\nCopyright Red Hat\nGNU General Public License, version 2 or later\n  <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n"
    },
    "swapFree": 8589930496,
    "swapTotal": 8589930496,
    "uptime": "13h 50m 38.00s (Approximately 0.54 days)",
    "variant": "v8",
    "linkmode": "dynamic",
    "emulatedArchitectures": [
      "linux/386",
      "linux/amd64",
      "linux/amd64",
      "linux/arm64be",
      "linux/loong64",
      "linux/mips",
      "linux/mips64",
      "linux/ppc",
      "linux/ppc64",
      "linux/ppc64le",
      "linux/riscv32",
      "linux/riscv64",
      "linux/s390x"
    ]
  },
}
```