### PR TITLE
[v5.8] Backport the quadlet replace fix

### DIFF
--- a/pkg/domain/infra/abi/quadlet.go
+++ b/pkg/domain/infra/abi/quadlet.go
@@ -335,13 +335,13 @@ func (ic *ContainerEngine) installQuadlet(_ context.Context, path, destName, ins
 		return "", fmt.Errorf("%q is not a supported Quadlet file type", filepath.Ext(finalPath))
 	}
 
-	var osFlags = os.O_CREATE | os.O_WRONLY
+	osFlags := os.O_CREATE | os.O_WRONLY
 
 	if !replace {
 		osFlags |= os.O_EXCL
 	}
 
-	file, err := os.OpenFile(finalPath, osFlags, 0644)
+	file, err := os.OpenFile(finalPath, osFlags, 0o644)
 	if err != nil {
 		if errors.Is(err, fs.ErrExist) && !replace {
 			return "", fmt.Errorf("a Quadlet with name %s already exists, refusing to overwrite", filepath.Base(finalPath))

--- a/test/system/253-podman-quadlet.bats
+++ b/test/system/253-podman-quadlet.bats
@@ -465,43 +465,59 @@ EOF
     assert $status -eq 0 "quadlet rm --ignore should succeed even for non-existent quadlets"
 }
 
-@test "quadlet install --replace" {
-    local install_dir=$(get_quadlet_install_dir)
-    # Create a test quadlet file
-    local quadlet_file=$PODMAN_TMPDIR/alpine-quadlet.container
-    local initial_exec='Exec=sh -c "echo STARTED CONTAINER; trap '\''exit'\'' SIGTERM; while :; do sleep 0.1; done"'
-    cat > $quadlet_file <<EOF
+@test "podman quadlet install --replace" {
+    # 1. Create a valid "Long" quadlet file with many environment variables
+    cat > "$PODMAN_TMPDIR/long.container" <<EOF
 [Container]
 Image=$IMAGE
-$initial_exec
+Exec=sh -c "echo STARTED; trap 'exit' SIGTERM; while :; do sleep 0.1; done"
 EOF
-    # Test quadlet install
-    run_podman quadlet install $quadlet_file
-    # Verify install output contains the quadlet name on a single line
-    assert "$output" =~ "alpine-quadlet.container" "install output should contain quadlet name"
+    for i in {1..10}; do echo "Environment=VAR$i=VAL$i" >> "$PODMAN_TMPDIR/long.container"; done
 
-    # Without replace should fail
-    run_podman 125 quadlet install $quadlet_file
+    # 2. Install the LONG file first
+    run_podman quadlet install "$PODMAN_TMPDIR/long.container"
+    is "$output" ".*long.container"
+
+    # 3. Without replace should fail
+    run_podman 125 quadlet install "$PODMAN_TMPDIR/long.container"
     assert "$output" =~ "refusing to overwrite" "reinstall without --replace must fail with the overwrite error message"
 
-    cat > $quadlet_file <<EOF
+    # 4. Overwrite the source file with valid "Short" content
+    cat > "$PODMAN_TMPDIR/long.container" <<EOF
 [Container]
-Image=$IMAGE
-Exec=sh -c "echo STARTED CONTAINER UPDATED; trap 'exit' SIGTERM; while :; do sleep 0.1; done"
+Image=alpine
 EOF
-    # With replace should pass and update quadlet
-    run_podman quadlet install --replace $quadlet_file
 
-    # Verify install output contains the quadlet name on a single line
-    assert "$output" =~ "alpine-quadlet.container" "install output should contain quadlet name"
+    # 5. Install the SAME file again with --replace
+    run_podman quadlet install --replace "$PODMAN_TMPDIR/long.container"
 
-    run_podman quadlet print alpine-quadlet.container
+    # --- VERIFICATION 1: CHECK FOR TRUNCATION ---
+    local install_dir=$(get_quadlet_install_dir)
+    run cat "$install_dir/long.container"
+    assert "$output" == "$(<$PODMAN_TMPDIR/long.container)" "File was correctly truncated/replaced atomically"
 
-    assert "$output" !~ "$initial_exec" "Printed content must not show the initial version"
-    assert "$output" == "$(<$quadlet_file)" "Printed content must match the updated file content"
+    # --- VERIFICATION 2: CHECK FOR DUPLICATES IN .APP FILE ---
 
-    # Clean up
-    run_podman quadlet rm alpine-quadlet.container
+    local app_file="$install_dir/.long.container.app"
+
+    # Check if the file exists
+    if [ ! -f "$app_file" ]; then
+        # If .app is missing, check if .asset was created instead (debugging IsExtSupported)
+        if [ -f "$install_dir/.long.container.asset" ]; then
+             die "Failed: Created .asset file instead of .app file. IsExtSupported check failed?"
+        fi
+        die "Failed: .app file not found at $app_file"
+    fi
+
+    # Check content of the .app file
+    run cat "$app_file"
+    # It should contain exactly one line: "long.container"
+    assert "$output" == "long.container" ".app file should contain the quadlet name"
+
+    # Ensure no duplicates (line count should be 1)
+    run wc -l < "$app_file"
+    assert "$output" -eq 1 "Should only be listed once in tracking files"
+
+    # Cleanup: Remove the installed quadlet
+    run_podman quadlet rm long.container
 }
-
-# vim: filetype=sh


### PR DESCRIPTION

Backport the quadlet fix from https://github.com/podman-container-tools/podman/pull/27980



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed an issue where podman quadlet install --replace would not truncate the file possibly leaving old file content in place. #29013
```
