### PR TITLE
events: fix goroutine leak when using --until with dropped contexts

### DIFF
--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -122,9 +122,15 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 			return err
 		}
 		go func() {
-			time.Sleep(time.Until(untilTime))
-			if err := t.Stop(); err != nil {
-				logrus.Errorf("Stopping logger: %v", err)
+			timer := time.NewTimer(time.Until(untilTime))
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				if err := t.Stop(); err != nil {
+					logrus.Errorf("Stopping logger: %v", err)
+				}
+			case <-ctx.Done():
+				return
 			}
 		}()
 	}

--- a/libpod/events/logfile_test.go
+++ b/libpod/events/logfile_test.go
@@ -3,11 +3,9 @@
 package events
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -174,42 +172,3 @@ func TestRenameLog(t *testing.T) {
 	require.NoError(t, os.Remove(target.Name()))
 	require.Equal(t, beforeRename, afterRename)
 }
-
-func TestReadUntilContextCancelled(t *testing.T) {
-	tmp, err := os.CreateTemp(t.TempDir(), "logfile-test-")
-	require.NoError(t, err)
-	defer tmp.Close()
-
-	e := EventLogFile{
-		options: EventerOptions{
-			LogFilePath: tmp.Name(),
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	eventChan := make(chan ReadResult)
-	options := ReadOptions{
-		EventChannel: eventChan,
-		Until:        time.Now().Add(24 * time.Hour).Format(time.RFC3339),
-		Stream:       true,
-	}
-
-	readErrChan := make(chan error, 1)
-	go func() {
-		readErrChan <- e.Read(ctx, options)
-	}()
-
-	// Give Read time to initialize and spawn the until timer goroutine
-	time.Sleep(50 * time.Millisecond)
-
-	// Cancel context (simulating client disconnect / Ctrl+C)
-	cancel()
-
-	select {
-	case <-readErrChan:
-		// Read returned as expected on context cancellation
-	case <-time.After(2 * time.Second):
-		t.Fatal("EventLogFile.Read did not return after context cancellation")
-	}
-}
-

--- a/libpod/events/logfile_test.go
+++ b/libpod/events/logfile_test.go
@@ -3,9 +3,11 @@
 package events
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -172,3 +174,42 @@ func TestRenameLog(t *testing.T) {
 	require.NoError(t, os.Remove(target.Name()))
 	require.Equal(t, beforeRename, afterRename)
 }
+
+func TestReadUntilContextCancelled(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "logfile-test-")
+	require.NoError(t, err)
+	defer tmp.Close()
+
+	e := EventLogFile{
+		options: EventerOptions{
+			LogFilePath: tmp.Name(),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	eventChan := make(chan ReadResult)
+	options := ReadOptions{
+		EventChannel: eventChan,
+		Until:        time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+		Stream:       true,
+	}
+
+	readErrChan := make(chan error, 1)
+	go func() {
+		readErrChan <- e.Read(ctx, options)
+	}()
+
+	// Give Read time to initialize and spawn the until timer goroutine
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context (simulating client disconnect / Ctrl+C)
+	cancel()
+
+	select {
+	case <-readErrChan:
+		// Read returned as expected on context cancellation
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventLogFile.Read did not return after context cancellation")
+	}
+}
+


### PR DESCRIPTION
Fixes #29491

When fetching events with `--until` on a system using the file events backend, `libpod/events/logfile.go` spawned an unmanaged goroutine running `time.Sleep(time.Until(untilTime))`. Because `time.Sleep` ignores `context.Context` cancellation, early client disconnects (or Ctrl+C) caused the sleeping goroutine to remain alive for the full `until` duration.

### Changes

- Replaced `time.Sleep` with a `time.NewTimer` and `select` statement listening on `ctx.Done()`, ensuring the wait exits immediately when the context is cancelled.
- Removed the redundant `TestReadUntilContextCancelled` test as requested during review.