### PR TITLE
Refactor: Remove redundant err.Error() in pkg/machine

### DIFF
--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -661,7 +661,7 @@ func (h HyperVStubber) StopHostNetworking(mc *vmconfigs.MachineConfig, vmType de
 	err := machine.StopWinProxy(mc.Name, vmType)
 	// in podman 4, this was a "soft" error; keeping behavior as such
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not stop API forwarding service (win-sshproxy.exe): %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Could not stop API forwarding service (win-sshproxy.exe): %v\n", err)
 	}
 
 	return nil

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -106,7 +106,7 @@ func LaunchWinProxy(opts WinProxyOpts, noInfo bool) {
 	if !noInfo {
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "API forwarding for Docker API clients is not available due to the following startup failures.")
-			fmt.Fprintf(os.Stderr, "\t%s\n", err.Error())
+			fmt.Fprintf(os.Stderr, "\t%v\n", err)
 			fmt.Fprintln(os.Stderr, "\nPodman clients are still able to connect.")
 		} else {
 			fmt.Printf("API forwarding listening on: %s\n", pipeName)

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -171,7 +171,7 @@ func reassignSSHPort(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 	defer func() {
 		if !success {
 			if err := ports.ReleaseMachinePort(newPort); err != nil {
-				logrus.Warnf("could not release port allocation as part of failure rollback (%d): %s", newPort, err.Error())
+				logrus.Warnf("could not release port allocation as part of failure rollback (%d): %v", newPort, err)
 			}
 		}
 	}()
@@ -184,7 +184,7 @@ func reassignSSHPort(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 	}
 
 	if err := ports.ReleaseMachinePort(oldPort); err != nil {
-		logrus.Warnf("could not release current ssh port allocation (%d): %s", oldPort, err.Error())
+		logrus.Warnf("could not release current ssh port allocation (%d): %v", oldPort, err)
 	}
 
 	// Update the backend's settings if relevant (e.g. WSL)

--- a/pkg/machine/shim/networking_unix.go
+++ b/pkg/machine/shim/networking_unix.go
@@ -78,7 +78,7 @@ func setupForwardingLinks(hostSocket, dataDir *define.VMFile) (string, machine.A
 		_ = userGlobalSocket.Delete()
 
 		if err := os.Symlink(hostSocket.GetPath(), userGlobalSocket.GetPath()); err != nil {
-			logrus.Warnf("could not create user global API forwarding link: %s", err.Error())
+			logrus.Warnf("could not create user global API forwarding link: %v", err)
 			return hostSocket.GetPath(), machine.MachineLocal, nil
 		}
 	}

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -247,11 +247,11 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, _ bool) error {
 
 	// Stop user-mode networking if enabled
 	if err := stopUserModeNetworking(mc); err != nil {
-		fmt.Fprintf(os.Stderr, "Could not cleanly stop user-mode networking: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Could not cleanly stop user-mode networking: %v\n", err)
 	}
 
 	if err := machine.StopWinProxy(mc.Name, vmtype); err != nil {
-		fmt.Fprintf(os.Stderr, "Could not stop API forwarding service (win-sshproxy.exe): %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Could not stop API forwarding service (win-sshproxy.exe): %v\n", err)
 	}
 
 	cmd := wutil.NewWSLCommand("-u", "root", "-d", dist, "sh")

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -161,7 +161,7 @@ func stopUserModeNetworking(mc *vmconfigs.MachineConfig) error {
 				err = fmt.Errorf("route state is missing a default route")
 			}
 		}
-		logrus.Warnf("problem tearing down user-mode networking cleanly, forcing: %s", err.Error())
+		logrus.Warnf("problem tearing down user-mode networking cleanly, forcing: %v", err)
 	}
 
 	return terminateDist(userModeDist)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Fixes #29501 

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #29501` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
