### PR TITLE
Fix empty detach keys being interpreted as default detach keys

### DIFF
--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -26,7 +26,7 @@ import (
 func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 
-	input := new(handlers.ExecCreateConfig)
+	input := new(handlers.ExecCreateConfigBody)
 	if err := utils.ReadJSONFromBody(r, &input); err != nil {
 		utils.Error(w, http.StatusBadRequest, err)
 		return
@@ -53,9 +53,7 @@ func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 	libpodConfig.AttachStdin = input.AttachStdin
 	libpodConfig.AttachStderr = input.AttachStderr
 	libpodConfig.AttachStdout = input.AttachStdout
-	if input.DetachKeys != "" {
-		libpodConfig.DetachKeys = &input.DetachKeys
-	}
+	libpodConfig.DetachKeys = input.DetachKeys
 	libpodConfig.Environment = make(map[string]string)
 	for _, envStr := range input.Env {
 		key, val, hasVal := strings.Cut(envStr, "=")
@@ -80,6 +78,11 @@ func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
+
+	if libpodConfig.DetachKeys == nil {
+		libpodConfig.DetachKeys = &runtimeConfig.Engine.DetachKeys
+	}
+
 	// Automatically log to syslog if the server has log-level=debug set
 	exitCommandArgs, err := specgenutil.CreateExitCommandArgs(storageConfig, runtimeConfig, logrus.IsLevelEnabled(logrus.DebugLevel), true, false, true)
 	if err != nil {

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -235,8 +235,17 @@ type HistoryResponse struct {
 	Comment   string
 }
 
+// #29507
+//
+// Deprecated: use `ExecCreateConfigBody` instead.
 type ExecCreateConfig struct {
 	dockerContainer.ExecCreateRequest
+}
+
+// #28193: added second type for JSON unmarshling, to prevent breaking change in `pkg/bindings`.
+type ExecCreateConfigBody struct {
+	dockerContainer.ExecCreateRequest
+	DetachKeys *string `json:"DetachKeys"`
 }
 
 type ExecStartConfig struct {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -948,6 +948,41 @@ t POST containers/create?platform=linux/aarch64 \
   Image=$IMAGE \
   404
 
+# 28193: podman --remote exec ignores empty detach keys (explicitly disable detach).
+# Previously the JSON decoder could not distinguish an absent field from an
+# explicitly-empty one, so DetachKeys:"" was silently ignored.
+podman run -d --name exec-detach-keys-test $IMAGE top
+
+# Without DetachKeys the system default must be preserved (non-empty).
+t POST containers/exec-detach-keys-test/exec \
+  Cmd='["true"]' \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t GET exec/$eid/json 200
+jq -e '.DetachKeys != ""' <<<"$output"
+
+# Explicitly empty DetachKeys disables detach - exec create must accept it.
+t POST containers/exec-detach-keys-test/exec \
+  Cmd='["true"]' \
+  DetachKeys='' \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t GET exec/$eid/json 200 .DetachKeys=''
+
+# A non-empty DetachKeys must be stored and returned by inspect.
+t POST containers/exec-detach-keys-test/exec \
+  Cmd='["true"]' \
+  DetachKeys='ctrl-c' \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t GET exec/$eid/json 200 .DetachKeys='ctrl-c'
+
+podman rm -f exec-detach-keys-test
+
+
 # test apiv2 create container with oci_runtime option :- https://github.com/containers/podman/issues/28429
 oci_runtimes=('runc' 'crun')
 


### PR DESCRIPTION
Fixes #28193
As mentioned in the issue and the linked PR #28405, the problem was string doesn't hold necessary information to conclude if detached keys were passed as `''` or omitted. So, the obvious fix was to change the `input.DetachKeys` to *string.

If default key is omitted, in `exec.go` we assign `libpodConfig.DetachKeys` to `&config.DefaultDetachKeys`.