### PR TITLE
pkg/trust: prevent panic on malformed GPG uid/pub lines

### DIFF
--- a/pkg/trust/policy.go
+++ b/pkg/trust/policy.go
@@ -100,7 +100,13 @@ func parseUids(colonDelimitKeys []byte) []string {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "uid:") || strings.HasPrefix(line, "pub:") {
-			uid := strings.Split(line, ":")[9]
+			fields := strings.Split(line, ":")
+			// A well-formed uid/pub record has the user ID in field 10;
+			// skip malformed lines instead of panicking on a short slice.
+			if len(fields) < 10 {
+				continue
+			}
+			uid := fields[9]
 			if uid == "" {
 				continue
 			}

--- a/pkg/trust/policy_test.go
+++ b/pkg/trust/policy_test.go
@@ -194,3 +194,14 @@ func xNewPRSigstoreSignedKeyPath(t *testing.T, keyPath string, signedIdentity si
 	require.NoError(t, err)
 	return pr
 }
+
+func TestParseUids(t *testing.T) {
+	// Malformed uid/pub records with fewer than 10 colon-separated fields
+	// must be skipped rather than panicking on an out-of-range index.
+	assert.Empty(t, parseUids([]byte("uid:u:1:2:3\n")))
+	assert.Empty(t, parseUids([]byte("pub:\n")))
+
+	// A well-formed uid record still yields the parsed email address.
+	valid := []byte("uid:u:1:2:3:4:5:6:7:Test User <test@example.com>\n")
+	assert.Equal(t, []string{"test@example.com"}, parseUids(valid))
+}


### PR DESCRIPTION
Fixes: #29508

<!-- Thanks for sending a pull request! -->

`parseUids` indexed `strings.Split(line, ":")[9]` for every `uid:`/`pub:`
line without checking the field count. GnuPG colon output can contain
records with fewer than 10 fields, which panicked with a slice-bounds
error. This guards the length and skips short records, and adds a
regression test for the short-line and well-formed cases.


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
