### PR TITLE
domain/filters: accept "dead"/"restarting" as status filter values

### DIFF
--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -19,6 +19,31 @@ import (
 	"go.podman.io/storage"
 )
 
+// dockerOnlyContainerStatuses are status filter values that the Docker
+// Compat and libpod list-containers APIs document as valid (status=...) but
+// that have no corresponding define.ContainerStatus, because Podman does not
+// model these Docker-only states internally (see
+// https://github.com/containers/podman/issues/28904 /
+// https://github.com/podman-container-tools/podman/issues/28904). Filtering
+// on them must not error since the API docs list them as valid, but no
+// container will ever match since Podman never reports these states.
+var dockerOnlyContainerStatuses = map[string]struct{}{
+	"dead":       {},
+	"restarting": {},
+}
+
+// isValidContainerStatusFilter reports whether filterValue is a status the
+// list APIs should accept: either a real Podman container state, or one of
+// the Docker-only states we accept-but-never-match for API compatibility.
+func isValidContainerStatusFilter(filterValue string) error {
+	if _, err := define.StringToContainerStatus(filterValue); err != nil {
+		if _, ok := dockerOnlyContainerStatuses[filterValue]; !ok {
+			return err
+		}
+	}
+	return nil
+}
+
 // GenerateContainerFilterFuncs return ContainerFilter functions based of filter.
 func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpod.Runtime) (func(container *libpod.Container) bool, error) {
 	switch filter {
@@ -72,7 +97,7 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 		}, nil
 	case "status":
 		for _, filterValue := range filterValues {
-			if _, err := define.StringToContainerStatus(filterValue); err != nil {
+			if err := isValidContainerStatusFilter(filterValue); err != nil {
 				return nil, err
 			}
 		}
@@ -456,7 +481,7 @@ func GenerateExternalContainerFilterFuncs(filter string, filterValues []string, 
 		}, nil
 	case "status":
 		for _, filterValue := range filterValues {
-			if _, err := define.StringToContainerStatus(filterValue); err != nil {
+			if err := isValidContainerStatusFilter(filterValue); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/domain/filters/containers_test.go
+++ b/pkg/domain/filters/containers_test.go
@@ -1,0 +1,49 @@
+//go:build !remote && (linux || freebsd)
+
+package filters
+
+import "testing"
+
+// Regression test for
+// https://github.com/podman-container-tools/podman/issues/28904
+// ("Status filter does not accept 'dead' and 'restarting' in list
+// containers podman API").
+//
+// Podman has no internal ContainerStatus that corresponds to Docker's
+// "dead" or "restarting" states, but both the libpod and Docker-compat
+// `containers/json` API docs list them as valid `status` filter values.
+// Before this fix, GenerateContainerFilterFuncs("status", ...) rejected
+// them with "unknown container state: ...: invalid argument" (surfaced by
+// the API as a 500), instead of accepting the filter and simply matching
+// zero containers the way an unmatched, but syntactically valid, Docker
+// status filter would.
+func TestGenerateContainerFilterFuncsStatusAcceptsDockerOnlyStates(t *testing.T) {
+	for _, status := range []string{"dead", "restarting"} {
+		fn, err := GenerateContainerFilterFuncs("status", []string{status}, nil)
+		if err != nil {
+			t.Errorf("status=%q: expected no error, got: %v", status, err)
+		}
+		if fn == nil {
+			t.Errorf("status=%q: expected a non-nil filter func", status)
+		}
+	}
+}
+
+// Sanity check that genuinely invalid status values are still rejected, so
+// the fix above does not silently accept arbitrary garbage.
+func TestGenerateContainerFilterFuncsStatusStillRejectsUnknownValues(t *testing.T) {
+	_, err := GenerateContainerFilterFuncs("status", []string{"not-a-real-status"}, nil)
+	if err == nil {
+		t.Fatal("expected an error for an unknown, non-Docker status value, got nil")
+	}
+}
+
+// Known-good status values (including the "stopped" -> "exited" Docker
+// compat alias) must keep working unmodified.
+func TestGenerateContainerFilterFuncsStatusAcceptsKnownValues(t *testing.T) {
+	for _, status := range []string{"created", "running", "paused", "exited", "stopped"} {
+		if _, err := GenerateContainerFilterFuncs("status", []string{status}, nil); err != nil {
+			t.Errorf("status=%q: expected no error, got: %v", status, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #28904.

The libpod and Docker-compat `containers/json` API docs advertise
`status=(created, restarting, running, removing, paused, exited, dead)`
as valid values for the `status` list filter, but Podman has no
`define.ContainerStatus` corresponding to Docker's `dead` or
`restarting` states. As a result, `GenerateContainerFilterFuncs` and
`GenerateExternalContainerFilterFuncs` rejected these two values
outright with `unknown container state: ...: invalid argument`,
surfaced by the API as a 500.

This PR accepts `dead` and `restarting` as valid filter values without
erroring, matching the documented API contract, while leaving the
actual state-matching logic untouched: since no container ever reports
`dead` or `restarting`, the filter simply matches zero containers for
those values instead of failing the request. Other invalid values are
still rejected as before.

## Test plan

- Added `pkg/domain/filters/containers_test.go` covering: `dead`/`restarting` no longer error, known-good values (`created`, `running`, `paused`, `exited`, `stopped`) still work, and genuinely unknown values (`not-a-real-status`) are still rejected.
- `go vet ./pkg/domain/filters/...` and `go test -c ./pkg/domain/filters/...` pass.
- Cross-compiled `cmd/podman` for Linux to confirm the change builds cleanly in the real target environment.
