### PR TITLE
api/auth: fix localhost-address matching to prevent userinfo bypass

### DIFF
--- a/pkg/api/handlers/compat/auth.go
+++ b/pkg/api/handlers/compat/auth.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/moby/moby/api/types/registry"
@@ -18,6 +19,37 @@ import (
 	"go.podman.io/podman/v6/pkg/domain/entities"
 )
 
+// isLocalhostServerAddress reports whether serverAddress refers to the
+// "localhost" host, either as a bare "host[:port]" address (e.g.
+// "localhost:5000") or as an "https://" URL (e.g. "https://localhost:5000").
+//
+// This intentionally parses the address as a URL instead of doing a plain
+// string-prefix check: a naive check like
+// strings.HasPrefix(serverAddress, "https://localhost:") can be bypassed
+// with userinfo syntax such as "https://localhost:password@evil.example",
+// which has that exact prefix but actually refers to "evil.example".
+// Parsing the address and inspecting only the Hostname() avoids that
+// confusion between userinfo and host.
+func isLocalhostServerAddress(serverAddress string) bool {
+	addr := serverAddress
+	hasScheme := strings.Contains(addr, "://")
+	if !hasScheme {
+		// No scheme was given, so this is a bare "host[:port]" address
+		// (e.g. "localhost:5000"). Give it a scheme so url.Parse()
+		// splits host/port (and any userinfo) the same way it would
+		// for a full URL.
+		addr = "https://" + addr
+	}
+	u, err := url.Parse(addr)
+	if err != nil {
+		return false
+	}
+	if hasScheme && u.Scheme != "https" {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), "localhost")
+}
+
 func Auth(w http.ResponseWriter, r *http.Request) {
 	var authConfig registry.AuthConfig
 	if err := utils.ReadJSONFromBody(r, &authConfig); err != nil {
@@ -26,7 +58,7 @@ func Auth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	skipTLS := types.NewOptionalBool(false)
-	if strings.HasPrefix(authConfig.ServerAddress, "https://localhost/") || strings.HasPrefix(authConfig.ServerAddress, "https://localhost:") || strings.HasPrefix(authConfig.ServerAddress, "localhost:") {
+	if isLocalhostServerAddress(authConfig.ServerAddress) {
 		// support for local testing
 		skipTLS = types.NewOptionalBool(true)
 	}

--- a/pkg/api/handlers/compat/auth_test.go
+++ b/pkg/api/handlers/compat/auth_test.go
@@ -1,0 +1,46 @@
+//go:build !remote && (linux || freebsd)
+
+package compat
+
+import "testing"
+
+func TestIsLocalhostServerAddress(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverAddress string
+		want          bool
+	}{
+		{"bare host with port", "localhost:5000", true},
+		{"https URL with port", "https://localhost:5000", true},
+		{"https URL with trailing slash", "https://localhost/", true},
+		{"https URL with path", "https://localhost:5000/v2/", true},
+		{"https URL, no port or path", "https://localhost", true},
+		{"bare host, no port", "localhost", true},
+		{"case-insensitive host", "https://LOCALHOST:5000", true},
+		{"case-insensitive bare host", "LOCALHOST:5000", true},
+
+		// The actual bug: a crafted userinfo section that merely
+		// starts with "https://localhost:" must not be confused with
+		// the "localhost" host.
+		{"userinfo bypass with scheme", "https://localhost:password@evil.example", false},
+		{"userinfo bypass without scheme", "localhost:password@evil.example", false},
+		{"userinfo bypass with path", "https://localhost:1234@evil.example/v2/", false},
+
+		{"unrelated https host", "https://example.com", false},
+		{"unrelated bare host", "example.com:5000", false},
+		{"subdomain lookalike", "https://localhost.evil.example", false},
+		{"query string lookalike", "https://evil.example/?x=localhost", false},
+		{"http scheme not treated as insecure-allowed", "http://localhost:5000", false},
+		{"empty address", "", false},
+		{"loopback IP is not localhost by name", "https://127.0.0.1:5000", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLocalhostServerAddress(tt.serverAddress)
+			if got != tt.want {
+				t.Errorf("isLocalhostServerAddress(%q) = %v, want %v", tt.serverAddress, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #29506.

The docker-compat `/auth` endpoint (`pkg/api/handlers/compat/auth.go`) decides whether to skip TLS verification ("support for local testing") using plain string-prefix checks:

```go
strings.HasPrefix(authConfig.ServerAddress, "https://localhost/") ||
strings.HasPrefix(authConfig.ServerAddress, "https://localhost:") ||
strings.HasPrefix(authConfig.ServerAddress, "localhost:")
```

This is bypassable with URL userinfo syntax: `https://localhost:password@evil.example` (or the bare form `localhost:password@evil.example`) matches the `"https://localhost:"` / `"localhost:"` prefixes, but the real host is `evil.example`, not `localhost`. Any server address crafted this way gets `skipTLS = true`, disabling TLS verification for a host that isn't actually localhost.

## Fix

Replaced the prefix checks with `isLocalhostServerAddress()`, which parses the address with `net/url` (adding a `https://` scheme first if the address is a bare `host[:port]`) and checks only `u.Hostname()` against `"localhost"` (case-insensitive), never the userinfo section.

## Test plan

- Added `pkg/api/handlers/compat/auth_test.go` with 18 cases covering: all previously-matched legitimate forms (bare host, `https://` with/without port/path/trailing-slash, case-insensitivity), the userinfo bypass (with and without scheme, with a path), and non-matches (unrelated hosts, subdomain lookalikes, query-string lookalikes, `http://` scheme, loopback IP by address rather than name).
- `go vet` and `go test -c` pass on the changed package.
- Cross-compiled `cmd/podman` for Linux (`CGO_ENABLED=0 GOOS=linux go build`) to confirm the change builds cleanly in the real target environment.

