### PR TITLE
pkg/api/handlers/compat: populate IPAM IPRange in network inspect

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -71,6 +71,43 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 	utils.WriteResponse(w, http.StatusOK, report)
 }
 
+// prefixFromRange returns the single CIDR whose first and last addresses are
+// exactly start and end, if such a CIDR exists. It is the inverse of how the
+// create path stores a Docker IPRange: net.ParseCIDR followed by
+// netutil.FirstIPInSubnet/LastIPInSubnet (see CreateNetwork). A lease
+// range that is not CIDR-aligned (e.g. a podman-native `--ip-range start-end`)
+// has no single Docker CIDR representation, so ok is false and the caller leaves
+// IPRange unset.
+func prefixFromRange(start, end net.IP) (netip.Prefix, bool) {
+	// Stored lease-range IPs are commonly unmarshaled in 16-byte form; normalize
+	// to the canonical width so the mask math and length check below are correct.
+	if v4 := start.To4(); v4 != nil {
+		start = v4
+	}
+	if v4 := end.To4(); v4 != nil {
+		end = v4
+	}
+	if start == nil || end == nil || len(start) != len(end) {
+		return netip.Prefix{}, false
+	}
+	bits := len(start) * 8
+	for pfxLen := bits; pfxLen >= 0; pfxLen-- {
+		mask := net.CIDRMask(pfxLen, bits)
+		ipnet := &net.IPNet{IP: start.Mask(mask), Mask: mask}
+		first, err1 := netutil.FirstIPInSubnet(ipnet)
+		last, err2 := netutil.LastIPInSubnet(ipnet)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		if first.Equal(start) && last.Equal(end) {
+			if p, err := netip.ParsePrefix(ipnet.String()); err == nil {
+				return p, true
+			}
+		}
+	}
+	return netip.Prefix{}, false
+}
+
 func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, statuses []abi.ContainerNetStatus, network *nettypes.Network, changeDefaultName bool) (*dockerNetwork.Inspect, error) {
 	containerEndpoints := make(map[string]dockerNetwork.EndpointResource, len(statuses))
 	for _, st := range statuses {
@@ -121,7 +158,11 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, statuses []abi
 		ipamConfig := dockerNetwork.IPAMConfig{
 			Subnet:  subnet,
 			Gateway: gateway,
-			// TODO add range
+		}
+		if lr := sub.LeaseRange; lr != nil && lr.StartIP != nil && lr.EndIP != nil {
+			if ipRange, ok := prefixFromRange(lr.StartIP, lr.EndIP); ok {
+				ipamConfig.IPRange = ipRange
+			}
 		}
 		ipamConfigs = append(ipamConfigs, ipamConfig)
 	}

--- a/pkg/api/handlers/compat/networks_test.go
+++ b/pkg/api/handlers/compat/networks_test.go
@@ -1,0 +1,37 @@
+//go:build !remote && (linux || freebsd)
+
+package compat
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixFromRange(t *testing.T) {
+	tests := []struct {
+		name  string
+		start string
+		end   string
+		want  string // empty means prefixFromRange should report ok == false
+	}{
+		{"ipv4 /24", "10.89.0.1", "10.89.0.255", "10.89.0.0/24"},
+		{"ipv4 /28", "192.168.1.17", "192.168.1.31", "192.168.1.16/28"},
+		{"ipv4 /8", "10.0.0.1", "10.255.255.255", "10.0.0.0/8"},
+		{"ipv6 /64", "fd00::1", "fd00::ffff:ffff:ffff:ffff", "fd00::/64"},
+		{"non-aligned range", "10.0.0.5", "10.0.0.20", ""},
+		{"reversed range", "10.0.0.255", "10.0.0.1", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := prefixFromRange(net.ParseIP(tt.start), net.ParseIP(tt.end))
+			if tt.want == "" {
+				require.False(t, ok, "expected no CIDR for range %s-%s, got %v", tt.start, tt.end, got)
+				return
+			}
+			require.True(t, ok, "expected a CIDR for range %s-%s", tt.start, tt.end)
+			require.Equal(t, tt.want, got.String())
+		})
+	}
+}

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -111,6 +111,14 @@ t POST networks/create Name=net3\ CheckDuplicate=false 409
 # network delete docker
 t DELETE networks/net3 204
 
+# create a network with an IP range and verify the compat inspect endpoint
+# round-trips the IPRange back into IPAM.Config (https://github.com/containers/podman/issues/28378)
+t POST networks/create Name=net_iprange\ IPAM='{"Config":[{"Subnet":"172.30.0.0/24","Gateway":"172.30.0.1","IPRange":"172.30.0.128/28"}]}' 201
+t GET networks/net_iprange 200 \
+  .IPAM.Config[0].Subnet=172.30.0.0/24 \
+  .IPAM.Config[0].IPRange=172.30.0.128/28
+t DELETE networks/net_iprange 204
+
 #compat api list networks sanity checks
 t GET networks?filters='garb1age}' 500 \
     .cause="invalid character 'g' looking for beginning of value"


### PR DESCRIPTION
Fixes: #28378

The Docker-compat `network inspect` endpoint left `IPAM.Config[].IPRange`
empty even when the network was created with an IP range — the conversion
had a literal `// TODO add range`. Docker stores the range as a single CIDR
(`netip.Prefix`) while podman stores start/end lease IPs, so this
reconstructs the CIDR by inverting what the create path does
(`netutil.First/LastIPInSubnet`), and leaves `IPRange` unset when the lease
range is not CIDR-aligned (no single Docker CIDR exists — safe degradation).

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
