### PR TITLE
test/system: fix healthcheck since race

### DIFF
--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -96,10 +96,6 @@ Log[-1].ExitCode | 1
 Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\\\n\"
 " "$current_time" "healthy"
 
-    # Capture time before systemctl checks so we don't miss the "unhealthy"
-    # event that may fire during those checks (health-interval is only 1s).
-    current_time=$(date --iso-8601=ns)
-
     # Check that we now we do have valid podman units with this
     # name so that the leak check below does not turn into a NOP without noticing.
     run -0 systemctl list-units
@@ -114,7 +110,13 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\\\n\"
     run -0 systemctl show --all "$cid-*.service"
     assert "$output" =~ "StartLimitIntervalUSec=0" "The hc service has the right interval set"
 
-    # After three successive failures, container should no longer be healthy
+    # After three successive failures, container should no longer be healthy.
+    # No new timestamp here on purpose: with a 1s interval the third failure
+    # can fire while the "First failure" checks above are still running, so a
+    # timestamp taken at this point can land after the unhealthy event and the
+    # events window below would never contain it (#29353). Reusing the
+    # timestamp captured before the failure was triggered is safe because the
+    # wait loop only looks at the last event.
     _check_health $ctrname "Four or more failures" "
 Status           | \"unhealthy\"
 FailingStreak    | [3456]


### PR DESCRIPTION
I filed #29353 after this test came up as the most frequent failure in the rerun history I have been going through, and the diagnosis came out of the journal artifacts of two failed jobs: the unhealthy event fires 19ms and 60ms before the `--since` timestamp the test captures, so the events window can never contain it. With a 1s interval the third failure can fire while the "First failure" checks are still running.

81fceb48d already moved this capture before the systemctl checks for the same reason, but it still sits after the trigger. This drops it and reuses the timestamp taken before the touch. I think that is safe because the wait loop only matches the last event, and the assertion table already accepts FailingStreak 3-6.

cc @Luap99 
