### PR TITLE
pkg/api/server: document noHostname and noPodPrefix kube play params

### DIFF
--- a/pkg/api/server/register_kube.go
+++ b/pkg/api/server/register_kube.go
@@ -79,6 +79,11 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    items:
 	//      type: string
 	//  - in: query
+	//    name: noHostname
+	//    type: boolean
+	//    default: false
+	//    description: Do not create /etc/hostname within the container, instead use the version from the image
+	//  - in: query
 	//    name: noHosts
 	//    type: boolean
 	//    default: false
@@ -152,6 +157,11 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    name: build
 	//    type: boolean
 	//    description: Build the images with corresponding context.
+	//  - in: query
+	//    name: noPodPrefix
+	//    type: boolean
+	//    default: false
+	//    description: Do not prefix container name with pod name
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.


### PR DESCRIPTION
The `PlayKubeLibpod` swagger operation (`POST /libpod/play/kube`) documented 18 of
the 20 query parameters its handler decodes (`pkg/api/handlers/libpod/kube.go`).
Two were missing: `noHostname` and `noPodPrefix`. This adds them so the generated
API docs and clients match the parameters the endpoint actually accepts.
Descriptions mirror the CLI flag help (`--no-hostname`, `--no-pod-prefix`).

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
