### PR TITLE
[v5.8] fix machine linux tests and bump to 5.8.7-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,10 +457,11 @@ jobs:
           sudo ln -sfr /usr/libexec/virtiofsd /usr/local/libexec/podman/virtiofsd
 
       # The default podman ship in ubuntu comes with an old unsupported registries.conf v1 format,
-      # just remove it as we need no special config.
-      - name: "Configure registries.conf"
+      # just remove it as we need no special config. And also the seccomp profile in /etc is wrong
+      # as it triggers a podman build error as the path is send via the API inside we do not have that.
+      - name: "Remove containers configs"
         run: |
-          sudo rm -f /etc/containers/registries.conf
+          sudo rm -f /etc/containers/registries.conf /etc/containers/seccomp.json
 
       # podman-machine needs kvm access
       - name: "Fix kvm permissions"

--- a/version/rawversion/version.go
+++ b/version/rawversion/version.go
@@ -4,4 +4,4 @@ package rawversion
 //
 // This indirection is needed to prevent semver packages from bloating
 // Quadlet's binary size.
-const RawVersion = "5.8.6"
+const RawVersion = "5.8.7-dev"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

They are hard broken as the runner images added
/etc/containers/seccomp.json at the podman build remote client tries to
send that to the server which then fails.


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
