### PR TITLE
Performance: Replace strings.ToLower with strings.EqualFold

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -731,7 +731,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 // otherwise it returns true
 func useLayers() string {
 	layers := os.Getenv("BUILDAH_LAYERS")
-	if strings.ToLower(layers) == "false" || layers == "0" {
+	if strings.EqualFold(layers, "false") || layers == "0" {
 		return "false"
 	}
 	return "true"

--- a/libpod/runtime_volume_common.go
+++ b/libpod/runtime_volume_common.go
@@ -92,7 +92,7 @@ func (r *Runtime) newVolume(ctx context.Context, noCreatePluginVolume bool, opti
 		for key, val := range volume.config.Options {
 			switch strings.ToLower(key) {
 			case "device":
-				if strings.ToLower(volume.config.Options["type"]) == define.TypeBind {
+				if strings.EqualFold(volume.config.Options["type"], define.TypeBind) {
 					if err := fileutils.Exists(val); err != nil {
 						return nil, fmt.Errorf("invalid volume option %s for driver 'local': %w", key, err)
 					}

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -120,7 +120,7 @@ func createAnonymousFilterVolumeFunction(filterValues []string) (libpod.VolumeFi
 	return func(v *libpod.Volume) bool {
 		for _, val := range filterValues {
 			anon := v.Anonymous()
-			invert := strings.ToLower(val) == "false" || val == "0"
+			invert := strings.EqualFold(val, "false") || val == "0"
 			if invert {
 				anon = !anon
 			}

--- a/pkg/domain/infra/abi/apply.go
+++ b/pkg/domain/infra/abi/apply.go
@@ -121,7 +121,7 @@ func setUpClusterClient(kconfig k8sAPI.Config, applyOptions entities.ApplyOption
 	caCertPool := x509.NewCertPool()
 
 	// Be insecure if user sets ca-cert-file flag to insecure
-	if strings.ToLower(caCertFile) == "insecure" {
+	if strings.EqualFold(caCertFile, "insecure") {
 		insecureSkipVerify = true
 	} else if caCertFile == "" {
 		caCertFile = kconfig.Clusters[0].Cluster.CertificateAuthority

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -1021,5 +1021,5 @@ func promptUpdateSystemConn() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return strings.ToLower(answer)[0] == 'y', nil
+	return len(answer) > 0 && (answer[0] == 'y' || answer[0] == 'Y'), nil
 }

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -171,7 +171,7 @@ func supportAmbientCapabilities() bool {
 
 func shouldMask(mask string, unmask []string) bool {
 	for _, m := range unmask {
-		if strings.ToLower(m) == "all" {
+		if strings.EqualFold(m, "all") {
 			return false
 		}
 		for m1 := range strings.SplitSeq(m, ":") {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1215,7 +1215,7 @@ func ParseRestartPolicy(policy string) (string, uint, error) {
 	case 1:
 		// No retries specified
 		policyType = splitRestart[0]
-		if strings.ToLower(splitRestart[0]) == "never" {
+		if strings.EqualFold(splitRestart[0], "never") {
 			policyType = define.RestartPolicyNo
 		}
 	case 2:


### PR DESCRIPTION
Replaces unnecessary heap allocations for case-insensitive equality checks with standard library strings.EqualFold.

Fixes: #29526

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #29526` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
