### PR TITLE
hack/ci: do not swallow apiv2 failures

### DIFF
--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -186,9 +186,11 @@ function run_apiv2() {
     pip install --upgrade pip
     pip install --requirement ./test/apiv2/python/requirements.txt
     $SUDO sh -c "(
-        make localapiv2-bash
+        rc=0
+        make localapiv2-bash || rc=\$?
         source .venv/requests/bin/activate
-        make localapiv2-python
+        make localapiv2-python || rc=\$?
+        exit \$rc
     )" |& logformatter
 }
 

--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -3,6 +3,10 @@
 # test more container-related endpoints
 #
 
+# Reset server to known good state
+stop_service
+start_service
+
 podman pull "${IMAGE}" &>/dev/null
 
 # Ensure clean slate


### PR DESCRIPTION
The apiv2 bash suite has not gated CI since 66c6da6e84. `run_apiv2` puts both make targets inside one `sh -c "( ... )"` with no `set -e`, so only the last command decides the exit status and `make localapiv2-bash` is discarded. `set -eo pipefail` at the top of runner.sh is the outer bash and does not reach into that inner `sh`.

It is failing right now on main. Run 31847250452, job `apiv2 rootless fedora-current`, conclusion success, log line 3089:

```
make: *** [Makefile:762: localapiv2-bash] Error 17
```

Same thing in the three earlier green main runs I checked (31687097967, 31540756565, 31514570842), each with plan `1..2191` and `Error 17`.

I used an accumulator rather than `set -e` so the python half still runs when the bash half fails - otherwise we would lose that half of the report on every failure. Checked the shapes on bash 5.2: the current one exits 0 when the first target fails, this one exits 1 and still runs both.

I have not looked into the 17 failures themselves yet, they look like three clusters in 26-containersWait and 27-containersEvents. Happy to open a separate issue for those once this gates again.
