### PR TITLE
hack/ci: pass --remote to bud tests

### DIFF
--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -198,7 +198,11 @@ function run_bindings() {
 }
 
 function run_bud() {
-    $SUDO ./test/buildah-bud/run-buildah-bud-tests |& logformatter
+    local args=()
+    if [[ "$MODE" == "remote" ]]; then
+        args+=(--remote)
+    fi
+    $SUDO ./test/buildah-bud/run-buildah-bud-tests "${args[@]}" |& logformatter
 }
 
 function run_compose_v2() {

--- a/test/buildah-bud/run-buildah-bud-tests
+++ b/test/buildah-bud/run-buildah-bud-tests
@@ -33,6 +33,7 @@ Flags, useful for manual debugging:
 # Parse command-line options (used in development only, not in CI)
 do_checkout=y
 do_test=y
+REMOTE=
 declare -a bats_filter=()
 for i; do
     value=$(expr "$i" : '[^=]*=\(.*\)')
@@ -40,7 +41,7 @@ for i; do
         --no-checkout)  do_checkout= ; shift;;
         --no-test)      do_test=     ; shift;;
         --filter=*)     bats_filter=("--filter" "$value"); shift;;
-        --remote)       PODBIN_NAME=remote;;
+        --remote)       REMOTE=1;;
        -h|--help)       echo "$usage"; exit 0;;
         *)              echo "$ME: Unrecognized option '$i'" >&2; exit 1;;
     esac
@@ -73,10 +74,8 @@ PATCHES=${BUD_TEST_DIR}/buildah-tests.diff
 BUD_TEST_DIR_REL=$(dirname $(git ls-files --full-name ${BASH_SOURCE[0]}))
 # Path to podman binary; again, do it before we cd
 PODMAN_BINARY=$(pwd)/bin/podman
-REMOTE=
 # If remote, start server & change path
-if [[ "${PODBIN_NAME:-}" = "remote" ]]; then
-    REMOTE=1
+if [[ -n "$REMOTE" ]]; then
     PODMAN_BINARY+="-remote"
 fi
 


### PR DESCRIPTION
The `bud remote` job runs the same local binary as `bud local`. Both jobs from run 31847250452 on main print the identical bats invocation:

```
sudo env TMPDIR=/var/tmp PODMAN_BINARY=/var/tmp/podman-container-tools/podman/bin/podman PODMAN_SERVER_LOG= REMOTE= ...
```

`bin/podman`, not `podman-remote`, and `REMOTE=` empty, in the job named remote.

The remote path in `run-buildah-bud-tests` is gated on `PODBIN_NAME` (line 78), which Cirrus used to set per matrix task. The migration replaced that with a `mode:` matrix key, but `run_bud()` never reads `$MODE` - `run_int`, `run_sys`, `run_machine` and `run_upgrade` all do. `grep -rn PODBIN_NAME` outside vendor finds it only inside `run-buildah-bud-tests` itself and in the treadmill script's Cirrus text.

So `apply-podman-deltas` has 30 `skip_if_remote` and 4 `skip_if_rootless_remote` entries that are currently no-ops, and podman-remote build coverage has been off since the migration.

`--remote` is already an option on the script and sets `PODBIN_NAME=remote` before that gate, so this is one branch in `run_bud`.

Worth saying plainly: this restores coverage rather than being a no-op, so the remote leg may go red on things that have been hidden. Most of the historically broken ones should already be covered by those deltas, but if new failures show up I am happy to iterate on them here or in a follow-up.
