### PR TITLE
Add --quiet to podman artifact ls

### DIFF
--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -2,6 +2,7 @@ package artifact
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -36,6 +37,7 @@ type listFlagType struct {
 	format    string
 	noHeading bool
 	noTrunc   bool
+	quiet     bool
 }
 
 type artifactListOutput struct {
@@ -78,9 +80,14 @@ func init() {
 	_ = listCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&artifactListOutput{}))
 	flags.BoolVarP(&listFlag.noHeading, "noheading", "n", false, "Do not print column headings")
 	flags.BoolVar(&listFlag.noTrunc, "no-trunc", false, "Do not truncate output")
+	flags.BoolVarP(&listFlag.quiet, "quiet", "q", false, "Display only artifact digests")
 }
 
 func list(cmd *cobra.Command, _ []string) error {
+	if listFlag.quiet && cmd.Flags().Changed("format") {
+		return errors.New("quiet and format flags cannot be used together")
+	}
+
 	reports, err := registry.ImageEngine().ArtifactList(registry.Context(), entities.ArtifactListOptions{})
 	if err != nil {
 		return err
@@ -135,11 +142,22 @@ func list(cmd *cobra.Command, _ []string) error {
 		})
 	}
 
+	if listFlag.quiet {
+		quietOut(artifacts)
+		return nil
+	}
+
 	switch {
 	case report.IsJSON(listFlag.format):
 		return writeJSON(artifacts)
 	default:
 		return writeTemplate(cmd, artifacts)
+	}
+}
+
+func quietOut(listed []artifactListOutput) {
+	for _, a := range listed {
+		fmt.Println(a.Digest)
 	}
 }
 

--- a/docs/source/markdown/podman-artifact-ls.1.md.in
+++ b/docs/source/markdown/podman-artifact-ls.1.md.in
@@ -30,6 +30,10 @@ Print results with a Go template.
 
 @@option noheading
 
+#### **--quiet**, **-q**
+
+Lists only the artifact digests.
+
 ## EXAMPLES
 
 List artifacts in the local store
@@ -74,6 +78,13 @@ $ podman artifact ls --format json"
         "Digest": "cd734b558ceb"
     }
 ]
+```
+
+List only artifact digests
+```
+$ podman artifact ls --quiet
+ab609fad386d
+cd734b558ceb
 ```
 
 

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -87,6 +87,30 @@ var _ = Describe("Podman artifact", func() {
 		Expect(noHeaderOutput).To(HaveLen(2))
 		Expect(noHeaderOutput).ToNot(ContainElement("REPOSITORY"))
 
+		// check with --quiet and verify only the (truncated) digests are printed
+		quietSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--quiet")
+		quietOutput := quietSession.OutputToStringArray()
+		Expect(quietOutput).To(HaveLen(2))
+		Expect(quietOutput).ToNot(ContainElement("REPOSITORY"))
+		Expect(quietOutput).To(ContainElement(defaultOutput))
+		for _, digest := range quietOutput {
+			Expect(digest).To(HaveLen(12))
+		}
+
+		// check with --quiet and --no-trunc combined and verify full (non-truncated) digests are printed
+		quietNoTruncSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--quiet", "--no-trunc")
+		quietNoTruncOutput := quietNoTruncSession.OutputToStringArray()
+		Expect(quietNoTruncOutput).To(HaveLen(2))
+		Expect(quietNoTruncOutput).ToNot(ContainElement("REPOSITORY"))
+		for _, digest := range quietNoTruncOutput {
+			Expect(digest).To(HaveLen(len(add1.OutputToString())))
+		}
+
+		// check --quiet and --format together are rejected
+		quietFormatSession := podmanTest.Podman([]string{"artifact", "ls", "--quiet", "--format", "{{.Repository}}"})
+		quietFormatSession.WaitWithDefaultTimeout()
+		Expect(quietFormatSession).To(ExitWithError(125, "quiet and format flags cannot be used together"))
+
 		// Check if .VirtualSize is reported correctly
 		virtualSizeFormatSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.VirtualSize}}")
 		virtualSizes := virtualSizeFormatSession.OutputToStringArray()


### PR DESCRIPTION
Problem: Right now there's no clean way to get just artifact IDs (The Digest hashcodes) out of podman artifact ls. You end up either parsing the table or reaching for --format {{.Digest}}, which is inefficient for scripting. The other list commands (images, ps, artifact push/pull) all have -q/--quiet already pre-existing.

Impact: users can now run `podman artifact ls --quiet` to get one digest per line (the unique hashcode), no header, suitable for piping into other podman commands.

Change: adds a `--quiet`/`-q` bool flag to the list command. When set (and `--format` is not also given), `output.Digest` is printed for each artifact instead of the table.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
<img width="992" height="194" alt="image" src="https://github.com/user-attachments/assets/d3ffa703-964e-45f3-a98c-3a5afb845c95" />
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Add `--quiet`/`-q` to `podman artifact ls` to print only artifact digests.
```