### PR TITLE
hack/ci: exit instead of return on missing github credentials

### DIFF
--- a/hack/ci/pr-should-include-tests
+++ b/hack/ci/pr-should-include-tests
@@ -40,7 +40,7 @@ if [[ -n "$PR_NUMBER" ]]; then
     for var in GITHUB_TOKEN GITHUB_REPOSITORY; do
         if [[ -z "${!var}" ]]; then
             echo "$ME: cannot query github: \$$var is undefined" >&2
-            return 1
+            exit 1
         fi
     done
 

--- a/hack/ci/pr-should-include-tests.t
+++ b/hack/ci/pr-should-include-tests.t
@@ -89,6 +89,12 @@ function run_test_script() {
 rc=0
 testnum=0
 
+# This harness may run in CI, where PR_NUMBER is set in the environment. The
+# cases below only exercise the local git-diff logic, not the github override-
+# label lookup (which needs real credentials), so ensure the script under test
+# never enters that path.
+unset PR_NUMBER
+
 while read expected_rc parent_sha  commit_sha pr rest; do
     # Skip blank lines
     test -z "$expected_rc" && continue


### PR DESCRIPTION
pr-should-include-tests is executed, not sourced, so the `return 1` used when GITHUB_TOKEN or GITHUB_REPOSITORY is unset does not stop the script. bash prints `return: can only return from a function or sourced script` and execution falls through to the curl call with empty credentials, ultimately failing with the misleading `PR does not include tests` message instead of the intended `cannot query github` error.


<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
