### PR TITLE
Fix ErrorToStringArray empty output handling

### DIFF
--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Podman volume ls", func() {
 		empty := podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(empty.OutputToString()).To(ContainSubstring("DRIVER"))
 		Expect(empty.OutputToString()).To(ContainSubstring("VOLUME NAME"))
-		Expect(empty.ErrorToStringArray()).To(HaveLen(1))
+		Expect(empty.ErrorToStringArray()).To(BeEmpty())
 
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()

--- a/test/utils/podmansession_test.go
+++ b/test/utils/podmansession_test.go
@@ -27,7 +27,13 @@ var _ = Describe("PodmanSession test", func() {
 	})
 
 	It("Test ErrorToStringArray", func() {
-		Expect(session.ErrorToStringArray()).To(Equal([]string{"PodmanSession", "test", "Podman Session", ""}))
+		Expect(session.ErrorToStringArray()).To(Equal([]string{"PodmanSession", "test", "Podman Session"}))
+	})
+
+	It("Test ErrorToStringArray with empty output", func() {
+		session = StartFakeCmdSession([]string{})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ErrorToStringArray()).To(BeEmpty())
 	})
 
 	It("Test GrepString", func() {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -269,8 +269,14 @@ func (s *PodmanSession) ErrorToString() string {
 // ErrorToStringArray returns the stderr output as a []string
 // where each array item is a line split by newline
 func (s *PodmanSession) ErrorToStringArray() []string {
+	var results []string
 	output := string(s.Err.Contents())
-	return strings.Split(output, "\n")
+	for line := range strings.SplitSeq(output, "\n") {
+		if line != "" {
+			results = append(results, line)
+		}
+	}
+	return results
 }
 
 // GrepString takes session output and behaves like grep. it returns a bool


### PR DESCRIPTION
ErrorToStringArray currently returns an empty string as an entry when stderr is completely empty because splitting an empty string on a newline produces a one-element result. This makes empty stderr appear as if error output was produced.

This change filters out empty lines before returning the result. It also updates the existing test expectation, adds coverage for empty output, and updates the HaveLen(1) assertion in volume_ls_test.go to BeEmpty(), since that's the correct value now that the underlying bug is fixed.
