### PR TITLE
hack/ci: fix log summary for non-int ginkgo suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ help: ## Print this help message
 	hack/ci/pr-removes-fixed-skips.t
 	hack/ci/pr-should-include-tests.t
 	hack/ci/logformatter.t
+	hack/ci/github_log_summary.t
 	test/system/helpers.t
 
 .PHONY: lint

--- a/hack/ci/github_log_summary.py
+++ b/hack/ci/github_log_summary.py
@@ -104,12 +104,20 @@ class BatsLogFilterParser(HTMLParser):
 
 
 
+# logformatter decides how to mark up a log by looking at the log contents,
+# not at the test name, and only its ginkgo path emits the "log-failed" class.
+# Detect the format the same way, so that ginkgo suites which are not named
+# "int-" (the bindings suite, for example) are parsed as ginkgo rather than
+# falling through to the bats parser.
+GINKGO_MARKER = 'class="log-failed"'
+
+
 def filter_html_file(file_path):
     # Read the HTML content
     with open(file_path, 'r', encoding='utf-8') as f:
         html_content = f.read()
 
-    if 'int-' in file_path:
+    if GINKGO_MARKER in html_content:
         parser = GinkgoLogFilterParser()
         parser.feed(html_content)
         return parser.results
@@ -119,10 +127,14 @@ def filter_html_file(file_path):
     return [parser.data]
 
 
-# Running the filter
-matching_elements = filter_html_file(sys.argv[1])
+def main(file_paths):
+    for file_path in file_paths:
+        for element in filter_html_file(file_path):
+            print("```")
+            print(element)
+            print("```")
 
-for element in matching_elements:
-    print(f"```")
-    print(element)
-    print("```")
+
+# Running the filter
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/hack/ci/github_log_summary.t
+++ b/hack/ci/github_log_summary.t
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# tests for github_log_summary.py
+#
+
+import importlib.util
+import os
+import tempfile
+import unittest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# The tool is a script, not a module, so load it by path.
+spec = importlib.util.spec_from_file_location(
+    "github_log_summary", os.path.join(TESTS_DIR, "github_log_summary.py")
+)
+github_log_summary = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(github_log_summary)
+
+
+# Trimmed-down versions of what logformatter emits. The ginkgo path wraps
+# failures in a "log-failed" span inside the "tt" block; the bats path marks
+# up each line with a "bats-*" class.
+GINKGO_HTML = """<div class='tt'> <!-- begin processed output -->
+<span class="timestamp">[+0298s] </span><span class="log-failed">[FAILED] podman pod correctly sets up PIDNS</span>
+<span class="timestamp">[+0298s] </span>expected exit code 0, got 125
+</div>
+"""
+
+GINKGO_PASSING_HTML = """<div class='tt'> <!-- begin processed output -->
+<span class="timestamp">[+0271s] </span>ok, all tests passed
+</div>
+"""
+
+BATS_HTML = """<div class='tt'> <!-- begin processed output -->
+<span class='bats-failed'><a name='t--00001'>not ok 1 podman run</a></span>
+<span class='bats-log'># expected 0, got 125</span>
+</div>
+"""
+
+
+def summarize(html, name):
+    """Write html to a file called name, then run it through the filter."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(html)
+        return github_log_summary.filter_html_file(path)
+
+
+class TestFormatDetection(unittest.TestCase):
+    def test_ginkgo_int_suite(self):
+        """The int suite is ginkgo and is detected as such."""
+        out = "".join(summarize(GINKGO_HTML, "int-local-root-fedora.log.html"))
+        self.assertIn("[FAILED] podman pod correctly sets up PIDNS", out)
+        self.assertIn("expected exit code 0, got 125", out)
+
+    def test_ginkgo_suite_not_named_int(self):
+        """Ginkgo suites are detected by content, not by the file name.
+
+        The bindings suite is ginkgo but is not called "int-". Keying off the
+        name meant its failures were parsed with the bats parser, which found
+        no bats markup and so reported nothing useful.
+        """
+        out = "".join(summarize(GINKGO_HTML, "bindings-root-fedora.log.html"))
+        self.assertIn("[FAILED] podman pod correctly sets up PIDNS", out)
+        self.assertIn("expected exit code 0, got 125", out)
+
+    def test_bats_suite(self):
+        """The bats parser still handles bats logs."""
+        out = "".join(summarize(BATS_HTML, "sys-local-root-fedora.log.html"))
+        self.assertIn("not ok 1 podman run", out)
+        self.assertIn("expected 0, got 125", out)
+
+    def test_ginkgo_without_failures(self):
+        """A ginkgo log with no failures has nothing to report."""
+        out = "".join(summarize(GINKGO_PASSING_HTML, "int-local-root-fedora.log.html"))
+        self.assertEqual(out.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our contributing guidelines and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per LLM Policy
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below (or `None` if no user-facing changes)

`github_log_summary.py` decided whether a log was ginkgo or bats by looking at the
file name — `if 'int-' in file_path`. `logformatter` decides from the log contents
instead, so the two disagree for any ginkgo suite whose `TEST_NAME` does not begin
with `int`.

The bindings suite is one of those. It is ginkgo, it runs in the `small-tests`
matrix, and `run_bindings` pipes it through `logformatter`. Feeding one and the same
ginkgo log through the summary under two names:

| file name | summary output |
|---|---|
| `int-local-root-fedora-current.log.html` | full failure block — test name, source location, timeline |
| `bindings-root-fedora-current.log.html` | `1 Failed` |

So when bindings fails, the "Output failure log as GITHUB_STEP_SUMMARY" step prints a
bare count and nothing else, at the one moment the summary is meant to be useful.

Detect the format from the content instead. The `log-failed` class is only emitted on
the ginkgo path; the logrus handler emits log *levels*, so it can never produce
`failed`.

Two smaller things in the same file:

- The script only summarized `sys.argv[1]`, while the workflow passes a glob. Each job
  writes one html file today, so nothing is lost in practice, but any further file was
  silently dropped. It now walks every argument.
- The entry point is guarded on `__main__`, which is what makes the script importable
  and therefore testable.

Added `hack/ci/github_log_summary.t`, the first test for this script, run from
`.check-self-tests` alongside `logformatter.t`. It covers ginkgo detection for both
`int-` and non-`int-` names, bats logs, and a ginkgo log with no failures. Reverting
only the detection line fails exactly one of the four, so it does discriminate.

One note on CI: `pr-should-include-tests` looks for changes under `test/` or in
`*_test.go`, and `hack/` self-tests are neither, so the check will fail here even
though this adds a test. It will need the `No New Tests` label.

#### Does this PR introduce a user-facing change?

```release-note
None
```
