### PR TITLE
farm: add --quiet/-q flag to podman farm list

### DIFF
--- a/cmd/podman/farm/list.go
+++ b/cmd/podman/farm/list.go
@@ -1,6 +1,7 @@
 package farm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -34,6 +35,7 @@ and the output format can be changed to JSON or a user specified Go template.`
 	// Temporary struct to hold cli values.
 	lsOpts = struct {
 		Format string
+		Quiet  bool
 	}{}
 )
 
@@ -47,9 +49,15 @@ func init() {
 	formatFlagName := "format"
 	flags.StringVar(&lsOpts.Format, formatFlagName, "", "Format farm output using Go template")
 	_ = lsCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&config.Farm{}))
+
+	flags.BoolVarP(&lsOpts.Quiet, "quiet", "q", false, "Print farm names only")
 }
 
 func list(cmd *cobra.Command, args []string) error {
+	if lsOpts.Quiet && cmd.Flag("format").Changed {
+		return errors.New("quiet and format flags cannot be used together")
+	}
+
 	format := lsOpts.Format
 	if format == "" && len(args) > 0 {
 		format = "json"
@@ -75,9 +83,12 @@ func list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if format != "" {
+	switch {
+	case format != "":
 		rpt, err = rpt.Parse(report.OriginUser, format)
-	} else {
+	case lsOpts.Quiet:
+		rpt, err = rpt.Parse(report.OriginUser, "{{range .}}{{.Name}}\n{{end -}}")
+	default:
 		rpt, err = rpt.Parse(report.OriginPodman,
 			"{{range .}}{{.Name}}\t{{.Connections}}\t{{.Default}}\t{{.ReadWrite}}\n{{end -}}")
 	}

--- a/docs/source/markdown/podman-farm-list.1.md
+++ b/docs/source/markdown/podman-farm-list.1.md
@@ -25,6 +25,10 @@ Valid placeholders for the Go template listed below:
 | .Name           | Farm name                                                             |
 | .ReadWrite      | Indicates if this farm can be modified using the podman farm commands |
 
+#### **--quiet**, **-q**
+
+Print farm output in quiet mode. Only print the farm names.
+
 ## EXAMPLE
 
 List all farms:
@@ -61,6 +65,13 @@ $ podman farm list --format json
 Show only farm names:
 ```
 $ podman farm list --format "{{.Name}}"
+farm1
+farm2
+```
+
+Show only farm names using **--quiet**:
+```
+$ podman farm list --quiet
 farm1
 farm2
 ```

--- a/test/e2e/farm_test.go
+++ b/test/e2e/farm_test.go
@@ -80,6 +80,37 @@ farm3 [] false true
 			Expect(session).Should(Not(ExitCleanly()))
 		})
 
+		It("list farms quiet", func() {
+			// create farm with multiple system connections
+			cmd := []string{"farm", "create", "farm1", "QA", "QB"}
+			session := podmanTest.Podman(cmd)
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(ExitCleanly())
+
+			// create farm with only one system connection
+			cmd = []string{"farm", "create", "farm2", "QA"}
+			session = podmanTest.Podman(cmd)
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(ExitCleanly())
+
+			// --quiet should print only farm names, one per line
+			session = podmanTest.Podman([]string{"farm", "list", "--quiet"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(ExitCleanly())
+			Expect(string(session.Out.Contents())).To(Equal("farm1\nfarm2\n"))
+
+			// -q shorthand behaves the same as --quiet
+			session = podmanTest.Podman([]string{"farm", "list", "-q"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(ExitCleanly())
+			Expect(string(session.Out.Contents())).To(Equal("farm1\nfarm2\n"))
+
+			// --quiet and --format together should error
+			session = podmanTest.Podman([]string{"farm", "list", "--quiet", "--format", "{{.Name}}"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(ExitWithError(125, "quiet and format flags cannot be used together"))
+		})
+
 		It("update existing farms", func() {
 			// create farm with multiple system connections
 			cmd := []string{"farm", "create", "farm1", "QA", "QB"}


### PR DESCRIPTION
The command feature 'farm' is really helpful when it comes to building multi-architecture container images, with a build out on various different CPU architecture machines (e.g. amd64, arm64 etc.). With this we essentially produce a multi-architecture image useable on many different kinds of machines. Once those farms are built, we can list them out (ls) in a human readable format.

Essentially, when we do a 'podman farm list', it will print out every field (e.g. name, connections, default etc.). What --quiet & -q flags does is it cuts the noise by ONLY printing the names of the farms, rather than all the other farms list metadata.

Benefits of having this feature in the future is for automation and scripts to just pull the farm names from the list. This is mostly important for the CI pipelines to loop over.

**Note**: make validatepr fails at hack/ci/pr-removes-fixed-skips.t due to a missing Perl module (Test::Differences) in the validatepr container image; Unrelated to this change. All lint/format/docs steps (golangci-lint, pre-commit hooks, markdown-preprocess, xref-helpmsgs-manpages) passed clean.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
Yes; Please refer to the video demo along with the release notes
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

https://github.com/user-attachments/assets/b2666f16-1638-40e3-bcd3-ccaee2876dcc


```release-note
Added the `--quiet`/`-q` flag to `podman farm list` to print only farm names.
```
