### PR TITLE
events: Add missing Copy status to StringToStatus

### DIFF
--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -150,6 +150,8 @@ func StringToStatus(name string) (Status, error) {
 		return Cleanup, nil
 	case Commit.String():
 		return Commit, nil
+	case Copy.String():
+		return Copy, nil
 	case Create.String():
 		return Create, nil
 	case Exec.String():

--- a/libpod/events/events_test.go
+++ b/libpod/events/events_test.go
@@ -1,0 +1,70 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringToStatusRoundTrip(t *testing.T) {
+	// Every Status constant must survive a round-trip through StringToStatus.
+	allStatuses := []Status{
+		Attach,
+		AutoUpdate,
+		Build,
+		Checkpoint,
+		Cleanup,
+		Commit,
+		Copy,
+		Create,
+		Exec,
+		ExecDied,
+		Exited,
+		Export,
+		HealthStatus,
+		History,
+		Import,
+		Init,
+		Kill,
+		LoadFromArchive,
+		Mount,
+		NetworkConnect,
+		NetworkDisconnect,
+		Pause,
+		Prune,
+		Pull,
+		PullError,
+		Push,
+		Refresh,
+		Remove,
+		Rename,
+		Renumber,
+		Restart,
+		Restore,
+		Rotate,
+		Save,
+		Start,
+		Stop,
+		Sync,
+		Tag,
+		Unmount,
+		Unpause,
+		Untag,
+		Update,
+	}
+
+	for _, s := range allStatuses {
+		t.Run(string(s), func(t *testing.T) {
+			got, err := StringToStatus(s.String())
+			require.NoError(t, err, "StringToStatus(%q) should not error", s.String())
+			assert.Equal(t, s, got)
+		})
+	}
+}
+
+func TestStringToStatusUnknown(t *testing.T) {
+	_, err := StringToStatus("bogus")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown event status")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed `podman machine cp` events being silently dropped or erroring in the remote API and journald event paths due to the "copy" status missing from `StringToStatus`.
```
