### PR TITLE
refactor: remove redundant err.Error() calls

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -414,7 +414,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	// Hard code TMPDIR functions to use /var/tmp, if user did not override
 	if _, ok := os.LookupEnv("TMPDIR"); !ok {
 		if tmpdir, err := podmanConfig.ContainersConfDefaultsRO.ImageCopyTmpDir(); err != nil {
-			logrus.Warnf("Failed to retrieve default tmp dir: %s", err.Error())
+			logrus.Warnf("Failed to retrieve default tmp dir: %v", err)
 		} else {
 			os.Setenv("TMPDIR", tmpdir)
 		}
@@ -474,7 +474,7 @@ func configHook() {
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			// Cases where the folder does not exist are allowed, BUT cases where some other Stat() error
 			// is returned should fail
-			fmt.Fprintf(os.Stderr, "Supplied --config folder (%s) exists but is not accessible: %s\n", dockerConfig, err.Error())
+			fmt.Fprintf(os.Stderr, "Supplied --config folder (%s) exists but is not accessible: %v\n", dockerConfig, err)
 			os.Exit(1)
 		}
 		if err == nil && !statInfo.IsDir() {
@@ -483,7 +483,7 @@ func configHook() {
 			os.Exit(1)
 		}
 		if err := os.Setenv("DOCKER_CONFIG", dockerConfig); err != nil {
-			fmt.Fprintf(os.Stderr, "cannot set DOCKER_CONFIG=%s: %s\n", dockerConfig, err.Error())
+			fmt.Fprintf(os.Stderr, "cannot set DOCKER_CONFIG=%s: %v\n", dockerConfig, err)
 			os.Exit(1)
 		}
 	}
@@ -529,7 +529,7 @@ func stdOutHook() {
 
 			// if we couldn't open the file for write, then just bail with an error.
 		} else {
-			fmt.Fprintf(os.Stderr, "unable to open file for standard output: %s\n", err.Error())
+			fmt.Fprintf(os.Stderr, "unable to open file for standard output: %v\n", err)
 			os.Exit(1)
 		}
 	}
@@ -594,7 +594,7 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 	pFlags := cmd.PersistentFlags()
 	if registry.IsRemote() {
 		if err := lFlags.MarkHidden("remote"); err != nil {
-			logrus.Warnf("Unable to mark --remote flag as hidden: %s", err.Error())
+			logrus.Warnf("Unable to mark --remote flag as hidden: %v", err)
 		}
 		podmanConfig.Remote = true
 	} else {
@@ -697,7 +697,7 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 			"trace",
 		} {
 			if err := pFlags.MarkHidden(f); err != nil {
-				logrus.Warnf("Unable to mark %s flag as hidden: %s", f, err.Error())
+				logrus.Warnf("Unable to mark %s flag as hidden: %v", f, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Remove redundant `err.Error()` calls when formatting errors in
`cmd/podman/root.go` and `pkg/domain/infra/abi/generate.go`.

The errors are passed directly to the formatting functions using `%v`,
following idiomatic Go error formatting and the existing Podman style.

## Changes

- Replace redundant `err.Error()` calls with `%v` and `err`.
- No functional behavior is changed.
- No unrelated code was modified.

## Validation

- `git diff --check` passes.
- Local Go tests were not run because Go is not installed in the current development environment.