### PR TITLE
docs: remove hardcoded config paths in favor of man page references (#29187)

### DIFF
--- a/docs/source/markdown/podman-image-trust.1.md.in
+++ b/docs/source/markdown/podman-image-trust.1.md.in
@@ -14,8 +14,7 @@ The location is determined
 by the transport and the registry host of the image.  Using this container image `docker://docker.io/library/busybox`
 as an example, `docker` is the transport and `docker.io` is the registry host.
 
-Trust is defined in **/etc/containers/policy.json** and is enforced when a user attempts to pull
-a remote image from a registry.  The trust policy in policy.json describes a registry scope (registry and/or repository) for the trust.  This trust can use public keys for signed images.
+Trust is defined in **policy.json** (see **containers-policy.json(5)** for exact paths) and is enforced when a user attempts to pull a remote image from a registry.  The trust policy in policy.json describes a registry scope (registry and/or repository) for the trust.  This trust can use public keys for signed images.
 
 The scope of the trust is evaluated from most specific to the least specific. In other words, a policy may be:
 

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -426,41 +426,41 @@ the exit codes follow the `chroot` standard, see below:
 
 ## CONFIGURATION FILES
 
-**containers.conf** (`/usr/share/containers/containers.conf`, `/etc/containers/containers.conf`, `$HOME/.config/containers/containers.conf`)
+**containers.conf**
 
 Podman has builtin defaults for command line options. These defaults can be overridden using the containers.conf configuration files.
 
-Distributions ship the `/usr/share/containers/containers.conf` file with their default settings. Administrators can override fields in this file by creating the `/etc/containers/containers.conf` file.  Users can further modify defaults by creating the `$HOME/.config/containers/containers.conf` file. Podman merges its builtin defaults with the specified fields from these files, if they exist. Fields specified in the users file override the administrator's file, which overrides the distribution's file, which override the built-in defaults.
+For a complete list of supported paths and their override order, see **containers.conf(5)**. Podman merges its builtin defaults with the specified fields from these files, if they exist. Fields specified in the users file override the administrator's file, which overrides the distribution's file, which override the built-in defaults.
 
 Podman uses builtin defaults if no containers.conf file is found.
 
 If the **CONTAINERS_CONF** environment variable is set, then its value is used for the containers.conf file rather than the default.
 
-**mounts.conf** (`/usr/share/containers/mounts.conf`)
+**mounts.conf**
 
-The mounts.conf file specifies volume mount directories that are automatically mounted inside containers when executing the `podman run` or `podman start` commands. Administrators can override the defaults file by creating `/etc/containers/mounts.conf`.
+The mounts.conf file specifies volume mount directories that are automatically mounted inside containers when executing the `podman run` or `podman start` commands.
 
-When Podman runs in rootless mode, the file `$HOME/.config/containers/mounts.conf` overrides the default if it exists. For details, see containers-mounts.conf(5).
+For a complete list of supported paths and details, see **containers-mounts.conf(5)**.
 
-**policy.json** (`/etc/containers/policy.json`, `$HOME/.config/containers/policy.json`)
+**policy.json**
 
 Signature verification policy files are used to specify policy, e.g. trusted keys, applicable when deciding whether to accept an image, or individual signatures of that image, as valid. For details, see containers-policy.json(5).
 
-**registries.conf** (`/etc/containers/registries.conf`, `$HOME/.config/containers/registries.conf`)
+**registries.conf**
 
 registries.conf is the configuration file which specifies which container registries is consulted when completing image names which do not include a registry or domain portion.
 
-Non root users of Podman can create the `$HOME/.config/containers/registries.conf` file to be used instead of the system defaults.
+For a complete list of supported paths, including user-specific and system-wide defaults, see **containers-registries.conf(5)**.
 
 If the **CONTAINERS_REGISTRIES_CONF** environment variable is set, then its value is used for the registries.conf file rather than the default.
 
-**storage.conf** (`/etc/containers/storage.conf`, `$HOME/.config/containers/storage.conf`)
+**storage.conf**
 
 storage.conf is the storage configuration file for all tools using containers/storage
 
 The storage configuration file specifies all of the available container storage options for tools using shared container storage.
 
-When Podman runs in rootless mode, the file `$HOME/.config/containers/storage.conf` is used instead of the system defaults.
+When Podman runs in rootless mode, For a complete list of supported paths, including user-specific and system-wide defaults, see **containers-storage.conf(5)**.
 
 If the **CONTAINERS_STORAGE_CONF** environment variable is set, then its value is used for the storage.conf file rather than the default.
 


### PR DESCRIPTION
## Overview
Fixes #29187 by updating outdated configuration file documentation in the Podman man pages. 

Instead of hardorcoding specific directory paths (which can quickly become outdated as configuration parsing rules change or expand), this update removes the hardcoded paths from the headings and text, pointing users directly to their respective manual pages for the complete source of truth.

## Changes Made
1. **`docs/source/markdown/podman.1.md`**:
   - Removed hardcoded path lists from the headings of `containers.conf`, `mounts.conf`, `policy.json`, `registries.conf`, and `storage.conf`.
   - Updated the body text to direct users to their corresponding man pages (e.g., `containers.conf(5)`, `containers-mounts.conf(5)`, etc.) for full override and path resolution details.

2. **`docs/source/markdown/podman-image-trust.1.md.in`**:
   - Updated the `DESCRIPTION` section to stop assuming `/etc/containers/policy.json` is the sole policy location.
   - Replaced it with a general reference to `policy.json` and a link to `containers-policy.json(5)` for exact system and user path handling.
