### PR TITLE
Added implementation for --noheading option for podman farm list

### DIFF
--- a/cmd/podman/farm/list.go
+++ b/cmd/podman/farm/list.go
@@ -51,13 +51,14 @@ func init() {
 	_ = lsCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&config.Farm{}))
 
 	flags.BoolVarP(&lsOpts.Quiet, "quiet", "q", false, "Print farm names only")
+	flags.BoolP("noheading", "n", false, "Do not print headers")
 }
 
 func list(cmd *cobra.Command, args []string) error {
 	if lsOpts.Quiet && cmd.Flag("format").Changed {
 		return errors.New("quiet and format flags cannot be used together")
 	}
-
+	noHeading, _ := cmd.Flags().GetBool("noheading")
 	format := lsOpts.Format
 	if format == "" && len(args) > 0 {
 		format = "json"
@@ -96,7 +97,7 @@ func list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if rpt.RenderHeaders {
+	if rpt.RenderHeaders && !noHeading {
 		err = rpt.Execute([]map[string]string{{
 			"Default":     "Default",
 			"Connections": "Connections",

--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -14,6 +14,7 @@ podman-create.1.md
 podman-diff.1.md
 podman-exec.1.md
 podman-farm-build.1.md
+podman-farm-list.1.md
 podman-image-sign.1.md
 podman-image-trust.1.md
 podman-images.1.md

--- a/docs/source/markdown/options/noheading.md
+++ b/docs/source/markdown/options/noheading.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman artifact ls, image trust, images, machine list, network ls, pod ps, quadlet list, secret ls, volume ls
+####>   podman artifact ls, farm list, image trust, images, machine list, network ls, pod ps, quadlet list, secret ls, volume ls
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--noheading**, **-n**

--- a/docs/source/markdown/podman-farm-list.1.md.in
+++ b/docs/source/markdown/podman-farm-list.1.md.in
@@ -25,6 +25,8 @@ Valid placeholders for the Go template listed below:
 | .Name           | Farm name                                                             |
 | .ReadWrite      | Indicates if this farm can be modified using the podman farm commands |
 
+@@option noheading
+
 #### **--quiet**, **-q**
 
 Print farm output in quiet mode. Only print the farm names.
@@ -38,6 +40,14 @@ Name        Connections  Default     ReadWrite
 farm1       [f38 f37]    false       true
 farm2       [f37]        true        true
 ```
+
+List all farms without showing the headers:
+```
+$ podman farm list --noheading
+farm1       [f38 f37]    false       true
+farm2       [f37]        true        true
+```
+
 Show farms in JSON format:
 ```
 $ podman farm list --format json

--- a/test/farm/001-farm.bats
+++ b/test/farm/001-farm.bats
@@ -9,6 +9,19 @@ load helpers.bash
     run_podman farm ls
     assert "$output" =~ $FARMNAME
     assert "$output" =~ ${CONNECTION_NAME}
+
+    #Confirm name header present on farm list output
+    assert "$output" =~ "Name"
+
+    #Test the farm list output for no headers
+    run_podman farm ls --noheading
+    assert "$output" !~ "Name"
+    assert "$output" =~ "$FARMNAME"
+
+    #Test the farm list noheading shorthand
+    run_podman farm ls -n
+    assert "$output" !~ "Name"
+    assert "$output" =~ "$FARMNAME"
 }
 
 @test "farm - build on local only" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```

#### Pr description
This pr implements the --noheading option for podman farm list including the -n shorthand command. After adding the implementation, it was tested manually by running the cli command and the output is displayed as expected. Also, added the manfile and the system test in the respective files.This implementation lists the podman farms without the headers i.e (Name,Connections,Default,ReadWrite)

Cli command:
./bin/podman farm list --noheading
./bin/podman farm list -n

