### PR TITLE
ci: add deterministic failure classifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,7 @@ help: ## Print this help message
 	hack/ci/pr-should-include-tests.t
 	hack/ci/logformatter.t
 	hack/ci/ci_run_collector_test.py
+	hack/ci/ci_log_retriever_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,7 @@ help: ## Print this help message
 	hack/ci/logformatter.t
 	hack/ci/ci_run_collector_test.py
 	hack/ci/ci_log_retriever_test.py
+	hack/ci/ci_failure_classifier_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ help: ## Print this help message
 	hack/ci/pr-removes-fixed-skips.t
 	hack/ci/pr-should-include-tests.t
 	hack/ci/logformatter.t
+	hack/ci/ci_run_collector_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/hack/ci/ci_failure_classifier.py
+++ b/hack/ci/ci_failure_classifier.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""
+ci_failure_classifier - Deterministic classification of CI failures.
+
+Categorizes CI failure logs using pattern-matching rules based on
+real Podman CI failure patterns. Each rule has a category, a set of
+regex patterns, a confidence score, and evidence extraction logic.
+
+Designed to handle the most common and well-understood failure types
+reliably and testably before any LLM-based analysis (PR 5).
+
+Usage:
+    # Classify failures from ci_log_retriever output
+    ./hack/ci/ci_log_retriever.py --run-id 31813098642 | \
+        ./hack/ci/ci_failure_classifier.py --stdin
+
+    # Classify a single log snippet
+    echo '{"normalized_log_excerpt": "panic: nil pointer"}' | \
+        ./hack/ci/ci_failure_classifier.py --stdin
+
+Environment:
+    GITHUB_TOKEN       Required if using --run-id to fetch data.
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+# Import upstream modules from the pipeline.
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import ci_run_collector
+import ci_log_retriever
+
+
+# --- Failure categories ---
+
+# Category constants. Each maps to a human-readable description.
+CATEGORIES = {
+    "test_assertion_failure": (
+        "A test assertion failed — the code under test produced an "
+        "unexpected result."
+    ),
+    "panic": (
+        "A Go panic, segfault, or fatal runtime error crashed the process."
+    ),
+    "timeout": (
+        "The job or test exceeded its time limit."
+    ),
+    "network_error": (
+        "A network-related failure: DNS resolution, connection refused, "
+        "TLS handshake, or HTTP timeout."
+    ),
+    "infrastructure_failure": (
+        "CI infrastructure problem: VM boot, lima setup, runner issue, "
+        "or disk/mount error."
+    ),
+    "resource_exhaustion": (
+        "System resource exhaustion: OOM, file descriptor limit, "
+        "storage space, or process limit."
+    ),
+    "container_runtime_error": (
+        "Container runtime failure: crun/runc error, namespace setup, "
+        "cgroup, or seccomp problem."
+    ),
+    "image_pull_failure": (
+        "Failed to pull a container image from a registry."
+    ),
+    "build_failure": (
+        "Compilation or build error: Go build failure, linker error, "
+        "or missing dependency."
+    ),
+    "dependency_failure": (
+        "External dependency failure: package install, pip/go module "
+        "download, or missing tool."
+    ),
+    "permission_error": (
+        "Permission or access denied error in test execution."
+    ),
+    "unknown": (
+        "Could not determine the failure category from the available "
+        "log content."
+    ),
+}
+
+
+# --- Classification rules ---
+
+@dataclass
+class ClassificationRule:
+    """A single pattern-matching rule for failure classification."""
+
+    category: str
+    name: str
+    patterns: list  # List of compiled regex patterns (any match triggers).
+    confidence: float  # 0.0 to 1.0
+    priority: int = 0  # Higher priority rules win ties.
+
+    def match(self, text: str) -> Optional[dict]:
+        """
+        Test if this rule matches the given text.
+
+        Returns a dict with match details if any pattern matches,
+        or None if no match.
+        """
+        for pattern in self.patterns:
+            m = pattern.search(text)
+            if m:
+                # Extract evidence: the matching line plus context.
+                start = max(0, m.start() - 200)
+                end = min(len(text), m.end() + 200)
+                evidence = text[start:end].strip()
+                return {
+                    "rule_name": self.name,
+                    "category": self.category,
+                    "confidence": self.confidence,
+                    "priority": self.priority,
+                    "matched_pattern": pattern.pattern,
+                    "matched_text": m.group(0)[:200],
+                    "evidence": evidence[:500],
+                }
+        return None
+
+
+def _compile_rules() -> list:
+    """
+    Build the ordered list of classification rules.
+
+    Rules are ordered by specificity — more specific patterns first,
+    with higher priority. When multiple rules match, the highest
+    priority+confidence combination wins.
+    """
+    rules = []
+
+    # --- Panic / crash (highest priority — always significant) ---
+    rules.append(ClassificationRule(
+        category="panic",
+        name="go_panic",
+        patterns=[
+            re.compile(r"^panic:\s", re.MULTILINE),
+            re.compile(r"^fatal error:\s", re.MULTILINE),
+            re.compile(r"signal SIGSEGV", re.IGNORECASE),
+            re.compile(r"signal SIGABRT", re.IGNORECASE),
+            re.compile(r"^goroutine \d+ \[running\]", re.MULTILINE),
+        ],
+        confidence=0.95,
+        priority=100,
+    ))
+
+    # --- Timeout ---
+    rules.append(ClassificationRule(
+        category="timeout",
+        name="job_timeout",
+        patterns=[
+            re.compile(r"The job running on runner .+ has exceeded the maximum execution time", re.IGNORECASE),
+            re.compile(r"Error:\s+Timed out after\s+\d+", re.IGNORECASE),
+            re.compile(r"context deadline exceeded"),
+            re.compile(r"timed?\s*out.*waiting", re.IGNORECASE),
+            re.compile(r"test\s+timed?\s*out\s+after", re.IGNORECASE),
+        ],
+        confidence=0.90,
+        priority=90,
+    ))
+
+    # --- Resource exhaustion ---
+    rules.append(ClassificationRule(
+        category="resource_exhaustion",
+        name="oom",
+        patterns=[
+            re.compile(r"Out [Oo]f [Mm]emory", re.IGNORECASE),
+            re.compile(r"OOM\s*kill", re.IGNORECASE),
+            re.compile(r"Cannot allocate memory", re.IGNORECASE),
+            re.compile(r"oom-kill:"),
+            re.compile(r"Killed\s+process\s+\d+"),
+        ],
+        confidence=0.95,
+        priority=85,
+    ))
+
+    rules.append(ClassificationRule(
+        category="resource_exhaustion",
+        name="disk_space",
+        patterns=[
+            re.compile(r"No space left on device", re.IGNORECASE),
+            re.compile(r"ENOSPC"),
+            re.compile(r"Disk quota exceeded", re.IGNORECASE),
+        ],
+        confidence=0.95,
+        priority=85,
+    ))
+
+    rules.append(ClassificationRule(
+        category="resource_exhaustion",
+        name="fd_limit",
+        patterns=[
+            re.compile(r"Too many open files", re.IGNORECASE),
+            re.compile(r"EMFILE"),
+            re.compile(r"ENFILE"),
+        ],
+        confidence=0.90,
+        priority=80,
+    ))
+
+    # --- Infrastructure failure ---
+    rules.append(ClassificationRule(
+        category="infrastructure_failure",
+        name="lima_vm_failure",
+        patterns=[
+            re.compile(r"limactl.*(?:failed|error|timeout)", re.IGNORECASE),
+            re.compile(r"lima.*VM.*(?:failed|not running|crashed)", re.IGNORECASE),
+            re.compile(r"FATA\[.*\].*lima", re.IGNORECASE),
+            re.compile(r"failed to start.*VM", re.IGNORECASE),
+        ],
+        confidence=0.90,
+        priority=80,
+    ))
+
+    rules.append(ClassificationRule(
+        category="infrastructure_failure",
+        name="runner_failure",
+        patterns=[
+            re.compile(r"Runner\s+.*(?:lost|disconnected|offline)", re.IGNORECASE),
+            re.compile(r"The self-hosted runner.*lost communication", re.IGNORECASE),
+            re.compile(r"Receiving request timed out", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=75,
+    ))
+
+    # --- Network errors ---
+    rules.append(ClassificationRule(
+        category="network_error",
+        name="dns_failure",
+        patterns=[
+            re.compile(r"(?:Temporary failure|NXDOMAIN).*(?:name resolution|resolving)", re.IGNORECASE),
+            re.compile(r"could not resolve host", re.IGNORECASE),
+            re.compile(r"Name or service not known", re.IGNORECASE),
+            re.compile(r"no such host", re.IGNORECASE),
+        ],
+        confidence=0.90,
+        priority=70,
+    ))
+
+    rules.append(ClassificationRule(
+        category="network_error",
+        name="connection_failure",
+        patterns=[
+            re.compile(r"connection refused", re.IGNORECASE),
+            re.compile(r"connection reset by peer", re.IGNORECASE),
+            re.compile(r"connection timed out", re.IGNORECASE),
+            re.compile(r"dial tcp.*: i/o timeout"),
+            re.compile(r"TLS handshake timeout", re.IGNORECASE),
+            re.compile(r"Client\.Timeout exceeded", re.IGNORECASE),
+            re.compile(r"net/http:.*timeout", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=70,
+    ))
+
+    # --- Image pull failures ---
+    rules.append(ClassificationRule(
+        category="image_pull_failure",
+        name="registry_error",
+        patterns=[
+            re.compile(r"(?:failed to|error|unable to)\s+pull\s+(?:image|manifest)", re.IGNORECASE),
+            re.compile(r"manifest unknown", re.IGNORECASE),
+            re.compile(r"(?:401|403)\s+(?:Unauthorized|Forbidden).*registry", re.IGNORECASE),
+            re.compile(r"(?:registry|quay\.io|docker\.io).*(?:unavailable|timeout|error)", re.IGNORECASE),
+            re.compile(r"Error: initializing source.*registry", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=65,
+    ))
+
+    # --- Container runtime errors ---
+    rules.append(ClassificationRule(
+        category="container_runtime_error",
+        name="crun_runc_error",
+        patterns=[
+            re.compile(r"(?:crun|runc):\s+(?:error|fatal)", re.IGNORECASE),
+            re.compile(r"OCI runtime error", re.IGNORECASE),
+            re.compile(r"error creating.*(?:namespace|cgroup)", re.IGNORECASE),
+            re.compile(r"rootfs_linux\.go.*mounting", re.IGNORECASE),
+            re.compile(r"error setting up.*network", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=60,
+    ))
+
+    # --- Build failure ---
+    rules.append(ClassificationRule(
+        category="build_failure",
+        name="go_build_error",
+        patterns=[
+            re.compile(r"^#\s+\S+\n.*\.go:\d+:\d+:.*(?:undefined|cannot|undeclared)", re.MULTILINE),
+            re.compile(r"cannot find package", re.IGNORECASE),
+            re.compile(r"could not import", re.IGNORECASE),
+            re.compile(r"build failed", re.IGNORECASE),
+            re.compile(r"(?:linker|ld).*(?:undefined reference|symbol)", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=55,
+    ))
+
+    # --- Dependency failure ---
+    rules.append(ClassificationRule(
+        category="dependency_failure",
+        name="package_install_failure",
+        patterns=[
+            re.compile(r"(?:dnf|apt-get|yum|rpm).*(?:error|failed|unable)", re.IGNORECASE),
+            re.compile(r"pip.*(?:error|failed).*install", re.IGNORECASE),
+            re.compile(r"go: .*module.*not found", re.IGNORECASE),
+            re.compile(r"No matching packages", re.IGNORECASE),
+        ],
+        confidence=0.80,
+        priority=50,
+    ))
+
+    # --- Permission errors ---
+    rules.append(ClassificationRule(
+        category="permission_error",
+        name="access_denied",
+        patterns=[
+            re.compile(r"(?:Permission|Access)\s+denied", re.IGNORECASE),
+            re.compile(r"EACCES"),
+            re.compile(r"operation not permitted", re.IGNORECASE),
+            re.compile(r"(?:rootless|unprivileged).*not.*(?:allowed|supported)", re.IGNORECASE),
+        ],
+        confidence=0.80,
+        priority=45,
+    ))
+
+    # --- Test assertion failures (lowest priority — most common, least specific) ---
+    rules.append(ClassificationRule(
+        category="test_assertion_failure",
+        name="ginkgo_assertion",
+        patterns=[
+            re.compile(r"^\[FAIL\]", re.MULTILINE),
+            re.compile(r"^Expected\s*$", re.MULTILINE),
+            re.compile(r"Expected\s+\n\s+<.*>:", re.MULTILINE),
+            re.compile(r"to equal\s*$", re.MULTILINE),
+            re.compile(r"Unexpected error:", re.IGNORECASE),
+            re.compile(r"FAIL!\s+--\s+\d+\s+Passed\s*\|\s*[1-9]\d*\s+Failed"),
+        ],
+        confidence=0.85,
+        priority=40,
+    ))
+
+    rules.append(ClassificationRule(
+        category="test_assertion_failure",
+        name="bats_assertion",
+        patterns=[
+            re.compile(r"^not ok\s+\d+", re.MULTILINE),
+            re.compile(r"expected:\s+\d+\s*$\s*actual:\s+\d+", re.MULTILINE),
+            re.compile(r"#\s+\(in test file.*\.bats", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=40,
+    ))
+
+    return rules
+
+
+# Module-level compiled rules (built once at import time).
+RULES = _compile_rules()
+
+
+# --- Classification result ---
+
+@dataclass
+class ClassificationResult:
+    """The result of classifying a single failure record."""
+
+    category: str
+    category_description: str
+    confidence: float
+    rule_name: str
+    matched_pattern: str
+    matched_text: str
+    evidence: str
+    all_matches: list = field(default_factory=list)
+
+
+def classify_text(text: str, rules: Optional[list] = None) -> ClassificationResult:
+    """
+    Classify a block of text against all rules.
+
+    Returns the highest-priority match, with all matches stored
+    in `all_matches` for transparency.
+    """
+    if rules is None:
+        rules = RULES
+
+    all_matches = []
+    for rule in rules:
+        match = rule.match(text)
+        if match:
+            all_matches.append(match)
+
+    if not all_matches:
+        return ClassificationResult(
+            category="unknown",
+            category_description=CATEGORIES["unknown"],
+            confidence=0.0,
+            rule_name="none",
+            matched_pattern="",
+            matched_text="",
+            evidence="",
+        )
+
+    # Sort by priority (descending), then confidence (descending).
+    all_matches.sort(key=lambda m: (m["priority"], m["confidence"]), reverse=True)
+    best = all_matches[0]
+
+    return ClassificationResult(
+        category=best["category"],
+        category_description=CATEGORIES.get(best["category"], ""),
+        confidence=best["confidence"],
+        rule_name=best["rule_name"],
+        matched_pattern=best["matched_pattern"],
+        matched_text=best["matched_text"],
+        evidence=best["evidence"],
+        all_matches=all_matches,
+    )
+
+
+def classify_failure_record(record: dict) -> dict:
+    """
+    Classify a FailureRecord (from ci_log_retriever) and return
+    the record augmented with classification data.
+    """
+    # Combine all text sources for classification.
+    text_parts = []
+
+    # Prioritize failure sections (most relevant).
+    for section in record.get("failure_sections", []):
+        text_parts.append(section.get("text", ""))
+
+    # Fall back to the full normalized log excerpt.
+    excerpt = record.get("normalized_log_excerpt", "")
+    if excerpt:
+        text_parts.append(excerpt)
+
+    combined_text = "\n".join(text_parts)
+
+    if not combined_text.strip():
+        result = ClassificationResult(
+            category="unknown",
+            category_description=CATEGORIES["unknown"],
+            confidence=0.0,
+            rule_name="no_log_content",
+            matched_pattern="",
+            matched_text="",
+            evidence="No log content available for classification.",
+        )
+    else:
+        result = classify_text(combined_text)
+
+    # Augment the record with classification.
+    classified = dict(record)
+    classified["classification"] = {
+        "category": result.category,
+        "category_description": result.category_description,
+        "confidence": result.confidence,
+        "rule_name": result.rule_name,
+        "matched_text": result.matched_text,
+        "evidence": result.evidence,
+        "all_matches_count": len(result.all_matches),
+    }
+
+    return classified
+
+
+def format_classification_summary(records: list) -> str:
+    """Format classified records as a human-readable summary."""
+    lines = []
+    # Group by category.
+    by_category = {}
+    for rec in records:
+        cat = rec.get("classification", {}).get("category", "unknown")
+        by_category.setdefault(cat, []).append(rec)
+
+    lines.append(f"Classification Summary ({len(records)} failures)")
+    lines.append("=" * 50)
+
+    for cat in sorted(by_category, key=lambda c: len(by_category[c]), reverse=True):
+        recs = by_category[cat]
+        lines.append(f"\n{cat} ({len(recs)}):")
+        lines.append(f"  {CATEGORIES.get(cat, '')}")
+        for rec in recs:
+            clf = rec.get("classification", {})
+            lines.append(
+                f"  - Run #{rec.get('run_number', '?')} "
+                f"job={rec.get('job_name', '?')!r} "
+                f"conf={clf.get('confidence', 0):.0%} "
+                f"rule={clf.get('rule_name', '?')}"
+            )
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Classify CI failure logs into categories.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", ci_log_retriever.DEFAULT_REPO),
+        help="GitHub repository",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=int,
+        help="Fetch and classify failures for a specific run ID",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read failure records from stdin (JSON from ci_log_retriever.py)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Output human-readable summary (default)",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        if args.stdin:
+            records = json.load(sys.stdin)
+            if isinstance(records, dict):
+                records = [records]
+        elif args.run_id:
+            # Full pipeline: collect → retrieve logs → classify.
+            run_data = ci_run_collector.collect_single_run(
+                args.repo, args.run_id, token
+            )
+            records = ci_log_retriever.build_failure_records(
+                run_data, repo=args.repo, token=token
+            )
+        else:
+            parser.error("Specify --run-id or --stdin")
+            return
+
+        classified = [classify_failure_record(r) for r in records]
+
+        if args.json_output:
+            json.dump(classified, sys.stdout, indent=2)
+            print()
+        else:
+            if not classified:
+                print("No failure records to classify.")
+            else:
+                print(format_classification_summary(classified))
+
+    except ci_run_collector.GitHubAPIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except (json.JSONDecodeError, KeyError) as e:
+        print(f"Error: Invalid input data: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_failure_classifier_test.py
+++ b/hack/ci/ci_failure_classifier_test.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_failure_classifier.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_failure_classifier_test.py -v
+    python3 hack/ci/ci_failure_classifier_test.py
+"""
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_failure_classifier
+
+
+# --- Realistic log snippets for each failure category ---
+
+LOG_GINKGO_ASSERTION = """\
+-----
+[FAIL] Podman run with volume
+  Expected
+      <string>: /tmp/testdir
+  to equal
+      <string>: /tmp/expected
+-----
+FAIL! -- 45 Passed | 1 Failed | 0 Pending | 3 Skipped
+"""
+
+LOG_BATS_ASSERTION = """\
+1..50
+ok 1 podman ps
+ok 2 podman images
+not ok 3 podman run with networking
+# (in test file test/system/500-networking.bats, line 42)
+#   `run_podman run --rm --net=host alpine wget -qO- http://localhost:8080' failed
+#   expected: 0
+#   actual:   7
+ok 4 podman stop
+"""
+
+LOG_GO_PANIC = """\
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1234]
+
+goroutine 1 [running]:
+main.(*Runtime).Start(0x0, 0xc000123456)
+    /go/src/podman/libpod/runtime.go:123 +0x45
+"""
+
+LOG_SIGABRT = """\
+signal SIGABRT received, stopping runtime
+goroutine 42 [running]:
+os/signal.signal_recv()
+"""
+
+LOG_TIMEOUT = """\
+The job running on runner cncf-ubuntu-8-32-x86-abc has exceeded the maximum execution time of 30 minutes
+Canceling job...
+"""
+
+LOG_CONTEXT_DEADLINE = """\
+Error: context deadline exceeded: failed to connect to /run/podman/podman.sock
+Error: timed out waiting for container
+"""
+
+LOG_OOM = """\
+kernel: Out of memory: Killed process 12345 (podman) total-vm:8388608kB
+oom-kill: constraint=CONSTRAINT_MEMCG
+"""
+
+LOG_DISK_SPACE = """\
+Error: writing blob: copying layer sha256:abc123
+No space left on device
+ENOSPC
+"""
+
+LOG_FD_LIMIT = """\
+Error: unable to create runtime: Too many open files
+"""
+
+LOG_LIMA_FAILURE = """\
+FATA[0120] limactl: failed to start VM: error mounting volume
+lima VM not running after setup, check host configuration
+"""
+
+LOG_RUNNER_FAILURE = """\
+The self-hosted runner lost communication with the server.
+Receiving request timed out.
+"""
+
+LOG_DNS_FAILURE = """\
+Error: failed to pull image: could not resolve host: quay.io
+Temporary failure in name resolution
+"""
+
+LOG_CONNECTION_FAILURE = """\
+dial tcp 10.0.2.15:5000: connection refused
+Get "https://registry.example.com/v2/": net/http: TLS handshake timeout
+"""
+
+LOG_IMAGE_PULL = """\
+Error: initializing source docker://quay.io/libpod/testimage:latest:
+failed to pull image: manifest unknown
+"""
+
+LOG_CRUN_ERROR = """\
+crun: error creating container: OCI runtime error
+error creating new namespace: operation not permitted
+"""
+
+LOG_BUILD_FAILURE = """\
+# go.podman.io/podman/v6/cmd/podman
+cmd/podman/main.go:42:15: undefined: newCommand
+build failed
+"""
+
+LOG_DEPENDENCY_FAILURE = """\
+dnf install -y golang
+Error: No matching packages to list
+"""
+
+LOG_PERMISSION_ERROR = """\
+Error: Permission denied while trying to bind mount /proc/sys
+operation not permitted for rootless user
+"""
+
+LOG_CLEAN = """\
+Running test suite
+ok 1 podman ps
+ok 2 podman images
+ok 3 podman run
+SUCCESS! -- 3 Passed | 0 Failed | 0 Skipped
+"""
+
+
+class TestClassifyText(unittest.TestCase):
+    """Tests for classify_text with each failure category."""
+
+    def test_ginkgo_assertion(self):
+        result = ci_failure_classifier.classify_text(LOG_GINKGO_ASSERTION)
+        self.assertEqual(result.category, "test_assertion_failure")
+        self.assertGreater(result.confidence, 0.5)
+
+    def test_bats_assertion(self):
+        result = ci_failure_classifier.classify_text(LOG_BATS_ASSERTION)
+        self.assertEqual(result.category, "test_assertion_failure")
+        self.assertIn("bats", result.rule_name)
+
+    def test_go_panic(self):
+        result = ci_failure_classifier.classify_text(LOG_GO_PANIC)
+        self.assertEqual(result.category, "panic")
+        self.assertGreaterEqual(result.confidence, 0.90)
+
+    def test_sigabrt(self):
+        result = ci_failure_classifier.classify_text(LOG_SIGABRT)
+        self.assertEqual(result.category, "panic")
+
+    def test_timeout(self):
+        result = ci_failure_classifier.classify_text(LOG_TIMEOUT)
+        self.assertEqual(result.category, "timeout")
+        self.assertGreaterEqual(result.confidence, 0.85)
+
+    def test_context_deadline(self):
+        result = ci_failure_classifier.classify_text(LOG_CONTEXT_DEADLINE)
+        self.assertEqual(result.category, "timeout")
+
+    def test_oom(self):
+        result = ci_failure_classifier.classify_text(LOG_OOM)
+        self.assertEqual(result.category, "resource_exhaustion")
+        self.assertGreaterEqual(result.confidence, 0.90)
+
+    def test_disk_space(self):
+        result = ci_failure_classifier.classify_text(LOG_DISK_SPACE)
+        self.assertEqual(result.category, "resource_exhaustion")
+
+    def test_fd_limit(self):
+        result = ci_failure_classifier.classify_text(LOG_FD_LIMIT)
+        self.assertEqual(result.category, "resource_exhaustion")
+
+    def test_lima_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_LIMA_FAILURE)
+        self.assertEqual(result.category, "infrastructure_failure")
+
+    def test_runner_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_RUNNER_FAILURE)
+        self.assertEqual(result.category, "infrastructure_failure")
+
+    def test_dns_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_DNS_FAILURE)
+        self.assertEqual(result.category, "network_error")
+
+    def test_connection_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_CONNECTION_FAILURE)
+        self.assertEqual(result.category, "network_error")
+
+    def test_image_pull(self):
+        result = ci_failure_classifier.classify_text(LOG_IMAGE_PULL)
+        self.assertEqual(result.category, "image_pull_failure")
+
+    def test_crun_error(self):
+        result = ci_failure_classifier.classify_text(LOG_CRUN_ERROR)
+        self.assertEqual(result.category, "container_runtime_error")
+
+    def test_build_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_BUILD_FAILURE)
+        self.assertEqual(result.category, "build_failure")
+
+    def test_dependency_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_DEPENDENCY_FAILURE)
+        self.assertEqual(result.category, "dependency_failure")
+
+    def test_permission_error(self):
+        result = ci_failure_classifier.classify_text(LOG_PERMISSION_ERROR)
+        self.assertEqual(result.category, "permission_error")
+
+    def test_clean_log_returns_unknown(self):
+        result = ci_failure_classifier.classify_text(LOG_CLEAN)
+        self.assertEqual(result.category, "unknown")
+
+    def test_empty_text_returns_unknown(self):
+        result = ci_failure_classifier.classify_text("")
+        self.assertEqual(result.category, "unknown")
+        self.assertEqual(result.confidence, 0.0)
+
+
+class TestPriorityResolution(unittest.TestCase):
+    """Tests that higher-priority rules win when multiple rules match."""
+
+    def test_panic_beats_assertion(self):
+        """A log with both panic and assertion markers should classify as panic."""
+        text = LOG_GO_PANIC + "\n" + LOG_GINKGO_ASSERTION
+        result = ci_failure_classifier.classify_text(text)
+        self.assertEqual(result.category, "panic")
+
+    def test_timeout_beats_assertion(self):
+        """Timeout is more specific than assertion failure."""
+        text = LOG_TIMEOUT + "\n" + LOG_BATS_ASSERTION
+        result = ci_failure_classifier.classify_text(text)
+        self.assertEqual(result.category, "timeout")
+
+    def test_oom_beats_assertion(self):
+        """OOM is more specific than assertion failure."""
+        text = LOG_OOM + "\n" + LOG_GINKGO_ASSERTION
+        result = ci_failure_classifier.classify_text(text)
+        self.assertEqual(result.category, "resource_exhaustion")
+
+    def test_all_matches_tracked(self):
+        """When multiple rules match, all are recorded."""
+        text = LOG_GO_PANIC + "\n" + LOG_GINKGO_ASSERTION
+        result = ci_failure_classifier.classify_text(text)
+        self.assertGreater(len(result.all_matches), 1)
+
+
+class TestClassifyFailureRecord(unittest.TestCase):
+    """Tests for classify_failure_record with FailureRecord dicts."""
+
+    def test_classifies_from_failure_sections(self):
+        record = {
+            "run_id": 12345,
+            "run_number": 100,
+            "workflow": "ci",
+            "job_name": "sys local root fedora-current",
+            "job_id": 90001,
+            "step_name": "Run test on lima",
+            "branch": "main",
+            "commit_sha": "abc123",
+            "commit_message": "test commit",
+            "event": "push",
+            "created_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com",
+            "failure_sections": [
+                {"type": "ginkgo_failure", "text": LOG_GINKGO_ASSERTION},
+            ],
+            "normalized_log_excerpt": "",
+            "raw_log_bytes": 1024,
+        }
+        result = ci_failure_classifier.classify_failure_record(record)
+        clf = result["classification"]
+        self.assertEqual(clf["category"], "test_assertion_failure")
+        self.assertGreater(clf["confidence"], 0.0)
+        self.assertIn("category_description", clf)
+
+    def test_classifies_from_log_excerpt(self):
+        """Falls back to normalized_log_excerpt if no failure_sections."""
+        record = {
+            "run_id": 12345,
+            "run_number": 100,
+            "workflow": "ci",
+            "job_name": "test-job",
+            "job_id": 90001,
+            "step_name": "step",
+            "branch": "main",
+            "commit_sha": "abc",
+            "commit_message": "msg",
+            "event": "push",
+            "created_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com",
+            "failure_sections": [],
+            "normalized_log_excerpt": LOG_GO_PANIC,
+            "raw_log_bytes": 512,
+        }
+        result = ci_failure_classifier.classify_failure_record(record)
+        self.assertEqual(result["classification"]["category"], "panic")
+
+    def test_unknown_when_no_content(self):
+        record = {
+            "run_id": 12345,
+            "run_number": 100,
+            "workflow": "ci",
+            "job_name": "test-job",
+            "job_id": 90001,
+            "step_name": "step",
+            "branch": "main",
+            "commit_sha": "abc",
+            "commit_message": "msg",
+            "event": "push",
+            "created_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com",
+            "failure_sections": [],
+            "normalized_log_excerpt": "",
+            "raw_log_bytes": 0,
+        }
+        result = ci_failure_classifier.classify_failure_record(record)
+        self.assertEqual(result["classification"]["category"], "unknown")
+
+    def test_preserves_original_fields(self):
+        """Classification should augment, not replace, original fields."""
+        record = {
+            "run_id": 12345,
+            "run_number": 100,
+            "workflow": "ci",
+            "job_name": "test-job",
+            "job_id": 90001,
+            "step_name": "step",
+            "branch": "main",
+            "commit_sha": "abc123",
+            "commit_message": "test",
+            "event": "push",
+            "created_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com",
+            "failure_sections": [],
+            "normalized_log_excerpt": LOG_DNS_FAILURE,
+            "raw_log_bytes": 256,
+        }
+        result = ci_failure_classifier.classify_failure_record(record)
+        # Original fields preserved.
+        self.assertEqual(result["run_id"], 12345)
+        self.assertEqual(result["job_name"], "test-job")
+        self.assertEqual(result["commit_sha"], "abc123")
+        # Classification added.
+        self.assertIn("classification", result)
+        self.assertEqual(result["classification"]["category"], "network_error")
+
+
+class TestFormatSummary(unittest.TestCase):
+    """Tests for format_classification_summary."""
+
+    def test_groups_by_category(self):
+        records = [
+            {
+                "run_number": 1,
+                "job_name": "job-a",
+                "classification": {
+                    "category": "panic",
+                    "confidence": 0.95,
+                    "rule_name": "go_panic",
+                },
+            },
+            {
+                "run_number": 2,
+                "job_name": "job-b",
+                "classification": {
+                    "category": "panic",
+                    "confidence": 0.90,
+                    "rule_name": "go_panic",
+                },
+            },
+            {
+                "run_number": 3,
+                "job_name": "job-c",
+                "classification": {
+                    "category": "network_error",
+                    "confidence": 0.85,
+                    "rule_name": "dns_failure",
+                },
+            },
+        ]
+        output = ci_failure_classifier.format_classification_summary(records)
+        self.assertIn("panic (2)", output)
+        self.assertIn("network_error (1)", output)
+        self.assertIn("3 failures", output)
+
+    def test_empty_records(self):
+        output = ci_failure_classifier.format_classification_summary([])
+        self.assertIn("0 failures", output)
+
+
+class TestClassificationRule(unittest.TestCase):
+    """Tests for the ClassificationRule dataclass."""
+
+    def test_match_returns_evidence(self):
+        rule = ci_failure_classifier.ClassificationRule(
+            category="test",
+            name="test_rule",
+            patterns=[ci_failure_classifier.re.compile(r"FAIL")],
+            confidence=0.9,
+            priority=50,
+        )
+        result = rule.match("This test will FAIL here")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "test")
+        self.assertEqual(result["matched_text"], "FAIL")
+        self.assertIn("FAIL", result["evidence"])
+
+    def test_no_match_returns_none(self):
+        rule = ci_failure_classifier.ClassificationRule(
+            category="test",
+            name="test_rule",
+            patterns=[ci_failure_classifier.re.compile(r"NONEXISTENT")],
+            confidence=0.9,
+            priority=50,
+        )
+        result = rule.match("Nothing matches here")
+        self.assertIsNone(result)
+
+
+class TestCategoriesComplete(unittest.TestCase):
+    """Ensure all categories used in rules have descriptions."""
+
+    def test_all_rule_categories_have_descriptions(self):
+        for rule in ci_failure_classifier.RULES:
+            self.assertIn(
+                rule.category,
+                ci_failure_classifier.CATEGORIES,
+                f"Rule '{rule.name}' uses category '{rule.category}' "
+                f"which has no description in CATEGORIES.",
+            )
+
+    def test_unknown_category_exists(self):
+        self.assertIn("unknown", ci_failure_classifier.CATEGORIES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hack/ci/ci_log_retriever.py
+++ b/hack/ci/ci_log_retriever.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+ci_log_retriever - Retrieve and normalize CI failure logs from GitHub Actions.
+
+Downloads raw job logs via the GitHub Actions API, strips noise
+(ANSI escapes, timestamps, GitHub Actions markup), extracts
+failure-relevant sections, and produces structured failure records
+suitable for downstream classification and flake detection.
+
+Usage:
+    # Retrieve logs for failed jobs from a specific run
+    ./hack/ci/ci_log_retriever.py --run-id 31813098642
+
+    # Pipe from ci_run_collector for batch processing
+    ./hack/ci/ci_run_collector.py --branch main --status failure --limit 5 --json | \
+        ./hack/ci/ci_log_retriever.py --stdin
+
+Environment:
+    GITHUB_TOKEN       Required for log downloads (API returns 302 redirects).
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+"""
+
+import argparse
+import io
+import json
+import os
+import re
+import sys
+import zipfile
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+# Import the API layer from PR 1.
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import ci_run_collector
+
+# Default repository.
+DEFAULT_REPO = "podman-container-tools/podman"
+# Maximum bytes of raw log to process per job (10 MB).
+MAX_LOG_BYTES = 10 * 1024 * 1024
+# Maximum bytes of extracted failure context to keep per record.
+MAX_FAILURE_EXCERPT_BYTES = 64 * 1024
+
+
+# --- ANSI / GHA noise stripping ---
+
+# ANSI escape sequences (colors, cursor movement, etc.).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?\x07")
+# GitHub Actions timestamp prefix: "2024-08-14T15:12:34.1234567Z "
+_GHA_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s?")
+# GitHub Actions group markers.
+_GHA_GROUP_RE = re.compile(r"^##\[(?:group|endgroup|command|error|warning|notice)\]")
+# Logformatter timestamp: "[+NNNs] "
+_LOGFORMATTER_TS_RE = re.compile(r"^\[\+\d+s\]\s?")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text."""
+    return _ANSI_RE.sub("", text)
+
+
+def strip_gha_timestamps(text: str) -> str:
+    """Remove GitHub Actions timestamp prefixes from each line."""
+    return "\n".join(
+        _GHA_TIMESTAMP_RE.sub("", line) for line in text.split("\n")
+    )
+
+
+def strip_gha_markup(text: str) -> str:
+    """Remove GitHub Actions workflow command markup (##[group], etc.)."""
+    return "\n".join(
+        line for line in text.split("\n") if not _GHA_GROUP_RE.match(line)
+    )
+
+
+def strip_logformatter_timestamps(text: str) -> str:
+    """Remove logformatter [+NNNs] timestamp prefixes."""
+    return "\n".join(
+        _LOGFORMATTER_TS_RE.sub("", line) for line in text.split("\n")
+    )
+
+
+# --- Secret redaction ---
+
+def _redact_hex_token(match: re.Match) -> str:
+    """
+    Selectively redact long hex strings that look like tokens.
+
+    Preserves git commit SHAs (exactly 40 hex chars in git context)
+    and container image digests. Only redacts if the pattern is
+    unlikely to be a legitimate identifier.
+    """
+    value = match.group(0)
+    # Preserve 40-char strings that look like git SHAs.
+    if len(value) == 40:
+        return value
+    # Preserve sha256 digest prefixes (64 chars).
+    if len(value) == 64:
+        return value
+    # Redact everything else.
+    return f"[REDACTED_TOKEN_{len(value)}chars]"
+
+
+# Common secret patterns to redact from logs before analysis.
+_SECRET_PATTERNS = [
+    # GitHub tokens (classic and fine-grained).
+    (re.compile(r"ghp_[A-Za-z0-9]{36,}"), "[REDACTED_GH_TOKEN]"),
+    (re.compile(r"ghs_[A-Za-z0-9]{36,}"), "[REDACTED_GH_TOKEN]"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{80,}"), "[REDACTED_GH_TOKEN]"),
+    # Bearer/Basic auth headers.
+    (re.compile(r"(?i)(Bearer|Basic)\s+[A-Za-z0-9+/=_-]{20,}"), "[REDACTED_AUTH]"),
+    # URLs with embedded credentials.
+    (re.compile(r"https?://[^@\s]+:[^@\s]+@"), "https://[REDACTED]@"),
+    # AWS-style keys.
+    (re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}"), "[REDACTED_AWS_KEY]"),
+    # Generic long hex tokens (40+ chars, like SHA tokens).
+    (re.compile(r"(?<![a-fA-F0-9])[a-fA-F0-9]{40,}(?![a-fA-F0-9])"), _redact_hex_token),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Redact potential secrets and credentials from log text."""
+    for pattern, replacement in _SECRET_PATTERNS:
+        if callable(replacement):
+            text = pattern.sub(replacement, text)
+        else:
+            text = pattern.sub(replacement, text)
+    return text
+
+
+# --- Log normalization pipeline ---
+
+def normalize_log(raw_log: str) -> str:
+    """
+    Apply the full normalization pipeline to raw log content.
+
+    Order matters: strip ANSI first (it can interfere with other
+    patterns), then timestamps, then markup, then redact secrets.
+    """
+    text = strip_ansi(raw_log)
+    text = strip_gha_timestamps(text)
+    text = strip_gha_markup(text)
+    text = strip_logformatter_timestamps(text)
+    text = redact_secrets(text)
+    # Collapse excessive blank lines.
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+    return text
+
+
+# --- Failure section extraction ---
+
+# Ginkgo failure block markers.
+_GINKGO_FAIL_START_RE = re.compile(
+    r"^(?:\[FAIL\]|Failure \[|•! Failure|FAIL!)"
+    r"|^Unexpected error:|^Expected\s",
+    re.MULTILINE,
+)
+_GINKGO_DIVIDER_RE = re.compile(r"^-{5,}$", re.MULTILINE)
+# BATS failure markers.
+_BATS_FAIL_RE = re.compile(r"^not ok\s+\d+", re.MULTILINE)
+# Generic panic/fatal markers.
+_PANIC_RE = re.compile(r"^(?:panic:|fatal error:|SIGSEGV|goroutine \d+)", re.MULTILINE)
+# Ginkgo summary line with failure count.
+_GINKGO_SUMMARY_RE = re.compile(
+    r"^(?:FAIL!|SUCCESS!)\s+--\s+.*\d+\s+Passed", re.MULTILINE
+)
+
+
+def extract_failure_sections(log_text: str) -> list:
+    """
+    Extract failure-relevant sections from normalized log text.
+
+    Returns a list of (section_type, text) tuples.
+    Attempts to extract meaningful context around each failure
+    rather than returning the entire (potentially huge) log.
+    """
+    sections = []
+    lines = log_text.split("\n")
+
+    # Strategy: scan for failure markers, then capture context window.
+    for i, line in enumerate(lines):
+        section_type = None
+
+        if _GINKGO_FAIL_START_RE.search(line):
+            section_type = "ginkgo_failure"
+        elif _BATS_FAIL_RE.search(line):
+            section_type = "bats_failure"
+        elif _PANIC_RE.search(line):
+            section_type = "panic"
+        elif _GINKGO_SUMMARY_RE.search(line):
+            section_type = "ginkgo_summary"
+
+        if section_type:
+            # Capture context: 5 lines before, the match, and 30 lines after.
+            start = max(0, i - 5)
+            end = min(len(lines), i + 31)
+            context = "\n".join(lines[start:end])
+
+            # Avoid duplicate captures: skip if this overlaps with
+            # the previous section.
+            if sections and sections[-1][2] >= start:
+                # Extend the previous section instead.
+                prev_type, prev_text, prev_end = sections[-1]
+                if end > prev_end:
+                    extended = "\n".join(lines[prev_end:end])
+                    sections[-1] = (
+                        prev_type,
+                        prev_text + "\n" + extended,
+                        end,
+                    )
+                continue
+
+            sections.append((section_type, context, end))
+
+    # Strip internal end-index tracking before returning.
+    return [(t, text) for t, text, _ in sections]
+
+
+# --- Structured failure record ---
+
+@dataclass
+class FailureRecord:
+    """A structured record of a single CI failure."""
+
+    run_id: int
+    run_number: int
+    workflow: str
+    job_name: str
+    job_id: int
+    step_name: str
+    branch: str
+    commit_sha: str
+    commit_message: str
+    event: str
+    created_at: str
+    html_url: str
+    failure_sections: list = field(default_factory=list)
+    normalized_log_excerpt: str = ""
+    raw_log_bytes: int = 0
+
+
+# --- Log retrieval from GitHub Actions API ---
+
+def download_job_log(
+    repo: str, job_id: int, token: Optional[str] = None
+) -> Optional[str]:
+    """
+    Download the raw log for a specific job via the GitHub Actions API.
+
+    The API returns a 302 redirect to a time-limited URL for a zip
+    file containing the log. We follow the redirect and extract the
+    text content.
+
+    Returns the log as a string, or None if retrieval fails.
+    """
+    import urllib.request
+    import urllib.error
+
+    url = f"{ci_run_collector.API_BASE}/repos/{repo}/actions/jobs/{job_id}/logs"
+    headers = ci_run_collector._build_headers(token)
+
+    try:
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            content_type = resp.headers.get("Content-Type", "")
+            raw_bytes = resp.read(MAX_LOG_BYTES)
+
+            # The API may return a zip file or plain text depending
+            # on the redirect target.
+            if content_type == "application/zip" or raw_bytes[:4] == b"PK\x03\x04":
+                return _extract_zip_log(raw_bytes)
+            return raw_bytes.decode("utf-8", errors="replace")
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+        print(
+            f"Warning: Failed to download log for job {job_id}: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _extract_zip_log(zip_bytes: bytes) -> str:
+    """Extract text content from a zip file containing log data."""
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            # Concatenate all text files in the zip.
+            parts = []
+            for name in sorted(zf.namelist()):
+                try:
+                    content = zf.read(name).decode("utf-8", errors="replace")
+                    parts.append(f"=== {name} ===\n{content}")
+                except Exception:
+                    continue
+            return "\n".join(parts)
+    except zipfile.BadZipFile:
+        return zip_bytes.decode("utf-8", errors="replace")
+
+
+def build_failure_records(
+    run_data: dict,
+    repo: str = DEFAULT_REPO,
+    token: Optional[str] = None,
+    download_logs: bool = True,
+) -> list:
+    """
+    Build structured failure records from a single run's data.
+
+    Takes a run dict (as output by ci_run_collector) and produces
+    a list of FailureRecord dicts, one per failed job.
+    """
+    records = []
+    failed_jobs = [
+        j for j in run_data.get("jobs", []) if j.get("conclusion") == "failure"
+    ]
+
+    for job in failed_jobs:
+        failed_steps = job.get("failed_steps", [])
+        step_name = failed_steps[0]["name"] if failed_steps else "unknown"
+
+        record = FailureRecord(
+            run_id=run_data["run_id"],
+            run_number=run_data.get("run_number", 0),
+            workflow=run_data.get("workflow", ""),
+            job_name=job["name"],
+            job_id=job["job_id"],
+            step_name=step_name,
+            branch=run_data.get("branch", ""),
+            commit_sha=run_data.get("commit_sha", ""),
+            commit_message=run_data.get("commit_message", "").split("\n")[0],
+            event=run_data.get("event", ""),
+            created_at=run_data.get("created_at", ""),
+            html_url=job.get("html_url", ""),
+        )
+
+        if download_logs:
+            raw_log = download_job_log(repo, job["job_id"], token)
+            if raw_log:
+                record.raw_log_bytes = len(raw_log.encode("utf-8"))
+                normalized = normalize_log(raw_log)
+                # Extract failure sections.
+                sections = extract_failure_sections(normalized)
+                record.failure_sections = [
+                    {"type": t, "text": text[:MAX_FAILURE_EXCERPT_BYTES]}
+                    for t, text in sections
+                ]
+                # Keep a bounded excerpt of the full normalized log.
+                record.normalized_log_excerpt = normalized[
+                    :MAX_FAILURE_EXCERPT_BYTES
+                ]
+
+        records.append(asdict(record))
+
+    return records
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Retrieve and normalize CI failure logs.",
+        epilog="Requires GITHUB_TOKEN for log downloads.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=int,
+        help="Retrieve logs for a specific run ID",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read run data from stdin (JSON from ci_run_collector.py --json)",
+    )
+    parser.add_argument(
+        "--no-download",
+        action="store_true",
+        help="Skip log download (produce records from metadata only)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON (default)",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        if args.stdin:
+            run_data_list = json.load(sys.stdin)
+            if isinstance(run_data_list, dict):
+                run_data_list = [run_data_list]
+        elif args.run_id:
+            run_data = ci_run_collector.collect_single_run(
+                args.repo, args.run_id, token
+            )
+            run_data_list = [run_data]
+        else:
+            parser.error("Specify --run-id or --stdin")
+            return
+
+        all_records = []
+        for run_data in run_data_list:
+            records = build_failure_records(
+                run_data,
+                repo=args.repo,
+                token=token,
+                download_logs=not args.no_download,
+            )
+            all_records.extend(records)
+
+        json.dump(all_records, sys.stdout, indent=2)
+        print()
+
+    except ci_run_collector.RateLimitError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+    except ci_run_collector.GitHubAPIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except (json.JSONDecodeError, KeyError) as e:
+        print(f"Error: Invalid input data: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_log_retriever_test.py
+++ b/hack/ci/ci_log_retriever_test.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_log_retriever.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_log_retriever_test.py -v
+    python3 hack/ci/ci_log_retriever_test.py
+"""
+
+import io
+import json
+import os
+import sys
+import unittest
+import zipfile
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_log_retriever
+
+
+# --- Test fixtures: sample log content ---
+
+SAMPLE_RAW_LOG_GINKGO = """\
+2026-08-14T15:12:34.1234567Z ##[group]Run test on lima
+2026-08-14T15:12:34.2345678Z ./hack/ci/ci.sh sys local root fedora-current
+2026-08-14T15:12:34.3456789Z ##[endgroup]
+2026-08-14T15:12:35.0000000Z \x1b[1m\x1b[32mRunner executing test as root user\x1b[0m
+2026-08-14T15:12:36.0000000Z [+12s] Running integration test suite
+2026-08-14T15:12:40.0000000Z [+16s] Podman run with --rm
+2026-08-14T15:12:40.1000000Z [+16s]     Expected container to be removed
+2026-08-14T15:12:41.0000000Z [+17s] -----
+2026-08-14T15:12:42.0000000Z [+18s] [FAIL] Podman run with volume
+2026-08-14T15:12:43.0000000Z [+19s] Expected
+2026-08-14T15:12:44.0000000Z [+20s]     <string>: /tmp/testdir
+2026-08-14T15:12:45.0000000Z [+21s] to equal
+2026-08-14T15:12:46.0000000Z [+22s]     <string>: /tmp/expected
+2026-08-14T15:12:47.0000000Z [+23s] -----
+2026-08-14T15:12:50.0000000Z [+26s] FAIL! -- 45 Passed | 1 Failed | 0 Pending | 3 Skipped
+"""
+
+SAMPLE_RAW_LOG_BATS = """\
+2026-08-14T16:00:00.0000000Z [+1s] 1..50
+2026-08-14T16:00:01.0000000Z [+2s] ok 1 podman ps
+2026-08-14T16:00:02.0000000Z [+3s] ok 2 podman images
+2026-08-14T16:00:03.0000000Z [+4s] not ok 3 podman run with networking
+2026-08-14T16:00:04.0000000Z [+5s] # (in test file test/system/500-networking.bats, line 42)
+2026-08-14T16:00:05.0000000Z [+6s] #   `run_podman run --rm --net=host alpine wget -qO- http://localhost:8080' failed
+2026-08-14T16:00:06.0000000Z [+7s] #   expected: 0
+2026-08-14T16:00:07.0000000Z [+8s] #   actual:   7
+2026-08-14T16:00:08.0000000Z [+9s] ok 4 podman stop
+"""
+
+SAMPLE_RAW_LOG_PANIC = """\
+2026-08-14T17:00:00.0000000Z some normal output
+2026-08-14T17:00:01.0000000Z panic: runtime error: invalid memory address or nil pointer dereference
+2026-08-14T17:00:02.0000000Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1234]
+2026-08-14T17:00:03.0000000Z
+2026-08-14T17:00:04.0000000Z goroutine 1 [running]:
+2026-08-14T17:00:05.0000000Z main.(*Runtime).Start(0x0, 0xc000123456)
+2026-08-14T17:00:06.0000000Z     /go/src/podman/libpod/runtime.go:123 +0x45
+"""
+
+SAMPLE_LOG_WITH_SECRETS = """\
+Authenticating with token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklm
+Pulling from https://user:p4ssw0rd@registry.example.com/image
+Using key AKIAIOSFODNN7EXAMPLE to access bucket
+Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc123.xyz
+"""
+
+SAMPLE_RUN_DATA = {
+    "run_id": 31813098642,
+    "run_number": 1503,
+    "workflow": "ci",
+    "branch": "main",
+    "commit_sha": "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8",
+    "commit_message": "Merge pull request #29279\n\nlibpod: fix prune race",
+    "event": "push",
+    "created_at": "2026-08-14T15:09:38Z",
+    "jobs": [
+        {
+            "job_id": 90001,
+            "name": "validate-source",
+            "conclusion": "success",
+            "html_url": "https://example.com/job/90001",
+            "failed_steps": [],
+        },
+        {
+            "job_id": 90002,
+            "name": "sys local root fedora-current / lima",
+            "conclusion": "failure",
+            "html_url": "https://example.com/job/90002",
+            "failed_steps": [
+                {"name": "Run test on lima", "number": 4, "conclusion": "failure"},
+            ],
+        },
+    ],
+}
+
+
+class TestStripAnsi(unittest.TestCase):
+    """Tests for ANSI escape code stripping."""
+
+    def test_removes_color_codes(self):
+        text = "\x1b[1m\x1b[32mGreen bold\x1b[0m normal"
+        self.assertEqual(ci_log_retriever.strip_ansi(text), "Green bold normal")
+
+    def test_removes_osc_sequences(self):
+        text = "before\x1b]0;title\x07after"
+        self.assertEqual(ci_log_retriever.strip_ansi(text), "beforeafter")
+
+    def test_preserves_plain_text(self):
+        text = "No escapes here"
+        self.assertEqual(ci_log_retriever.strip_ansi(text), text)
+
+    def test_empty_string(self):
+        self.assertEqual(ci_log_retriever.strip_ansi(""), "")
+
+
+class TestStripGhaTimestamps(unittest.TestCase):
+    """Tests for GitHub Actions timestamp removal."""
+
+    def test_removes_timestamps(self):
+        text = "2026-08-14T15:12:34.1234567Z Hello world"
+        self.assertEqual(
+            ci_log_retriever.strip_gha_timestamps(text), "Hello world"
+        )
+
+    def test_multiline(self):
+        text = (
+            "2026-08-14T15:12:34.1234567Z line 1\n"
+            "2026-08-14T15:12:35.0000000Z line 2\n"
+            "no timestamp line 3"
+        )
+        result = ci_log_retriever.strip_gha_timestamps(text)
+        self.assertEqual(result, "line 1\nline 2\nno timestamp line 3")
+
+    def test_preserves_non_timestamp_lines(self):
+        text = "Just a normal line"
+        self.assertEqual(ci_log_retriever.strip_gha_timestamps(text), text)
+
+
+class TestStripGhaMarkup(unittest.TestCase):
+    """Tests for GitHub Actions markup removal."""
+
+    def test_removes_group_markers(self):
+        text = "##[group]Test Setup\nactual output\n##[endgroup]"
+        result = ci_log_retriever.strip_gha_markup(text)
+        self.assertEqual(result, "actual output")
+
+    def test_removes_error_notices(self):
+        text = "##[error]Something failed\nDetails here"
+        result = ci_log_retriever.strip_gha_markup(text)
+        self.assertEqual(result, "Details here")
+
+    def test_preserves_normal_hashes(self):
+        text = "## This is markdown\n### Not GHA markup"
+        self.assertEqual(ci_log_retriever.strip_gha_markup(text), text)
+
+
+class TestStripLogformatterTimestamps(unittest.TestCase):
+    """Tests for logformatter [+NNNs] timestamp removal."""
+
+    def test_removes_timestamps(self):
+        text = "[+12s] Running test\n[+100s] Done"
+        result = ci_log_retriever.strip_logformatter_timestamps(text)
+        self.assertEqual(result, "Running test\nDone")
+
+    def test_preserves_non_timestamp_brackets(self):
+        text = "[FAIL] test failed"
+        result = ci_log_retriever.strip_logformatter_timestamps(text)
+        self.assertEqual(result, text)
+
+
+class TestRedactSecrets(unittest.TestCase):
+    """Tests for secret redaction."""
+
+    def test_redacts_github_token(self):
+        text = "token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklm"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertNotIn("ghp_", result)
+        self.assertIn("[REDACTED_GH_TOKEN]", result)
+
+    def test_redacts_url_credentials(self):
+        text = "pulling https://user:pass@registry.com/image"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertNotIn("user:pass", result)
+        self.assertIn("[REDACTED]", result)
+
+    def test_redacts_bearer_token(self):
+        text = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abc"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertNotIn("eyJhbG", result)
+        self.assertIn("[REDACTED_AUTH]", result)
+
+    def test_redacts_aws_keys(self):
+        text = "key: AKIAIOSFODNN7EXAMPLE"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", result)
+        self.assertIn("[REDACTED_AWS_KEY]", result)
+
+    def test_preserves_git_shas(self):
+        """40-char hex strings that look like git SHAs should be preserved."""
+        sha = "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8"
+        text = f"commit {sha}"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertIn(sha, result)
+
+    def test_preserves_normal_text(self):
+        text = "No secrets here, just normal CI output."
+        self.assertEqual(ci_log_retriever.redact_secrets(text), text)
+
+
+class TestNormalizeLog(unittest.TestCase):
+    """Tests for the full normalization pipeline."""
+
+    def test_ginkgo_log_normalization(self):
+        result = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_GINKGO)
+        # ANSI codes should be gone.
+        self.assertNotIn("\x1b[", result)
+        # GHA timestamps should be gone.
+        self.assertNotIn("2026-08-14T15:12", result)
+        # GHA markup should be gone.
+        self.assertNotIn("##[group]", result)
+        # Logformatter timestamps should be gone.
+        self.assertNotIn("[+12s]", result)
+        # Actual content should remain.
+        self.assertIn("[FAIL] Podman run with volume", result)
+        self.assertIn("FAIL!", result)
+
+    def test_bats_log_normalization(self):
+        result = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_BATS)
+        self.assertIn("not ok 3 podman run with networking", result)
+        self.assertNotIn("2026-08-14T16:00", result)
+
+    def test_collapses_excessive_blank_lines(self):
+        text = "line1\n\n\n\n\n\n\nline2"
+        result = ci_log_retriever.normalize_log(text)
+        self.assertEqual(result.count("\n\n\n\n"), 0)
+        self.assertIn("line1", result)
+        self.assertIn("line2", result)
+
+
+class TestExtractFailureSections(unittest.TestCase):
+    """Tests for failure section extraction."""
+
+    def test_extracts_ginkgo_failure(self):
+        normalized = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_GINKGO)
+        sections = ci_log_retriever.extract_failure_sections(normalized)
+        self.assertTrue(len(sections) > 0)
+        types = [t for t, _ in sections]
+        self.assertIn("ginkgo_failure", types)
+
+    def test_extracts_bats_failure(self):
+        normalized = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_BATS)
+        sections = ci_log_retriever.extract_failure_sections(normalized)
+        self.assertTrue(len(sections) > 0)
+        types = [t for t, _ in sections]
+        self.assertIn("bats_failure", types)
+
+    def test_extracts_panic(self):
+        normalized = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_PANIC)
+        sections = ci_log_retriever.extract_failure_sections(normalized)
+        self.assertTrue(len(sections) > 0)
+        types = [t for t, _ in sections]
+        self.assertIn("panic", types)
+
+    def test_extracts_ginkgo_summary(self):
+        normalized = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_GINKGO)
+        sections = ci_log_retriever.extract_failure_sections(normalized)
+        types = [t for t, _ in sections]
+        # Should find the FAIL! summary line.
+        self.assertTrue(
+            "ginkgo_summary" in types or "ginkgo_failure" in types,
+            f"Expected ginkgo_summary or ginkgo_failure in {types}",
+        )
+
+    def test_no_false_positives_on_clean_log(self):
+        clean_log = "All tests passed\nok 1 test\nok 2 test\nSUCCESS!"
+        sections = ci_log_retriever.extract_failure_sections(clean_log)
+        self.assertEqual(len(sections), 0)
+
+    def test_deduplicates_overlapping_sections(self):
+        """Adjacent failure markers should be merged, not duplicated."""
+        log = "[FAIL] test1\nExpected foo\nto equal bar\n[FAIL] test2\nExpected baz"
+        sections = ci_log_retriever.extract_failure_sections(log)
+        # All failure content should be captured, possibly merged.
+        all_text = "\n".join(text for _, text in sections)
+        self.assertIn("test1", all_text)
+        self.assertIn("test2", all_text)
+
+
+class TestExtractZipLog(unittest.TestCase):
+    """Tests for zip file extraction."""
+
+    def test_extracts_from_valid_zip(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("step_1.txt", "Step 1 output")
+            zf.writestr("step_2.txt", "Step 2 output")
+        result = ci_log_retriever._extract_zip_log(buf.getvalue())
+        self.assertIn("Step 1 output", result)
+        self.assertIn("Step 2 output", result)
+
+    def test_handles_invalid_zip(self):
+        result = ci_log_retriever._extract_zip_log(b"not a zip file")
+        self.assertIn("not a zip file", result)
+
+
+class TestBuildFailureRecords(unittest.TestCase):
+    """Tests for build_failure_records (no log download)."""
+
+    def test_creates_record_for_failed_job(self):
+        records = ci_log_retriever.build_failure_records(
+            SAMPLE_RUN_DATA, download_logs=False
+        )
+        self.assertEqual(len(records), 1)
+
+        rec = records[0]
+        self.assertEqual(rec["run_id"], 31813098642)
+        self.assertEqual(rec["job_name"], "sys local root fedora-current / lima")
+        self.assertEqual(rec["step_name"], "Run test on lima")
+        self.assertEqual(rec["branch"], "main")
+        self.assertEqual(rec["commit_message"], "Merge pull request #29279")
+
+    def test_skips_successful_jobs(self):
+        run_data = {
+            **SAMPLE_RUN_DATA,
+            "jobs": [SAMPLE_RUN_DATA["jobs"][0]],  # Only the passing job.
+        }
+        records = ci_log_retriever.build_failure_records(
+            run_data, download_logs=False
+        )
+        self.assertEqual(len(records), 0)
+
+    def test_handles_no_failed_steps(self):
+        """A failed job with no identified failed steps."""
+        job = {
+            "job_id": 99999,
+            "name": "cancelled-job",
+            "conclusion": "failure",
+            "html_url": "https://example.com",
+            "failed_steps": [],
+        }
+        run_data = {**SAMPLE_RUN_DATA, "jobs": [job]}
+        records = ci_log_retriever.build_failure_records(
+            run_data, download_logs=False
+        )
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["step_name"], "unknown")
+
+    @patch("ci_log_retriever.download_job_log")
+    def test_with_log_download(self, mock_download):
+        mock_download.return_value = SAMPLE_RAW_LOG_GINKGO
+        records = ci_log_retriever.build_failure_records(
+            SAMPLE_RUN_DATA, download_logs=True
+        )
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertGreater(rec["raw_log_bytes"], 0)
+        self.assertGreater(len(rec["normalized_log_excerpt"]), 0)
+        self.assertGreater(len(rec["failure_sections"]), 0)
+        # Verify failure sections have correct structure.
+        for section in rec["failure_sections"]:
+            self.assertIn("type", section)
+            self.assertIn("text", section)
+
+    @patch("ci_log_retriever.download_job_log")
+    def test_handles_log_download_failure(self, mock_download):
+        mock_download.return_value = None
+        records = ci_log_retriever.build_failure_records(
+            SAMPLE_RUN_DATA, download_logs=True
+        )
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["raw_log_bytes"], 0)
+        self.assertEqual(rec["normalized_log_excerpt"], "")
+        self.assertEqual(rec["failure_sections"], [])
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Integration tests for the full pipeline (without network)."""
+
+    @patch("ci_log_retriever.download_job_log")
+    def test_full_pipeline_ginkgo(self, mock_download):
+        mock_download.return_value = SAMPLE_RAW_LOG_GINKGO
+        records = ci_log_retriever.build_failure_records(SAMPLE_RUN_DATA)
+
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        # Metadata is correct.
+        self.assertEqual(rec["workflow"], "ci")
+        self.assertEqual(rec["branch"], "main")
+        # Log was normalized (no ANSI, no GHA timestamps).
+        self.assertNotIn("\x1b[", rec["normalized_log_excerpt"])
+        self.assertNotIn("2026-08-14T15:12", rec["normalized_log_excerpt"])
+        # Failure sections were extracted.
+        self.assertGreater(len(rec["failure_sections"]), 0)
+
+    @patch("ci_log_retriever.download_job_log")
+    def test_full_pipeline_with_secrets(self, mock_download):
+        mock_download.return_value = SAMPLE_LOG_WITH_SECRETS
+        records = ci_log_retriever.build_failure_records(SAMPLE_RUN_DATA)
+
+        rec = records[0]
+        excerpt = rec["normalized_log_excerpt"]
+        # Secrets should be redacted.
+        self.assertNotIn("ghp_", excerpt)
+        self.assertNotIn("p4ssw0rd", excerpt)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", excerpt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hack/ci/ci_run_collector.py
+++ b/hack/ci/ci_run_collector.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+ci_run_collector - Collect GitHub Actions CI run data for failure analysis.
+
+Retrieves workflow run and job data from the GitHub Actions API,
+identifies failed runs, and outputs structured JSON suitable for
+downstream analysis (classification, flake detection, etc.).
+
+Usage:
+    # List recent failed CI runs on main branch
+    ./hack/ci/ci_run_collector.py --branch main --status failure --limit 10
+
+    # Get detailed job information for a specific run
+    ./hack/ci/ci_run_collector.py --run-id 31813098642
+
+    # Output as JSON for piping to other tools
+    ./hack/ci/ci_run_collector.py --branch main --status failure --json
+
+Environment:
+    GITHUB_TOKEN     Optional. GitHub API token for authentication.
+                     Without it, requests are subject to stricter rate limits.
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+
+# Default repository; matches the upstream Podman project.
+DEFAULT_REPO = "podman-container-tools/podman"
+# Default workflow filename for the main CI pipeline.
+DEFAULT_WORKFLOW = "ci.yml"
+# GitHub API base URL.
+API_BASE = "https://api.github.com"
+# Maximum results per API page (GitHub caps at 100).
+MAX_PER_PAGE = 100
+# Default number of runs to retrieve.
+DEFAULT_LIMIT = 20
+# Maximum number of runs to retrieve in a single invocation to
+# avoid accidentally downloading huge amounts of data.
+MAX_LIMIT = 500
+# Seconds to wait before retrying after a rate-limit or transient error.
+RETRY_DELAYS = [1, 2, 4]
+
+
+@dataclass
+class FailedStep:
+    """A single failed step within a job."""
+
+    name: str
+    conclusion: str
+    number: int
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+
+
+@dataclass
+class JobResult:
+    """Summary of a single job within a workflow run."""
+
+    job_id: int
+    name: str
+    conclusion: str
+    status: str
+    html_url: str
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    runner_name: Optional[str] = None
+    failed_steps: list = field(default_factory=list)
+
+
+@dataclass
+class RunResult:
+    """Summary of a single workflow run."""
+
+    run_id: int
+    workflow: str
+    run_number: int
+    status: str
+    conclusion: str
+    branch: str
+    commit_sha: str
+    commit_message: str
+    event: str
+    html_url: str
+    created_at: str
+    updated_at: str
+    run_attempt: int
+    jobs: list = field(default_factory=list)
+
+
+class GitHubAPIError(Exception):
+    """Raised when a GitHub API request fails after retries."""
+
+
+class RateLimitError(GitHubAPIError):
+    """Raised when the GitHub API rate limit is exceeded."""
+
+
+def _build_headers(token: Optional[str] = None) -> dict:
+    """Build HTTP headers for GitHub API requests."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def api_request(url: str, token: Optional[str] = None) -> dict:
+    """
+    Make an authenticated GET request to the GitHub API with retry logic.
+
+    Handles transient errors (5xx, network) and rate limiting with
+    exponential backoff. Raises GitHubAPIError after exhausting retries.
+    """
+    headers = _build_headers(token)
+    last_error = None
+
+    for attempt, delay in enumerate(RETRY_DELAYS + [0]):
+        try:
+            req = urllib.request.Request(url, headers=headers, method="GET")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            last_error = e
+            if e.code == 403:
+                # Check for rate limit.
+                reset_time = e.headers.get("X-RateLimit-Reset")
+                remaining = e.headers.get("X-RateLimit-Remaining")
+                if remaining == "0" and reset_time:
+                    wait = max(0, int(reset_time) - int(time.time())) + 1
+                    raise RateLimitError(
+                        f"GitHub API rate limit exceeded. "
+                        f"Resets in {wait}s. "
+                        f"Set GITHUB_TOKEN for higher limits."
+                    ) from e
+            if e.code == 404:
+                raise GitHubAPIError(f"Resource not found: {url}") from e
+            if e.code < 500 and e.code != 429:
+                raise GitHubAPIError(
+                    f"GitHub API error {e.code}: {e.reason}"
+                ) from e
+            # Retry on 5xx and 429.
+            if delay:
+                time.sleep(delay)
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_error = e
+            if delay:
+                time.sleep(delay)
+
+    raise GitHubAPIError(
+        f"GitHub API request failed after {len(RETRY_DELAYS)} retries: "
+        f"{last_error}"
+    )
+
+
+def fetch_workflow_runs(
+    repo: str,
+    branch: Optional[str] = None,
+    status: Optional[str] = None,
+    workflow: str = DEFAULT_WORKFLOW,
+    limit: int = DEFAULT_LIMIT,
+    token: Optional[str] = None,
+) -> list:
+    """
+    Fetch workflow runs from the GitHub Actions API.
+
+    Returns a list of raw run dicts, paginated up to `limit` results.
+    """
+    per_page = min(limit, MAX_PER_PAGE)
+    params = [f"per_page={per_page}"]
+    if branch:
+        params.append(f"branch={branch}")
+    if status:
+        params.append(f"status={status}")
+
+    url = (
+        f"{API_BASE}/repos/{repo}/actions/workflows/{workflow}/runs"
+        f"?{'&'.join(params)}"
+    )
+
+    all_runs = []
+    pages_fetched = 0
+    max_pages = (limit + per_page - 1) // per_page
+
+    while url and pages_fetched < max_pages:
+        data = api_request(url, token)
+        runs = data.get("workflow_runs", [])
+        all_runs.extend(runs)
+        pages_fetched += 1
+
+        if len(all_runs) >= limit:
+            break
+
+        # Follow pagination via Link header logic.
+        # The API returns a 'next' link, but since we're using json
+        # response, we manually construct the next page URL.
+        if len(runs) < per_page:
+            break
+        page = pages_fetched + 1
+        url = (
+            f"{API_BASE}/repos/{repo}/actions/workflows/{workflow}/runs"
+            f"?{'&'.join(params)}&page={page}"
+        )
+
+    return all_runs[:limit]
+
+
+def fetch_jobs_for_run(
+    repo: str, run_id: int, token: Optional[str] = None
+) -> list:
+    """
+    Fetch all jobs for a given workflow run.
+
+    Returns a list of raw job dicts. Handles pagination for runs
+    with many jobs.
+    """
+    url = f"{API_BASE}/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"
+    all_jobs = []
+
+    while url:
+        data = api_request(url, token)
+        jobs = data.get("jobs", [])
+        all_jobs.extend(jobs)
+
+        if len(jobs) < 100:
+            break
+        # Simple page increment for additional jobs.
+        page = (len(all_jobs) // 100) + 1
+        url = (
+            f"{API_BASE}/repos/{repo}/actions/runs/{run_id}/jobs"
+            f"?per_page=100&page={page}"
+        )
+
+    return all_jobs
+
+
+def parse_run(raw_run: dict) -> RunResult:
+    """Parse a raw workflow run API response into a RunResult."""
+    commit = raw_run.get("head_commit", {}) or {}
+    return RunResult(
+        run_id=raw_run["id"],
+        workflow=raw_run.get("name", ""),
+        run_number=raw_run.get("run_number", 0),
+        status=raw_run.get("status", ""),
+        conclusion=raw_run.get("conclusion", ""),
+        branch=raw_run.get("head_branch", ""),
+        commit_sha=raw_run.get("head_sha", ""),
+        commit_message=commit.get("message", ""),
+        event=raw_run.get("event", ""),
+        html_url=raw_run.get("html_url", ""),
+        created_at=raw_run.get("created_at", ""),
+        updated_at=raw_run.get("updated_at", ""),
+        run_attempt=raw_run.get("run_attempt", 1),
+    )
+
+
+def parse_job(raw_job: dict) -> JobResult:
+    """Parse a raw job API response into a JobResult."""
+    failed_steps = []
+    for step in raw_job.get("steps", []):
+        if step.get("conclusion") == "failure":
+            failed_steps.append(
+                FailedStep(
+                    name=step.get("name", ""),
+                    conclusion=step.get("conclusion", ""),
+                    number=step.get("number", 0),
+                    started_at=step.get("started_at"),
+                    completed_at=step.get("completed_at"),
+                )
+            )
+
+    return JobResult(
+        job_id=raw_job["id"],
+        name=raw_job.get("name", ""),
+        conclusion=raw_job.get("conclusion", ""),
+        status=raw_job.get("status", ""),
+        html_url=raw_job.get("html_url", ""),
+        started_at=raw_job.get("started_at"),
+        completed_at=raw_job.get("completed_at"),
+        runner_name=raw_job.get("runner_name"),
+        failed_steps=[asdict(s) for s in failed_steps],
+    )
+
+
+def collect_failed_runs(
+    repo: str = DEFAULT_REPO,
+    branch: Optional[str] = None,
+    status: str = "failure",
+    workflow: str = DEFAULT_WORKFLOW,
+    limit: int = DEFAULT_LIMIT,
+    include_jobs: bool = True,
+    token: Optional[str] = None,
+) -> list:
+    """
+    Collect CI run data with optional job details.
+
+    This is the main entry point for programmatic use. Returns a list
+    of RunResult dicts.
+    """
+    raw_runs = fetch_workflow_runs(
+        repo=repo,
+        branch=branch,
+        status=status,
+        workflow=workflow,
+        limit=limit,
+        token=token,
+    )
+
+    results = []
+    for raw_run in raw_runs:
+        run = parse_run(raw_run)
+        if include_jobs:
+            raw_jobs = fetch_jobs_for_run(repo, run.run_id, token)
+            run.jobs = [asdict(parse_job(j)) for j in raw_jobs]
+        results.append(asdict(run))
+
+    return results
+
+
+def collect_single_run(
+    repo: str, run_id: int, token: Optional[str] = None
+) -> dict:
+    """Collect detailed data for a single workflow run."""
+    url = f"{API_BASE}/repos/{repo}/actions/runs/{run_id}"
+    raw_run = api_request(url, token)
+    run = parse_run(raw_run)
+
+    raw_jobs = fetch_jobs_for_run(repo, run_id, token)
+    run.jobs = [asdict(parse_job(j)) for j in raw_jobs]
+
+    return asdict(run)
+
+
+def format_summary(runs: list) -> str:
+    """Format run data as a human-readable summary."""
+    lines = []
+    for run in runs:
+        failed_jobs = [j for j in run.get("jobs", []) if j["conclusion"] == "failure"]
+        lines.append(
+            f"Run #{run['run_number']} ({run['run_id']}) "
+            f"[{run['conclusion']}] "
+            f"branch={run['branch']} "
+            f"commit={run['commit_sha'][:12]}"
+        )
+        # Truncate long commit messages to first line.
+        msg = run["commit_message"].split("\n")[0]
+        lines.append(f"  {msg}")
+        if failed_jobs:
+            lines.append(f"  Failed jobs ({len(failed_jobs)}):")
+            for job in failed_jobs:
+                steps = job.get("failed_steps", [])
+                step_names = ", ".join(s["name"] for s in steps) if steps else "unknown"
+                lines.append(f"    - {job['name']}: {step_names}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect GitHub Actions CI run data for failure analysis.",
+        epilog="Set GITHUB_TOKEN env var for authenticated API access.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--branch",
+        default=None,
+        help="Filter by branch name (e.g., 'main')",
+    )
+    parser.add_argument(
+        "--status",
+        default="failure",
+        choices=["failure", "success", "completed", "cancelled"],
+        help="Filter by run conclusion (default: failure)",
+    )
+    parser.add_argument(
+        "--workflow",
+        default=DEFAULT_WORKFLOW,
+        help=f"Workflow filename (default: {DEFAULT_WORKFLOW})",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"Maximum number of runs to retrieve (default: {DEFAULT_LIMIT}, max: {MAX_LIMIT})",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=int,
+        default=None,
+        help="Retrieve detailed data for a specific run ID",
+    )
+    parser.add_argument(
+        "--no-jobs",
+        action="store_true",
+        help="Skip fetching job details (faster, less data)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON instead of human-readable summary",
+    )
+    args = parser.parse_args()
+
+    if args.limit > MAX_LIMIT:
+        print(
+            f"Error: --limit must be <= {MAX_LIMIT} to avoid excessive API usage.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        if args.run_id:
+            results = [collect_single_run(args.repo, args.run_id, token)]
+        else:
+            results = collect_failed_runs(
+                repo=args.repo,
+                branch=args.branch,
+                status=args.status,
+                workflow=args.workflow,
+                limit=args.limit,
+                include_jobs=not args.no_jobs,
+                token=token,
+            )
+    except RateLimitError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+    except GitHubAPIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json_output:
+        json.dump(results, sys.stdout, indent=2)
+        print()  # Trailing newline.
+    else:
+        if not results:
+            print("No matching workflow runs found.")
+        else:
+            print(format_summary(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_run_collector_test.py
+++ b/hack/ci/ci_run_collector_test.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_run_collector.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_run_collector_test.py -v
+    python3 hack/ci/ci_run_collector_test.py
+"""
+
+import json
+import os
+import sys
+import unittest
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+# Ensure hack/ci is importable.
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_run_collector
+
+
+# --- Test fixtures ---
+
+SAMPLE_RUN = {
+    "id": 31813098642,
+    "name": "ci",
+    "run_number": 1503,
+    "status": "completed",
+    "conclusion": "failure",
+    "head_branch": "main",
+    "head_sha": "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8",
+    "event": "push",
+    "html_url": "https://github.com/podman-container-tools/podman/actions/runs/31813098642",
+    "created_at": "2026-08-14T15:09:38Z",
+    "updated_at": "2026-08-14T16:12:06Z",
+    "run_attempt": 1,
+    "head_commit": {
+        "id": "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8",
+        "message": "Merge pull request #29279 from vtushar06/fix-prune-build-race\n\nlibpod: do not fail prune when build container is already gone",
+        "timestamp": "2026-08-14T15:09:35Z",
+        "author": {"name": "Matt Heon", "email": "mheon@redhat.com"},
+        "committer": {"name": "GitHub", "email": "noreply@github.com"},
+    },
+}
+
+SAMPLE_JOB_PASSED = {
+    "id": 90001,
+    "name": "validate-source",
+    "conclusion": "success",
+    "status": "completed",
+    "html_url": "https://github.com/podman-container-tools/podman/actions/runs/31813098642/job/90001",
+    "started_at": "2026-08-14T15:10:00Z",
+    "completed_at": "2026-08-14T15:15:00Z",
+    "runner_name": "cncf-ubuntu-8-32-x86-1",
+    "steps": [
+        {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2026-08-14T15:10:00Z",
+            "completed_at": "2026-08-14T15:10:05Z",
+        },
+    ],
+}
+
+SAMPLE_JOB_FAILED = {
+    "id": 90002,
+    "name": "sys local root fedora-current / lima",
+    "conclusion": "failure",
+    "status": "completed",
+    "html_url": "https://github.com/podman-container-tools/podman/actions/runs/31813098642/job/90002",
+    "started_at": "2026-08-14T15:10:00Z",
+    "completed_at": "2026-08-14T15:45:00Z",
+    "runner_name": "cncf-ubuntu-8-32-x86-3",
+    "steps": [
+        {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2026-08-14T15:10:00Z",
+            "completed_at": "2026-08-14T15:10:05Z",
+        },
+        {
+            "name": "Run test on lima",
+            "status": "completed",
+            "conclusion": "failure",
+            "number": 4,
+            "started_at": "2026-08-14T15:12:00Z",
+            "completed_at": "2026-08-14T15:45:00Z",
+        },
+        {
+            "name": "Output failure log as GITHUB_STEP_SUMMARY",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 5,
+            "started_at": "2026-08-14T15:45:01Z",
+            "completed_at": "2026-08-14T15:45:02Z",
+        },
+    ],
+}
+
+
+def _mock_api_response(data: dict) -> MagicMock:
+    """Create a mock urllib response with JSON data."""
+    body = json.dumps(data).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestBuildHeaders(unittest.TestCase):
+    """Tests for _build_headers."""
+
+    def test_without_token(self):
+        headers = ci_run_collector._build_headers()
+        self.assertIn("Accept", headers)
+        self.assertNotIn("Authorization", headers)
+
+    def test_with_token(self):
+        headers = ci_run_collector._build_headers("ghp_test123")
+        self.assertEqual(headers["Authorization"], "Bearer ghp_test123")
+        self.assertEqual(headers["Accept"], "application/vnd.github+json")
+
+
+class TestApiRequest(unittest.TestCase):
+    """Tests for api_request."""
+
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_successful_request(self, mock_urlopen):
+        expected = {"total_count": 1, "workflow_runs": []}
+        mock_urlopen.return_value = _mock_api_response(expected)
+
+        result = ci_run_collector.api_request("https://api.github.com/test")
+        self.assertEqual(result, expected)
+
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_404_raises_immediately(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError(
+            "https://api.github.com/test", 404, "Not Found", {}, BytesIO(b"")
+        )
+        with self.assertRaises(ci_run_collector.GitHubAPIError) as ctx:
+            ci_run_collector.api_request("https://api.github.com/test")
+        self.assertIn("not found", str(ctx.exception).lower())
+
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_rate_limit_raises_rate_limit_error(self, mock_urlopen):
+        headers = MagicMock()
+        headers.get = lambda key, default=None: {
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": str(int(ci_run_collector.time.time()) + 60),
+        }.get(key, default)
+        err = HTTPError(
+            "https://api.github.com/test", 403, "Forbidden", headers, BytesIO(b"")
+        )
+        mock_urlopen.side_effect = err
+        with self.assertRaises(ci_run_collector.RateLimitError):
+            ci_run_collector.api_request("https://api.github.com/test")
+
+    @patch("ci_run_collector.time.sleep")
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_retry_on_server_error(self, mock_urlopen, mock_sleep):
+        # First two calls fail with 502, third succeeds.
+        expected = {"ok": True}
+        mock_urlopen.side_effect = [
+            HTTPError(
+                "https://api.github.com/test", 502, "Bad Gateway", {}, BytesIO(b"")
+            ),
+            HTTPError(
+                "https://api.github.com/test", 502, "Bad Gateway", {}, BytesIO(b"")
+            ),
+            _mock_api_response(expected),
+        ]
+        result = ci_run_collector.api_request("https://api.github.com/test")
+        self.assertEqual(result, expected)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch("ci_run_collector.time.sleep")
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_retry_exhaustion_raises(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = URLError("Connection refused")
+        with self.assertRaises(ci_run_collector.GitHubAPIError):
+            ci_run_collector.api_request("https://api.github.com/test")
+
+
+class TestParseRun(unittest.TestCase):
+    """Tests for parse_run."""
+
+    def test_parse_complete_run(self):
+        result = ci_run_collector.parse_run(SAMPLE_RUN)
+        self.assertEqual(result.run_id, 31813098642)
+        self.assertEqual(result.workflow, "ci")
+        self.assertEqual(result.run_number, 1503)
+        self.assertEqual(result.conclusion, "failure")
+        self.assertEqual(result.branch, "main")
+        self.assertEqual(result.commit_sha, "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8")
+        self.assertIn("fix-prune-build-race", result.commit_message)
+        self.assertEqual(result.event, "push")
+        self.assertEqual(result.run_attempt, 1)
+
+    def test_parse_run_missing_commit(self):
+        """Handles missing head_commit gracefully."""
+        run_data = {**SAMPLE_RUN, "head_commit": None}
+        result = ci_run_collector.parse_run(run_data)
+        self.assertEqual(result.commit_message, "")
+
+    def test_parse_run_minimal(self):
+        """Handles minimal data without crashing."""
+        minimal = {"id": 1, "head_commit": {}}
+        result = ci_run_collector.parse_run(minimal)
+        self.assertEqual(result.run_id, 1)
+        self.assertEqual(result.workflow, "")
+
+
+class TestParseJob(unittest.TestCase):
+    """Tests for parse_job."""
+
+    def test_parse_passed_job(self):
+        result = ci_run_collector.parse_job(SAMPLE_JOB_PASSED)
+        self.assertEqual(result.job_id, 90001)
+        self.assertEqual(result.name, "validate-source")
+        self.assertEqual(result.conclusion, "success")
+        self.assertEqual(len(result.failed_steps), 0)
+
+    def test_parse_failed_job(self):
+        result = ci_run_collector.parse_job(SAMPLE_JOB_FAILED)
+        self.assertEqual(result.job_id, 90002)
+        self.assertEqual(result.name, "sys local root fedora-current / lima")
+        self.assertEqual(result.conclusion, "failure")
+        self.assertEqual(len(result.failed_steps), 1)
+        self.assertEqual(result.failed_steps[0]["name"], "Run test on lima")
+        self.assertEqual(result.failed_steps[0]["number"], 4)
+
+    def test_parse_job_no_steps(self):
+        """Handles job with no steps (e.g., cancelled)."""
+        job = {**SAMPLE_JOB_FAILED, "steps": []}
+        result = ci_run_collector.parse_job(job)
+        self.assertEqual(len(result.failed_steps), 0)
+
+
+class TestFetchWorkflowRuns(unittest.TestCase):
+    """Tests for fetch_workflow_runs."""
+
+    @patch("ci_run_collector.api_request")
+    def test_basic_fetch(self, mock_api):
+        mock_api.return_value = {
+            "total_count": 1,
+            "workflow_runs": [SAMPLE_RUN],
+        }
+        result = ci_run_collector.fetch_workflow_runs(
+            "podman-container-tools/podman", branch="main", limit=5
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], 31813098642)
+
+    @patch("ci_run_collector.api_request")
+    def test_limit_respected(self, mock_api):
+        """Results are capped at the requested limit."""
+        runs = [
+            {**SAMPLE_RUN, "id": i} for i in range(10)
+        ]
+        mock_api.return_value = {
+            "total_count": 10,
+            "workflow_runs": runs,
+        }
+        result = ci_run_collector.fetch_workflow_runs(
+            "podman-container-tools/podman", limit=3
+        )
+        self.assertEqual(len(result), 3)
+
+    @patch("ci_run_collector.api_request")
+    def test_pagination(self, mock_api):
+        """Multiple pages are fetched when needed."""
+        page1 = [
+            {**SAMPLE_RUN, "id": i} for i in range(100)
+        ]
+        page2 = [
+            {**SAMPLE_RUN, "id": i} for i in range(100, 150)
+        ]
+        mock_api.side_effect = [
+            {"total_count": 150, "workflow_runs": page1},
+            {"total_count": 150, "workflow_runs": page2},
+        ]
+        result = ci_run_collector.fetch_workflow_runs(
+            "podman-container-tools/podman", limit=150
+        )
+        self.assertEqual(len(result), 150)
+        self.assertEqual(mock_api.call_count, 2)
+
+    @patch("ci_run_collector.api_request")
+    def test_url_includes_filters(self, mock_api):
+        mock_api.return_value = {"total_count": 0, "workflow_runs": []}
+        ci_run_collector.fetch_workflow_runs(
+            "podman-container-tools/podman",
+            branch="main",
+            status="failure",
+            workflow="ci.yml",
+            limit=5,
+        )
+        call_url = mock_api.call_args[0][0]
+        self.assertIn("branch=main", call_url)
+        self.assertIn("status=failure", call_url)
+        self.assertIn("ci.yml", call_url)
+
+
+class TestCollectFailedRuns(unittest.TestCase):
+    """Tests for collect_failed_runs (integration of fetch + parse)."""
+
+    @patch("ci_run_collector.fetch_jobs_for_run")
+    @patch("ci_run_collector.fetch_workflow_runs")
+    def test_collect_with_jobs(self, mock_fetch_runs, mock_fetch_jobs):
+        mock_fetch_runs.return_value = [SAMPLE_RUN]
+        mock_fetch_jobs.return_value = [SAMPLE_JOB_PASSED, SAMPLE_JOB_FAILED]
+
+        results = ci_run_collector.collect_failed_runs(limit=1)
+        self.assertEqual(len(results), 1)
+
+        run = results[0]
+        self.assertEqual(run["run_id"], 31813098642)
+        self.assertEqual(len(run["jobs"]), 2)
+
+        failed_jobs = [j for j in run["jobs"] if j["conclusion"] == "failure"]
+        self.assertEqual(len(failed_jobs), 1)
+        self.assertEqual(failed_jobs[0]["name"], "sys local root fedora-current / lima")
+
+    @patch("ci_run_collector.fetch_workflow_runs")
+    def test_collect_without_jobs(self, mock_fetch_runs):
+        mock_fetch_runs.return_value = [SAMPLE_RUN]
+
+        results = ci_run_collector.collect_failed_runs(
+            limit=1, include_jobs=False
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["jobs"], [])
+
+
+class TestFormatSummary(unittest.TestCase):
+    """Tests for format_summary."""
+
+    def test_format_with_failures(self):
+        from dataclasses import asdict
+
+        run = ci_run_collector.parse_run(SAMPLE_RUN)
+        job = ci_run_collector.parse_job(SAMPLE_JOB_FAILED)
+        run.jobs = [asdict(job)]
+        run_dict = asdict(run)
+
+        output = ci_run_collector.format_summary([run_dict])
+        self.assertIn("Run #1503", output)
+        self.assertIn("failure", output)
+        self.assertIn("sys local root fedora-current", output)
+        self.assertIn("Run test on lima", output)
+
+    def test_format_empty(self):
+        output = ci_run_collector.format_summary([])
+        self.assertEqual(output, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?
Adds `hack/ci/ci_failure_classifier.py` and unit tests `hack/ci/ci_failure_classifier_test.py` to categorize normalized CI failures into structured, actionable categories before introducing AI/LLM layers.

### Why?
Supports **Issue #29265** (*"LFX Mentorship Program: Agentic CI Flake Categorization and Analysis"* - Phase 3: Failure Classification).

Before applying LLMs, deterministic pattern matching reliably and reproducibly classifies the vast majority of well-understood CI failures (panics, timeouts, OOM, infra issues, network errors, test assertions).

### How?
- **14 Priority Rules across 12 Categories**:
  - `panic` (priority 100), `timeout` (90), `resource_exhaustion` (85), `infrastructure_failure` (80), `network_error` (70), `image_pull_failure` (65), `container_runtime_error` (60), `build_failure` (55), `dependency_failure` (50), `permission_error` (45), `test_assertion_failure` (40), `unknown` (0).
- **Priority-Based Conflict Resolution**: Specific and fatal errors (panics, timeouts) take precedence over general test assertion failures.
- **Evidence Extraction**: Records exact matched text and confidence score for transparency.
- **Testing**: 34 unit tests covering every category with realistic log fixtures; registered in `make .check-self-tests`.
