### PR TITLE
ci: document CI flake analysis and add unified test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,7 @@ help: ## Print this help message
 	hack/ci/pr-should-include-tests.t
 	hack/ci/logformatter.t
 	hack/ci/ci_run_collector_test.py
+	hack/ci/ci_log_retriever_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,7 @@ help: ## Print this help message
 	hack/ci/ci_log_retriever_test.py
 	hack/ci/ci_failure_classifier_test.py
 	hack/ci/ci_flake_detector_test.py
+	hack/ci/ci_agentic_analyzer_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,7 @@ help: ## Print this help message
 	hack/ci/ci_run_collector_test.py
 	hack/ci/ci_log_retriever_test.py
 	hack/ci/ci_failure_classifier_test.py
+	hack/ci/ci_flake_detector_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,7 @@ help: ## Print this help message
 	hack/ci/ci_failure_classifier_test.py
 	hack/ci/ci_flake_detector_test.py
 	hack/ci/ci_agentic_analyzer_test.py
+	hack/ci/ci_reporter_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -286,12 +286,7 @@ help: ## Print this help message
 	hack/ci/pr-removes-fixed-skips.t
 	hack/ci/pr-should-include-tests.t
 	hack/ci/logformatter.t
-	hack/ci/ci_run_collector_test.py
-	hack/ci/ci_log_retriever_test.py
-	hack/ci/ci_failure_classifier_test.py
-	hack/ci/ci_flake_detector_test.py
-	hack/ci/ci_agentic_analyzer_test.py
-	hack/ci/ci_reporter_test.py
+	hack/ci/ci_flake_suite_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,7 @@ help: ## Print this help message
 	hack/ci/logformatter.t
 	hack/ci/ci_run_collector_test.py
 	hack/ci/ci_log_retriever_test.py
+	hack/ci/ci_failure_classifier_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ help: ## Print this help message
 	hack/ci/pr-removes-fixed-skips.t
 	hack/ci/pr-should-include-tests.t
 	hack/ci/logformatter.t
+	hack/ci/ci_run_collector_test.py
 	test/system/helpers.t
 
 .PHONY: lint

--- a/hack/ci/ci_agentic_analyzer.py
+++ b/hack/ci/ci_agentic_analyzer.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""
+ci_agentic_analyzer - LLM-powered analysis of CI failures.
+
+Provides deeper analysis of CI failure patterns using a large language
+model (LLM). Builds on the deterministic pipeline (PRs 1-4) by adding
+contextual reasoning about failure causes, suggested fixes, and
+correlation with known issues.
+
+The LLM layer is optional and gracefully degrades — the deterministic
+pipeline produces fully usable results without it.
+
+Usage:
+    # Analyze classified failures with LLM enhancement
+    ./hack/ci/ci_failure_classifier.py --stdin < records.json | \
+        ./hack/ci/ci_agentic_analyzer.py --stdin
+
+    # Analyze a specific run
+    ./hack/ci/ci_agentic_analyzer.py --run-id 31813098642
+
+    # Dry-run: show prompt without calling LLM
+    ./hack/ci/ci_agentic_analyzer.py --stdin --dry-run < records.json
+
+Environment:
+    CI_LLM_API_KEY     Required. API key for the LLM service.
+    CI_LLM_API_URL     LLM API endpoint URL.
+                       Default: https://api.openai.com/v1/chat/completions
+    CI_LLM_MODEL       Model identifier.
+                       Default: gpt-4o-mini
+    GITHUB_TOKEN       Required if using --run-id.
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import ci_failure_classifier
+import ci_log_retriever
+import ci_run_collector
+
+# --- Configuration ---
+
+DEFAULT_API_URL = "https://api.openai.com/v1/chat/completions"
+DEFAULT_MODEL = "gpt-4o-mini"
+# Maximum tokens to request from the LLM.
+MAX_RESPONSE_TOKENS = 1024
+# Maximum characters of failure context to include in prompt.
+MAX_CONTEXT_CHARS = 8000
+# Rate limit: minimum seconds between API calls.
+MIN_CALL_INTERVAL = 1.0
+# Maximum retries for LLM API calls.
+LLM_RETRY_DELAYS = [2, 5]
+
+
+# --- Prompt engineering ---
+
+SYSTEM_PROMPT = """\
+You are a CI failure analysis assistant for the Podman container engine project.
+Your task is to analyze CI test failure logs and provide structured analysis.
+
+You will receive:
+1. Failure metadata (job name, branch, commit, classification)
+2. Log excerpts showing the failure context
+3. The deterministic classification from the rule-based system
+
+Your analysis should:
+- Confirm or refine the rule-based classification
+- Identify the likely root cause
+- Suggest whether this is a flake or a genuine bug
+- Provide a concise actionable suggestion
+
+IMPORTANT CONSTRAINTS:
+- Be concise. Each field should be 1-2 sentences.
+- Do not speculate beyond what the log evidence supports.
+- If the evidence is insufficient, say so explicitly.
+- Never fabricate file paths, function names, or line numbers.
+
+You MUST respond with valid JSON matching this exact schema:
+{
+  "refined_category": "<category string>",
+  "root_cause": "<1-2 sentence description>",
+  "is_flake_assessment": "<likely_flake | likely_bug | uncertain>",
+  "confidence": <0.0 to 1.0>,
+  "suggested_action": "<1-2 sentence actionable suggestion>",
+  "reasoning": "<brief reasoning for the assessment>"
+}
+"""
+
+
+def build_analysis_prompt(record: dict) -> str:
+    """
+    Build a structured user prompt from a classified failure record.
+
+    Includes metadata, classification, and bounded failure context.
+    """
+    clf = record.get("classification", {})
+    sections = record.get("failure_sections", [])
+    excerpt = record.get("normalized_log_excerpt", "")
+
+    # Build context from failure sections (preferred) or excerpt.
+    context_parts = []
+    total_chars = 0
+    for section in sections:
+        text = section.get("text", "")
+        if total_chars + len(text) > MAX_CONTEXT_CHARS:
+            text = text[: MAX_CONTEXT_CHARS - total_chars]
+        context_parts.append(f"[{section.get('type', 'unknown')}]\n{text}")
+        total_chars += len(text)
+        if total_chars >= MAX_CONTEXT_CHARS:
+            break
+
+    if not context_parts and excerpt:
+        context_parts.append(excerpt[:MAX_CONTEXT_CHARS])
+
+    context = "\n---\n".join(context_parts) if context_parts else "(no log content available)"
+
+    prompt = f"""\
+Analyze this CI failure:
+
+## Metadata
+- Job: {record.get('job_name', 'unknown')}
+- Step: {record.get('step_name', 'unknown')}
+- Branch: {record.get('branch', 'unknown')}
+- Commit: {record.get('commit_sha', 'unknown')[:12]}
+- Commit message: {record.get('commit_message', 'unknown')[:100]}
+- Event: {record.get('event', 'unknown')}
+- Date: {record.get('created_at', 'unknown')}
+
+## Rule-Based Classification
+- Category: {clf.get('category', 'unknown')}
+- Confidence: {clf.get('confidence', 0):.0%}
+- Rule: {clf.get('rule_name', 'unknown')}
+- Matched: {clf.get('matched_text', '')[:100]}
+
+## Failure Log Context
+{context}
+
+Respond with valid JSON only.
+"""
+    return prompt
+
+
+# --- LLM API interaction ---
+
+@dataclass
+class LLMConfig:
+    """Configuration for the LLM API."""
+
+    api_url: str = DEFAULT_API_URL
+    api_key: str = ""
+    model: str = DEFAULT_MODEL
+    max_tokens: int = MAX_RESPONSE_TOKENS
+    temperature: float = 0.1  # Low temperature for consistent analysis.
+
+
+def call_llm(
+    prompt: str,
+    config: LLMConfig,
+    system_prompt: str = SYSTEM_PROMPT,
+) -> Optional[str]:
+    """
+    Call the LLM API with the given prompt.
+
+    Returns the raw response text, or None if the call fails.
+    Uses an OpenAI-compatible chat completions API.
+    """
+    if not config.api_key:
+        return None
+
+    payload = {
+        "model": config.model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+        "max_tokens": config.max_tokens,
+        "temperature": config.temperature,
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {config.api_key}",
+    }
+
+    data = json.dumps(payload).encode("utf-8")
+    last_error = None
+
+    for attempt, delay in enumerate(LLM_RETRY_DELAYS + [0]):
+        try:
+            req = urllib.request.Request(
+                config.api_url,
+                data=data,
+                headers=headers,
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                result = json.loads(resp.read().decode("utf-8"))
+                choices = result.get("choices", [])
+                if choices:
+                    return choices[0].get("message", {}).get("content", "")
+                return None
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+            last_error = e
+            if isinstance(e, urllib.error.HTTPError) and e.code < 500 and e.code != 429:
+                print(
+                    f"Warning: LLM API error {e.code}: {e.reason}",
+                    file=sys.stderr,
+                )
+                return None
+            if delay:
+                time.sleep(delay)
+
+    print(
+        f"Warning: LLM API failed after retries: {last_error}",
+        file=sys.stderr,
+    )
+    return None
+
+
+# --- Response validation ---
+
+VALID_CATEGORIES = set(ci_failure_classifier.CATEGORIES.keys())
+VALID_FLAKE_ASSESSMENTS = {"likely_flake", "likely_bug", "uncertain"}
+
+
+@dataclass
+class AgenticAnalysis:
+    """Validated analysis result from the LLM."""
+
+    refined_category: str = "unknown"
+    root_cause: str = ""
+    is_flake_assessment: str = "uncertain"
+    confidence: float = 0.0
+    suggested_action: str = ""
+    reasoning: str = ""
+    raw_response: str = ""
+    parse_error: str = ""
+
+
+def parse_llm_response(raw_response: str) -> AgenticAnalysis:
+    """
+    Parse and validate an LLM response into a structured analysis.
+
+    Treats LLM output as untrusted: validates all fields, applies
+    bounds checking, and falls back gracefully on parse errors.
+    """
+    analysis = AgenticAnalysis(raw_response=raw_response)
+
+    if not raw_response:
+        analysis.parse_error = "Empty response from LLM"
+        return analysis
+
+    # Strip markdown code fences if present.
+    text = raw_response.strip()
+    if text.startswith("```"):
+        # Remove ```json ... ``` wrapper.
+        lines = text.split("\n")
+        if lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        text = "\n".join(lines)
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        analysis.parse_error = f"Invalid JSON from LLM: {e}"
+        return analysis
+
+    if not isinstance(data, dict):
+        analysis.parse_error = f"Expected JSON object, got {type(data).__name__}"
+        return analysis
+
+    # Validate and extract fields with bounds checking.
+
+    # refined_category: must be a known category.
+    cat = data.get("refined_category", "unknown")
+    if isinstance(cat, str) and cat in VALID_CATEGORIES:
+        analysis.refined_category = cat
+    else:
+        analysis.refined_category = "unknown"
+
+    # root_cause: bounded string.
+    rc = data.get("root_cause", "")
+    if isinstance(rc, str):
+        analysis.root_cause = rc[:500]
+
+    # is_flake_assessment: must be one of the valid values.
+    fa = data.get("is_flake_assessment", "uncertain")
+    if isinstance(fa, str) and fa in VALID_FLAKE_ASSESSMENTS:
+        analysis.is_flake_assessment = fa
+    else:
+        analysis.is_flake_assessment = "uncertain"
+
+    # confidence: bounded float.
+    conf = data.get("confidence", 0.0)
+    if isinstance(conf, (int, float)):
+        analysis.confidence = max(0.0, min(1.0, float(conf)))
+
+    # suggested_action: bounded string.
+    sa = data.get("suggested_action", "")
+    if isinstance(sa, str):
+        analysis.suggested_action = sa[:500]
+
+    # reasoning: bounded string.
+    reasoning = data.get("reasoning", "")
+    if isinstance(reasoning, str):
+        analysis.reasoning = reasoning[:500]
+
+    return analysis
+
+
+# --- Main analysis pipeline ---
+
+def analyze_record(
+    record: dict,
+    config: Optional[LLMConfig] = None,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Analyze a single classified failure record with optional LLM.
+
+    If the LLM is unavailable or dry_run is True, the record is
+    returned with the deterministic classification only.
+    """
+    prompt = build_analysis_prompt(record)
+
+    result = dict(record)
+    result["agentic_analysis"] = {
+        "prompt": prompt if dry_run else "",
+        "status": "skipped",
+        "refined_category": "",
+        "root_cause": "",
+        "is_flake_assessment": "",
+        "confidence": 0.0,
+        "suggested_action": "",
+        "reasoning": "",
+    }
+
+    if dry_run:
+        result["agentic_analysis"]["status"] = "dry_run"
+        return result
+
+    if config is None or not config.api_key:
+        result["agentic_analysis"]["status"] = "no_api_key"
+        return result
+
+    raw_response = call_llm(prompt, config)
+    if raw_response is None:
+        result["agentic_analysis"]["status"] = "api_error"
+        return result
+
+    analysis = parse_llm_response(raw_response)
+
+    if analysis.parse_error:
+        result["agentic_analysis"]["status"] = f"parse_error: {analysis.parse_error}"
+        result["agentic_analysis"]["raw_response"] = raw_response[:1000]
+        return result
+
+    result["agentic_analysis"] = {
+        "status": "success",
+        "refined_category": analysis.refined_category,
+        "root_cause": analysis.root_cause,
+        "is_flake_assessment": analysis.is_flake_assessment,
+        "confidence": analysis.confidence,
+        "suggested_action": analysis.suggested_action,
+        "reasoning": analysis.reasoning,
+    }
+
+    return result
+
+
+def analyze_records(
+    records: list,
+    config: Optional[LLMConfig] = None,
+    dry_run: bool = False,
+) -> list:
+    """
+    Analyze multiple records with rate limiting between LLM calls.
+    """
+    results = []
+    for i, record in enumerate(records):
+        result = analyze_record(record, config, dry_run)
+        results.append(result)
+
+        # Rate limit between calls.
+        if (
+            not dry_run
+            and config
+            and config.api_key
+            and i < len(records) - 1
+        ):
+            time.sleep(MIN_CALL_INTERVAL)
+
+    return results
+
+
+def format_analysis_summary(records: list) -> str:
+    """Format agentic analysis results as a human-readable report."""
+    lines = []
+    lines.append("Agentic Analysis Report")
+    lines.append("=" * 60)
+
+    for rec in records:
+        aa = rec.get("agentic_analysis", {})
+        clf = rec.get("classification", {})
+
+        lines.append(f"\nRun #{rec.get('run_number', '?')} | {rec.get('job_name', '?')}")
+        lines.append(f"  Deterministic: {clf.get('category', '?')} ({clf.get('confidence', 0):.0%})")
+
+        status = aa.get("status", "unknown")
+        if status == "success":
+            lines.append(f"  LLM Refined:   {aa.get('refined_category', '?')} ({aa.get('confidence', 0):.0%})")
+            lines.append(f"  Root Cause:    {aa.get('root_cause', 'N/A')}")
+            lines.append(f"  Flake?:        {aa.get('is_flake_assessment', '?')}")
+            lines.append(f"  Action:        {aa.get('suggested_action', 'N/A')}")
+        elif status == "dry_run":
+            lines.append("  LLM: [DRY RUN — prompt generated but not sent]")
+        elif status == "no_api_key":
+            lines.append("  LLM: [SKIPPED — no CI_LLM_API_KEY set]")
+        else:
+            lines.append(f"  LLM: [{status}]")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="LLM-powered CI failure analysis.",
+        epilog="Set CI_LLM_API_KEY for LLM analysis. Without it, "
+        "only deterministic analysis is performed.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", ci_log_retriever.DEFAULT_REPO),
+        help="GitHub repository",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=int,
+        help="Analyze failures for a specific run ID",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read classified records from stdin (JSON)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate prompts without calling LLM",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    config = LLMConfig(
+        api_url=os.environ.get("CI_LLM_API_URL", DEFAULT_API_URL),
+        api_key=os.environ.get("CI_LLM_API_KEY", ""),
+        model=os.environ.get("CI_LLM_MODEL", DEFAULT_MODEL),
+    )
+
+    try:
+        if args.stdin:
+            records = json.load(sys.stdin)
+            if isinstance(records, dict):
+                records = [records]
+        elif args.run_id:
+            run_data = ci_run_collector.collect_single_run(
+                args.repo, args.run_id, token
+            )
+            failure_records = ci_log_retriever.build_failure_records(
+                run_data, repo=args.repo, token=token
+            )
+            records = [
+                ci_failure_classifier.classify_failure_record(r)
+                for r in failure_records
+            ]
+        else:
+            parser.error("Specify --run-id or --stdin")
+            return
+
+        results = analyze_records(records, config, dry_run=args.dry_run)
+
+        if args.json_output:
+            json.dump(results, sys.stdout, indent=2)
+            print()
+        else:
+            print(format_analysis_summary(results))
+
+    except ci_run_collector.GitHubAPIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except (json.JSONDecodeError, KeyError) as e:
+        print(f"Error: Invalid input data: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_agentic_analyzer_test.py
+++ b/hack/ci/ci_agentic_analyzer_test.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_agentic_analyzer.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_agentic_analyzer_test.py -v
+    python3 hack/ci/ci_agentic_analyzer_test.py
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_agentic_analyzer
+
+
+# --- Test fixtures ---
+
+SAMPLE_CLASSIFIED_RECORD = {
+    "run_id": 31813098642,
+    "run_number": 1503,
+    "workflow": "ci",
+    "job_name": "sys local root fedora-current / lima",
+    "job_id": 90002,
+    "step_name": "Run test on lima",
+    "branch": "main",
+    "commit_sha": "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8",
+    "commit_message": "Merge pull request #29279",
+    "event": "push",
+    "created_at": "2026-08-14T15:09:38Z",
+    "html_url": "https://example.com/job/90002",
+    "failure_sections": [
+        {
+            "type": "ginkgo_failure",
+            "text": "[FAIL] Podman run with volume\n  Expected\n    /tmp/testdir\n  to equal\n    /tmp/expected",
+        },
+    ],
+    "normalized_log_excerpt": "[FAIL] test excerpt",
+    "raw_log_bytes": 1024,
+    "classification": {
+        "category": "test_assertion_failure",
+        "category_description": "A test assertion failed.",
+        "confidence": 0.85,
+        "rule_name": "ginkgo_assertion",
+        "matched_text": "[FAIL]",
+        "evidence": "[FAIL] Podman run with volume",
+        "all_matches_count": 1,
+    },
+}
+
+VALID_LLM_RESPONSE = json.dumps({
+    "refined_category": "test_assertion_failure",
+    "root_cause": "Volume mount path mismatch in test expectations.",
+    "is_flake_assessment": "likely_bug",
+    "confidence": 0.9,
+    "suggested_action": "Update test fixture to use the correct expected path.",
+    "reasoning": "The test expects /tmp/expected but gets /tmp/testdir, suggesting a hardcoded path issue.",
+})
+
+VALID_LLM_RESPONSE_WRAPPED = f"```json\n{VALID_LLM_RESPONSE}\n```"
+
+INVALID_JSON_RESPONSE = "This is not JSON at all, just text analysis."
+
+PARTIAL_JSON_RESPONSE = json.dumps({
+    "refined_category": "test_assertion_failure",
+    # Missing several required fields.
+})
+
+UNKNOWN_CATEGORY_RESPONSE = json.dumps({
+    "refined_category": "made_up_category",
+    "root_cause": "Something.",
+    "is_flake_assessment": "invalid_value",
+    "confidence": 5.0,
+    "suggested_action": "Do something.",
+    "reasoning": "Because.",
+})
+
+
+class TestBuildAnalysisPrompt(unittest.TestCase):
+    """Tests for build_analysis_prompt."""
+
+    def test_includes_metadata(self):
+        prompt = ci_agentic_analyzer.build_analysis_prompt(SAMPLE_CLASSIFIED_RECORD)
+        self.assertIn("sys local root fedora-current / lima", prompt)
+        self.assertIn("Run test on lima", prompt)
+        self.assertIn("main", prompt)
+        self.assertIn("3a18c5e98f5c", prompt)
+        self.assertIn("test_assertion_failure", prompt)
+
+    def test_includes_failure_context(self):
+        prompt = ci_agentic_analyzer.build_analysis_prompt(SAMPLE_CLASSIFIED_RECORD)
+        self.assertIn("[FAIL] Podman run with volume", prompt)
+
+    def test_includes_classification(self):
+        prompt = ci_agentic_analyzer.build_analysis_prompt(SAMPLE_CLASSIFIED_RECORD)
+        self.assertIn("ginkgo_assertion", prompt)
+        self.assertIn("85%", prompt)
+
+    def test_no_failure_sections_uses_excerpt(self):
+        record = {
+            **SAMPLE_CLASSIFIED_RECORD,
+            "failure_sections": [],
+        }
+        prompt = ci_agentic_analyzer.build_analysis_prompt(record)
+        self.assertIn("test excerpt", prompt)
+
+    def test_no_content_shows_placeholder(self):
+        record = {
+            **SAMPLE_CLASSIFIED_RECORD,
+            "failure_sections": [],
+            "normalized_log_excerpt": "",
+        }
+        prompt = ci_agentic_analyzer.build_analysis_prompt(record)
+        self.assertIn("no log content available", prompt)
+
+    def test_context_bounded(self):
+        long_text = "x" * 20000
+        record = {
+            **SAMPLE_CLASSIFIED_RECORD,
+            "failure_sections": [{"type": "test", "text": long_text}],
+        }
+        prompt = ci_agentic_analyzer.build_analysis_prompt(record)
+        # Prompt should not include the full 20K chars.
+        self.assertLess(len(prompt), 15000)
+
+
+class TestParseLlmResponse(unittest.TestCase):
+    """Tests for parse_llm_response."""
+
+    def test_valid_response(self):
+        result = ci_agentic_analyzer.parse_llm_response(VALID_LLM_RESPONSE)
+        self.assertEqual(result.refined_category, "test_assertion_failure")
+        self.assertEqual(result.is_flake_assessment, "likely_bug")
+        self.assertAlmostEqual(result.confidence, 0.9)
+        self.assertIn("Volume mount", result.root_cause)
+        self.assertEqual(result.parse_error, "")
+
+    def test_valid_response_with_code_fence(self):
+        result = ci_agentic_analyzer.parse_llm_response(VALID_LLM_RESPONSE_WRAPPED)
+        self.assertEqual(result.refined_category, "test_assertion_failure")
+        self.assertEqual(result.parse_error, "")
+
+    def test_invalid_json(self):
+        result = ci_agentic_analyzer.parse_llm_response(INVALID_JSON_RESPONSE)
+        self.assertNotEqual(result.parse_error, "")
+        self.assertIn("Invalid JSON", result.parse_error)
+
+    def test_empty_response(self):
+        result = ci_agentic_analyzer.parse_llm_response("")
+        self.assertNotEqual(result.parse_error, "")
+        self.assertEqual(result.refined_category, "unknown")
+
+    def test_partial_response(self):
+        result = ci_agentic_analyzer.parse_llm_response(PARTIAL_JSON_RESPONSE)
+        self.assertEqual(result.refined_category, "test_assertion_failure")
+        self.assertEqual(result.root_cause, "")
+        self.assertEqual(result.is_flake_assessment, "uncertain")
+        self.assertEqual(result.parse_error, "")
+
+    def test_unknown_category_sanitized(self):
+        result = ci_agentic_analyzer.parse_llm_response(UNKNOWN_CATEGORY_RESPONSE)
+        # Invalid category should fall back to "unknown".
+        self.assertEqual(result.refined_category, "unknown")
+        # Invalid flake assessment should fall back to "uncertain".
+        self.assertEqual(result.is_flake_assessment, "uncertain")
+        # Confidence should be capped at 1.0.
+        self.assertLessEqual(result.confidence, 1.0)
+
+    def test_bounds_on_long_strings(self):
+        response = json.dumps({
+            "refined_category": "panic",
+            "root_cause": "x" * 2000,
+            "is_flake_assessment": "likely_bug",
+            "confidence": 0.8,
+            "suggested_action": "y" * 2000,
+            "reasoning": "z" * 2000,
+        })
+        result = ci_agentic_analyzer.parse_llm_response(response)
+        self.assertLessEqual(len(result.root_cause), 500)
+        self.assertLessEqual(len(result.suggested_action), 500)
+        self.assertLessEqual(len(result.reasoning), 500)
+
+    def test_non_dict_json(self):
+        result = ci_agentic_analyzer.parse_llm_response("[1, 2, 3]")
+        self.assertNotEqual(result.parse_error, "")
+        self.assertIn("Expected JSON object", result.parse_error)
+
+
+class TestAnalyzeRecord(unittest.TestCase):
+    """Tests for analyze_record."""
+
+    def test_dry_run(self):
+        result = ci_agentic_analyzer.analyze_record(
+            SAMPLE_CLASSIFIED_RECORD, dry_run=True
+        )
+        aa = result["agentic_analysis"]
+        self.assertEqual(aa["status"], "dry_run")
+        self.assertIn("sys local root fedora", aa["prompt"])
+
+    def test_no_api_key(self):
+        config = ci_agentic_analyzer.LLMConfig(api_key="")
+        result = ci_agentic_analyzer.analyze_record(
+            SAMPLE_CLASSIFIED_RECORD, config=config
+        )
+        self.assertEqual(result["agentic_analysis"]["status"], "no_api_key")
+
+    def test_no_config(self):
+        result = ci_agentic_analyzer.analyze_record(
+            SAMPLE_CLASSIFIED_RECORD, config=None
+        )
+        self.assertEqual(result["agentic_analysis"]["status"], "no_api_key")
+
+    @patch("ci_agentic_analyzer.call_llm")
+    def test_successful_llm_call(self, mock_call):
+        mock_call.return_value = VALID_LLM_RESPONSE
+        config = ci_agentic_analyzer.LLMConfig(api_key="test-key")
+        result = ci_agentic_analyzer.analyze_record(
+            SAMPLE_CLASSIFIED_RECORD, config=config
+        )
+        aa = result["agentic_analysis"]
+        self.assertEqual(aa["status"], "success")
+        self.assertEqual(aa["refined_category"], "test_assertion_failure")
+        self.assertEqual(aa["is_flake_assessment"], "likely_bug")
+
+    @patch("ci_agentic_analyzer.call_llm")
+    def test_llm_api_error(self, mock_call):
+        mock_call.return_value = None
+        config = ci_agentic_analyzer.LLMConfig(api_key="test-key")
+        result = ci_agentic_analyzer.analyze_record(
+            SAMPLE_CLASSIFIED_RECORD, config=config
+        )
+        self.assertEqual(result["agentic_analysis"]["status"], "api_error")
+
+    @patch("ci_agentic_analyzer.call_llm")
+    def test_llm_invalid_response(self, mock_call):
+        mock_call.return_value = INVALID_JSON_RESPONSE
+        config = ci_agentic_analyzer.LLMConfig(api_key="test-key")
+        result = ci_agentic_analyzer.analyze_record(
+            SAMPLE_CLASSIFIED_RECORD, config=config
+        )
+        self.assertIn("parse_error", result["agentic_analysis"]["status"])
+
+    def test_preserves_original_fields(self):
+        result = ci_agentic_analyzer.analyze_record(
+            SAMPLE_CLASSIFIED_RECORD, dry_run=True
+        )
+        self.assertEqual(result["run_id"], 31813098642)
+        self.assertEqual(result["job_name"], "sys local root fedora-current / lima")
+        self.assertIn("classification", result)
+
+
+class TestAnalyzeRecords(unittest.TestCase):
+    """Tests for analyze_records (batch processing)."""
+
+    def test_dry_run_batch(self):
+        records = [SAMPLE_CLASSIFIED_RECORD, SAMPLE_CLASSIFIED_RECORD]
+        results = ci_agentic_analyzer.analyze_records(records, dry_run=True)
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertEqual(r["agentic_analysis"]["status"], "dry_run")
+
+    @patch("ci_agentic_analyzer.call_llm")
+    @patch("ci_agentic_analyzer.time.sleep")
+    def test_rate_limiting(self, mock_sleep, mock_call):
+        mock_call.return_value = VALID_LLM_RESPONSE
+        config = ci_agentic_analyzer.LLMConfig(api_key="test-key")
+        records = [SAMPLE_CLASSIFIED_RECORD] * 3
+        results = ci_agentic_analyzer.analyze_records(records, config=config)
+        self.assertEqual(len(results), 3)
+        # Should have rate-limited between calls (n-1 sleeps).
+        self.assertEqual(mock_sleep.call_count, 2)
+
+
+class TestFormatAnalysisSummary(unittest.TestCase):
+    """Tests for format_analysis_summary."""
+
+    def test_format_dry_run(self):
+        records = ci_agentic_analyzer.analyze_records(
+            [SAMPLE_CLASSIFIED_RECORD], dry_run=True
+        )
+        output = ci_agentic_analyzer.format_analysis_summary(records)
+        self.assertIn("DRY RUN", output)
+        self.assertIn("Run #1503", output)
+
+    @patch("ci_agentic_analyzer.call_llm")
+    def test_format_success(self, mock_call):
+        mock_call.return_value = VALID_LLM_RESPONSE
+        config = ci_agentic_analyzer.LLMConfig(api_key="test-key")
+        records = ci_agentic_analyzer.analyze_records(
+            [SAMPLE_CLASSIFIED_RECORD], config=config
+        )
+        output = ci_agentic_analyzer.format_analysis_summary(records)
+        self.assertIn("LLM Refined", output)
+        self.assertIn("Root Cause", output)
+        self.assertIn("Volume mount", output)
+
+    def test_format_no_api_key(self):
+        config = ci_agentic_analyzer.LLMConfig(api_key="")
+        records = ci_agentic_analyzer.analyze_records(
+            [SAMPLE_CLASSIFIED_RECORD], config=config
+        )
+        output = ci_agentic_analyzer.format_analysis_summary(records)
+        self.assertIn("no CI_LLM_API_KEY", output)
+
+
+class TestLLMConfig(unittest.TestCase):
+    """Tests for LLMConfig defaults."""
+
+    def test_defaults(self):
+        config = ci_agentic_analyzer.LLMConfig()
+        self.assertEqual(config.api_url, ci_agentic_analyzer.DEFAULT_API_URL)
+        self.assertEqual(config.model, ci_agentic_analyzer.DEFAULT_MODEL)
+        self.assertEqual(config.api_key, "")
+        self.assertLess(config.temperature, 0.5)
+
+    def test_custom_config(self):
+        config = ci_agentic_analyzer.LLMConfig(
+            api_url="https://custom.api/v1/chat",
+            api_key="custom-key",
+            model="custom-model",
+        )
+        self.assertEqual(config.api_url, "https://custom.api/v1/chat")
+        self.assertEqual(config.api_key, "custom-key")
+
+
+class TestSystemPrompt(unittest.TestCase):
+    """Tests for the system prompt content."""
+
+    def test_prompt_requests_json(self):
+        self.assertIn("JSON", ci_agentic_analyzer.SYSTEM_PROMPT)
+
+    def test_prompt_includes_schema(self):
+        self.assertIn("refined_category", ci_agentic_analyzer.SYSTEM_PROMPT)
+        self.assertIn("root_cause", ci_agentic_analyzer.SYSTEM_PROMPT)
+        self.assertIn("is_flake_assessment", ci_agentic_analyzer.SYSTEM_PROMPT)
+
+    def test_prompt_includes_constraints(self):
+        self.assertIn("Do not speculate", ci_agentic_analyzer.SYSTEM_PROMPT)
+        self.assertIn("Never fabricate", ci_agentic_analyzer.SYSTEM_PROMPT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hack/ci/ci_failure_classifier.py
+++ b/hack/ci/ci_failure_classifier.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""
+ci_failure_classifier - Deterministic classification of CI failures.
+
+Categorizes CI failure logs using pattern-matching rules based on
+real Podman CI failure patterns. Each rule has a category, a set of
+regex patterns, a confidence score, and evidence extraction logic.
+
+Designed to handle the most common and well-understood failure types
+reliably and testably before any LLM-based analysis (PR 5).
+
+Usage:
+    # Classify failures from ci_log_retriever output
+    ./hack/ci/ci_log_retriever.py --run-id 31813098642 | \
+        ./hack/ci/ci_failure_classifier.py --stdin
+
+    # Classify a single log snippet
+    echo '{"normalized_log_excerpt": "panic: nil pointer"}' | \
+        ./hack/ci/ci_failure_classifier.py --stdin
+
+Environment:
+    GITHUB_TOKEN       Required if using --run-id to fetch data.
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+# Import upstream modules from the pipeline.
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import ci_run_collector
+import ci_log_retriever
+
+
+# --- Failure categories ---
+
+# Category constants. Each maps to a human-readable description.
+CATEGORIES = {
+    "test_assertion_failure": (
+        "A test assertion failed — the code under test produced an "
+        "unexpected result."
+    ),
+    "panic": (
+        "A Go panic, segfault, or fatal runtime error crashed the process."
+    ),
+    "timeout": (
+        "The job or test exceeded its time limit."
+    ),
+    "network_error": (
+        "A network-related failure: DNS resolution, connection refused, "
+        "TLS handshake, or HTTP timeout."
+    ),
+    "infrastructure_failure": (
+        "CI infrastructure problem: VM boot, lima setup, runner issue, "
+        "or disk/mount error."
+    ),
+    "resource_exhaustion": (
+        "System resource exhaustion: OOM, file descriptor limit, "
+        "storage space, or process limit."
+    ),
+    "container_runtime_error": (
+        "Container runtime failure: crun/runc error, namespace setup, "
+        "cgroup, or seccomp problem."
+    ),
+    "image_pull_failure": (
+        "Failed to pull a container image from a registry."
+    ),
+    "build_failure": (
+        "Compilation or build error: Go build failure, linker error, "
+        "or missing dependency."
+    ),
+    "dependency_failure": (
+        "External dependency failure: package install, pip/go module "
+        "download, or missing tool."
+    ),
+    "permission_error": (
+        "Permission or access denied error in test execution."
+    ),
+    "unknown": (
+        "Could not determine the failure category from the available "
+        "log content."
+    ),
+}
+
+
+# --- Classification rules ---
+
+@dataclass
+class ClassificationRule:
+    """A single pattern-matching rule for failure classification."""
+
+    category: str
+    name: str
+    patterns: list  # List of compiled regex patterns (any match triggers).
+    confidence: float  # 0.0 to 1.0
+    priority: int = 0  # Higher priority rules win ties.
+
+    def match(self, text: str) -> Optional[dict]:
+        """
+        Test if this rule matches the given text.
+
+        Returns a dict with match details if any pattern matches,
+        or None if no match.
+        """
+        for pattern in self.patterns:
+            m = pattern.search(text)
+            if m:
+                # Extract evidence: the matching line plus context.
+                start = max(0, m.start() - 200)
+                end = min(len(text), m.end() + 200)
+                evidence = text[start:end].strip()
+                return {
+                    "rule_name": self.name,
+                    "category": self.category,
+                    "confidence": self.confidence,
+                    "priority": self.priority,
+                    "matched_pattern": pattern.pattern,
+                    "matched_text": m.group(0)[:200],
+                    "evidence": evidence[:500],
+                }
+        return None
+
+
+def _compile_rules() -> list:
+    """
+    Build the ordered list of classification rules.
+
+    Rules are ordered by specificity — more specific patterns first,
+    with higher priority. When multiple rules match, the highest
+    priority+confidence combination wins.
+    """
+    rules = []
+
+    # --- Panic / crash (highest priority — always significant) ---
+    rules.append(ClassificationRule(
+        category="panic",
+        name="go_panic",
+        patterns=[
+            re.compile(r"^panic:\s", re.MULTILINE),
+            re.compile(r"^fatal error:\s", re.MULTILINE),
+            re.compile(r"signal SIGSEGV", re.IGNORECASE),
+            re.compile(r"signal SIGABRT", re.IGNORECASE),
+            re.compile(r"^goroutine \d+ \[running\]", re.MULTILINE),
+        ],
+        confidence=0.95,
+        priority=100,
+    ))
+
+    # --- Timeout ---
+    rules.append(ClassificationRule(
+        category="timeout",
+        name="job_timeout",
+        patterns=[
+            re.compile(r"The job running on runner .+ has exceeded the maximum execution time", re.IGNORECASE),
+            re.compile(r"Error:\s+Timed out after\s+\d+", re.IGNORECASE),
+            re.compile(r"context deadline exceeded"),
+            re.compile(r"timed?\s*out.*waiting", re.IGNORECASE),
+            re.compile(r"test\s+timed?\s*out\s+after", re.IGNORECASE),
+        ],
+        confidence=0.90,
+        priority=90,
+    ))
+
+    # --- Resource exhaustion ---
+    rules.append(ClassificationRule(
+        category="resource_exhaustion",
+        name="oom",
+        patterns=[
+            re.compile(r"Out [Oo]f [Mm]emory", re.IGNORECASE),
+            re.compile(r"OOM\s*kill", re.IGNORECASE),
+            re.compile(r"Cannot allocate memory", re.IGNORECASE),
+            re.compile(r"oom-kill:"),
+            re.compile(r"Killed\s+process\s+\d+"),
+        ],
+        confidence=0.95,
+        priority=85,
+    ))
+
+    rules.append(ClassificationRule(
+        category="resource_exhaustion",
+        name="disk_space",
+        patterns=[
+            re.compile(r"No space left on device", re.IGNORECASE),
+            re.compile(r"ENOSPC"),
+            re.compile(r"Disk quota exceeded", re.IGNORECASE),
+        ],
+        confidence=0.95,
+        priority=85,
+    ))
+
+    rules.append(ClassificationRule(
+        category="resource_exhaustion",
+        name="fd_limit",
+        patterns=[
+            re.compile(r"Too many open files", re.IGNORECASE),
+            re.compile(r"EMFILE"),
+            re.compile(r"ENFILE"),
+        ],
+        confidence=0.90,
+        priority=80,
+    ))
+
+    # --- Infrastructure failure ---
+    rules.append(ClassificationRule(
+        category="infrastructure_failure",
+        name="lima_vm_failure",
+        patterns=[
+            re.compile(r"limactl.*(?:failed|error|timeout)", re.IGNORECASE),
+            re.compile(r"lima.*VM.*(?:failed|not running|crashed)", re.IGNORECASE),
+            re.compile(r"FATA\[.*\].*lima", re.IGNORECASE),
+            re.compile(r"failed to start.*VM", re.IGNORECASE),
+        ],
+        confidence=0.90,
+        priority=80,
+    ))
+
+    rules.append(ClassificationRule(
+        category="infrastructure_failure",
+        name="runner_failure",
+        patterns=[
+            re.compile(r"Runner\s+.*(?:lost|disconnected|offline)", re.IGNORECASE),
+            re.compile(r"The self-hosted runner.*lost communication", re.IGNORECASE),
+            re.compile(r"Receiving request timed out", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=75,
+    ))
+
+    # --- Network errors ---
+    rules.append(ClassificationRule(
+        category="network_error",
+        name="dns_failure",
+        patterns=[
+            re.compile(r"(?:Temporary failure|NXDOMAIN).*(?:name resolution|resolving)", re.IGNORECASE),
+            re.compile(r"could not resolve host", re.IGNORECASE),
+            re.compile(r"Name or service not known", re.IGNORECASE),
+            re.compile(r"no such host", re.IGNORECASE),
+        ],
+        confidence=0.90,
+        priority=70,
+    ))
+
+    rules.append(ClassificationRule(
+        category="network_error",
+        name="connection_failure",
+        patterns=[
+            re.compile(r"connection refused", re.IGNORECASE),
+            re.compile(r"connection reset by peer", re.IGNORECASE),
+            re.compile(r"connection timed out", re.IGNORECASE),
+            re.compile(r"dial tcp.*: i/o timeout"),
+            re.compile(r"TLS handshake timeout", re.IGNORECASE),
+            re.compile(r"Client\.Timeout exceeded", re.IGNORECASE),
+            re.compile(r"net/http:.*timeout", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=70,
+    ))
+
+    # --- Image pull failures ---
+    rules.append(ClassificationRule(
+        category="image_pull_failure",
+        name="registry_error",
+        patterns=[
+            re.compile(r"(?:failed to|error|unable to)\s+pull\s+(?:image|manifest)", re.IGNORECASE),
+            re.compile(r"manifest unknown", re.IGNORECASE),
+            re.compile(r"(?:401|403)\s+(?:Unauthorized|Forbidden).*registry", re.IGNORECASE),
+            re.compile(r"(?:registry|quay\.io|docker\.io).*(?:unavailable|timeout|error)", re.IGNORECASE),
+            re.compile(r"Error: initializing source.*registry", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=65,
+    ))
+
+    # --- Container runtime errors ---
+    rules.append(ClassificationRule(
+        category="container_runtime_error",
+        name="crun_runc_error",
+        patterns=[
+            re.compile(r"(?:crun|runc):\s+(?:error|fatal)", re.IGNORECASE),
+            re.compile(r"OCI runtime error", re.IGNORECASE),
+            re.compile(r"error creating.*(?:namespace|cgroup)", re.IGNORECASE),
+            re.compile(r"rootfs_linux\.go.*mounting", re.IGNORECASE),
+            re.compile(r"error setting up.*network", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=60,
+    ))
+
+    # --- Build failure ---
+    rules.append(ClassificationRule(
+        category="build_failure",
+        name="go_build_error",
+        patterns=[
+            re.compile(r"^#\s+\S+\n.*\.go:\d+:\d+:.*(?:undefined|cannot|undeclared)", re.MULTILINE),
+            re.compile(r"cannot find package", re.IGNORECASE),
+            re.compile(r"could not import", re.IGNORECASE),
+            re.compile(r"build failed", re.IGNORECASE),
+            re.compile(r"(?:linker|ld).*(?:undefined reference|symbol)", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=55,
+    ))
+
+    # --- Dependency failure ---
+    rules.append(ClassificationRule(
+        category="dependency_failure",
+        name="package_install_failure",
+        patterns=[
+            re.compile(r"(?:dnf|apt-get|yum|rpm).*(?:error|failed|unable)", re.IGNORECASE),
+            re.compile(r"pip.*(?:error|failed).*install", re.IGNORECASE),
+            re.compile(r"go: .*module.*not found", re.IGNORECASE),
+            re.compile(r"No matching packages", re.IGNORECASE),
+        ],
+        confidence=0.80,
+        priority=50,
+    ))
+
+    # --- Permission errors ---
+    rules.append(ClassificationRule(
+        category="permission_error",
+        name="access_denied",
+        patterns=[
+            re.compile(r"(?:Permission|Access)\s+denied", re.IGNORECASE),
+            re.compile(r"EACCES"),
+            re.compile(r"operation not permitted", re.IGNORECASE),
+            re.compile(r"(?:rootless|unprivileged).*not.*(?:allowed|supported)", re.IGNORECASE),
+        ],
+        confidence=0.80,
+        priority=45,
+    ))
+
+    # --- Test assertion failures (lowest priority — most common, least specific) ---
+    rules.append(ClassificationRule(
+        category="test_assertion_failure",
+        name="ginkgo_assertion",
+        patterns=[
+            re.compile(r"^\[FAIL\]", re.MULTILINE),
+            re.compile(r"^Expected\s*$", re.MULTILINE),
+            re.compile(r"Expected\s+\n\s+<.*>:", re.MULTILINE),
+            re.compile(r"to equal\s*$", re.MULTILINE),
+            re.compile(r"Unexpected error:", re.IGNORECASE),
+            re.compile(r"FAIL!\s+--\s+\d+\s+Passed\s*\|\s*[1-9]\d*\s+Failed"),
+        ],
+        confidence=0.85,
+        priority=40,
+    ))
+
+    rules.append(ClassificationRule(
+        category="test_assertion_failure",
+        name="bats_assertion",
+        patterns=[
+            re.compile(r"^not ok\s+\d+", re.MULTILINE),
+            re.compile(r"expected:\s+\d+\s*$\s*actual:\s+\d+", re.MULTILINE),
+            re.compile(r"#\s+\(in test file.*\.bats", re.IGNORECASE),
+        ],
+        confidence=0.85,
+        priority=40,
+    ))
+
+    return rules
+
+
+# Module-level compiled rules (built once at import time).
+RULES = _compile_rules()
+
+
+# --- Classification result ---
+
+@dataclass
+class ClassificationResult:
+    """The result of classifying a single failure record."""
+
+    category: str
+    category_description: str
+    confidence: float
+    rule_name: str
+    matched_pattern: str
+    matched_text: str
+    evidence: str
+    all_matches: list = field(default_factory=list)
+
+
+def classify_text(text: str, rules: Optional[list] = None) -> ClassificationResult:
+    """
+    Classify a block of text against all rules.
+
+    Returns the highest-priority match, with all matches stored
+    in `all_matches` for transparency.
+    """
+    if rules is None:
+        rules = RULES
+
+    all_matches = []
+    for rule in rules:
+        match = rule.match(text)
+        if match:
+            all_matches.append(match)
+
+    if not all_matches:
+        return ClassificationResult(
+            category="unknown",
+            category_description=CATEGORIES["unknown"],
+            confidence=0.0,
+            rule_name="none",
+            matched_pattern="",
+            matched_text="",
+            evidence="",
+        )
+
+    # Sort by priority (descending), then confidence (descending).
+    all_matches.sort(key=lambda m: (m["priority"], m["confidence"]), reverse=True)
+    best = all_matches[0]
+
+    return ClassificationResult(
+        category=best["category"],
+        category_description=CATEGORIES.get(best["category"], ""),
+        confidence=best["confidence"],
+        rule_name=best["rule_name"],
+        matched_pattern=best["matched_pattern"],
+        matched_text=best["matched_text"],
+        evidence=best["evidence"],
+        all_matches=all_matches,
+    )
+
+
+def classify_failure_record(record: dict) -> dict:
+    """
+    Classify a FailureRecord (from ci_log_retriever) and return
+    the record augmented with classification data.
+    """
+    # Combine all text sources for classification.
+    text_parts = []
+
+    # Prioritize failure sections (most relevant).
+    for section in record.get("failure_sections", []):
+        text_parts.append(section.get("text", ""))
+
+    # Fall back to the full normalized log excerpt.
+    excerpt = record.get("normalized_log_excerpt", "")
+    if excerpt:
+        text_parts.append(excerpt)
+
+    combined_text = "\n".join(text_parts)
+
+    if not combined_text.strip():
+        result = ClassificationResult(
+            category="unknown",
+            category_description=CATEGORIES["unknown"],
+            confidence=0.0,
+            rule_name="no_log_content",
+            matched_pattern="",
+            matched_text="",
+            evidence="No log content available for classification.",
+        )
+    else:
+        result = classify_text(combined_text)
+
+    # Augment the record with classification.
+    classified = dict(record)
+    classified["classification"] = {
+        "category": result.category,
+        "category_description": result.category_description,
+        "confidence": result.confidence,
+        "rule_name": result.rule_name,
+        "matched_text": result.matched_text,
+        "evidence": result.evidence,
+        "all_matches_count": len(result.all_matches),
+    }
+
+    return classified
+
+
+def format_classification_summary(records: list) -> str:
+    """Format classified records as a human-readable summary."""
+    lines = []
+    # Group by category.
+    by_category = {}
+    for rec in records:
+        cat = rec.get("classification", {}).get("category", "unknown")
+        by_category.setdefault(cat, []).append(rec)
+
+    lines.append(f"Classification Summary ({len(records)} failures)")
+    lines.append("=" * 50)
+
+    for cat in sorted(by_category, key=lambda c: len(by_category[c]), reverse=True):
+        recs = by_category[cat]
+        lines.append(f"\n{cat} ({len(recs)}):")
+        lines.append(f"  {CATEGORIES.get(cat, '')}")
+        for rec in recs:
+            clf = rec.get("classification", {})
+            lines.append(
+                f"  - Run #{rec.get('run_number', '?')} "
+                f"job={rec.get('job_name', '?')!r} "
+                f"conf={clf.get('confidence', 0):.0%} "
+                f"rule={clf.get('rule_name', '?')}"
+            )
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Classify CI failure logs into categories.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", ci_log_retriever.DEFAULT_REPO),
+        help="GitHub repository",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=int,
+        help="Fetch and classify failures for a specific run ID",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read failure records from stdin (JSON from ci_log_retriever.py)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Output human-readable summary (default)",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        if args.stdin:
+            records = json.load(sys.stdin)
+            if isinstance(records, dict):
+                records = [records]
+        elif args.run_id:
+            # Full pipeline: collect → retrieve logs → classify.
+            run_data = ci_run_collector.collect_single_run(
+                args.repo, args.run_id, token
+            )
+            records = ci_log_retriever.build_failure_records(
+                run_data, repo=args.repo, token=token
+            )
+        else:
+            parser.error("Specify --run-id or --stdin")
+            return
+
+        classified = [classify_failure_record(r) for r in records]
+
+        if args.json_output:
+            json.dump(classified, sys.stdout, indent=2)
+            print()
+        else:
+            if not classified:
+                print("No failure records to classify.")
+            else:
+                print(format_classification_summary(classified))
+
+    except ci_run_collector.GitHubAPIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except (json.JSONDecodeError, KeyError) as e:
+        print(f"Error: Invalid input data: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_failure_classifier_test.py
+++ b/hack/ci/ci_failure_classifier_test.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_failure_classifier.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_failure_classifier_test.py -v
+    python3 hack/ci/ci_failure_classifier_test.py
+"""
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_failure_classifier
+
+
+# --- Realistic log snippets for each failure category ---
+
+LOG_GINKGO_ASSERTION = """\
+-----
+[FAIL] Podman run with volume
+  Expected
+      <string>: /tmp/testdir
+  to equal
+      <string>: /tmp/expected
+-----
+FAIL! -- 45 Passed | 1 Failed | 0 Pending | 3 Skipped
+"""
+
+LOG_BATS_ASSERTION = """\
+1..50
+ok 1 podman ps
+ok 2 podman images
+not ok 3 podman run with networking
+# (in test file test/system/500-networking.bats, line 42)
+#   `run_podman run --rm --net=host alpine wget -qO- http://localhost:8080' failed
+#   expected: 0
+#   actual:   7
+ok 4 podman stop
+"""
+
+LOG_GO_PANIC = """\
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1234]
+
+goroutine 1 [running]:
+main.(*Runtime).Start(0x0, 0xc000123456)
+    /go/src/podman/libpod/runtime.go:123 +0x45
+"""
+
+LOG_SIGABRT = """\
+signal SIGABRT received, stopping runtime
+goroutine 42 [running]:
+os/signal.signal_recv()
+"""
+
+LOG_TIMEOUT = """\
+The job running on runner cncf-ubuntu-8-32-x86-abc has exceeded the maximum execution time of 30 minutes
+Canceling job...
+"""
+
+LOG_CONTEXT_DEADLINE = """\
+Error: context deadline exceeded: failed to connect to /run/podman/podman.sock
+Error: timed out waiting for container
+"""
+
+LOG_OOM = """\
+kernel: Out of memory: Killed process 12345 (podman) total-vm:8388608kB
+oom-kill: constraint=CONSTRAINT_MEMCG
+"""
+
+LOG_DISK_SPACE = """\
+Error: writing blob: copying layer sha256:abc123
+No space left on device
+ENOSPC
+"""
+
+LOG_FD_LIMIT = """\
+Error: unable to create runtime: Too many open files
+"""
+
+LOG_LIMA_FAILURE = """\
+FATA[0120] limactl: failed to start VM: error mounting volume
+lima VM not running after setup, check host configuration
+"""
+
+LOG_RUNNER_FAILURE = """\
+The self-hosted runner lost communication with the server.
+Receiving request timed out.
+"""
+
+LOG_DNS_FAILURE = """\
+Error: failed to pull image: could not resolve host: quay.io
+Temporary failure in name resolution
+"""
+
+LOG_CONNECTION_FAILURE = """\
+dial tcp 10.0.2.15:5000: connection refused
+Get "https://registry.example.com/v2/": net/http: TLS handshake timeout
+"""
+
+LOG_IMAGE_PULL = """\
+Error: initializing source docker://quay.io/libpod/testimage:latest:
+failed to pull image: manifest unknown
+"""
+
+LOG_CRUN_ERROR = """\
+crun: error creating container: OCI runtime error
+error creating new namespace: operation not permitted
+"""
+
+LOG_BUILD_FAILURE = """\
+# go.podman.io/podman/v6/cmd/podman
+cmd/podman/main.go:42:15: undefined: newCommand
+build failed
+"""
+
+LOG_DEPENDENCY_FAILURE = """\
+dnf install -y golang
+Error: No matching packages to list
+"""
+
+LOG_PERMISSION_ERROR = """\
+Error: Permission denied while trying to bind mount /proc/sys
+operation not permitted for rootless user
+"""
+
+LOG_CLEAN = """\
+Running test suite
+ok 1 podman ps
+ok 2 podman images
+ok 3 podman run
+SUCCESS! -- 3 Passed | 0 Failed | 0 Skipped
+"""
+
+
+class TestClassifyText(unittest.TestCase):
+    """Tests for classify_text with each failure category."""
+
+    def test_ginkgo_assertion(self):
+        result = ci_failure_classifier.classify_text(LOG_GINKGO_ASSERTION)
+        self.assertEqual(result.category, "test_assertion_failure")
+        self.assertGreater(result.confidence, 0.5)
+
+    def test_bats_assertion(self):
+        result = ci_failure_classifier.classify_text(LOG_BATS_ASSERTION)
+        self.assertEqual(result.category, "test_assertion_failure")
+        self.assertIn("bats", result.rule_name)
+
+    def test_go_panic(self):
+        result = ci_failure_classifier.classify_text(LOG_GO_PANIC)
+        self.assertEqual(result.category, "panic")
+        self.assertGreaterEqual(result.confidence, 0.90)
+
+    def test_sigabrt(self):
+        result = ci_failure_classifier.classify_text(LOG_SIGABRT)
+        self.assertEqual(result.category, "panic")
+
+    def test_timeout(self):
+        result = ci_failure_classifier.classify_text(LOG_TIMEOUT)
+        self.assertEqual(result.category, "timeout")
+        self.assertGreaterEqual(result.confidence, 0.85)
+
+    def test_context_deadline(self):
+        result = ci_failure_classifier.classify_text(LOG_CONTEXT_DEADLINE)
+        self.assertEqual(result.category, "timeout")
+
+    def test_oom(self):
+        result = ci_failure_classifier.classify_text(LOG_OOM)
+        self.assertEqual(result.category, "resource_exhaustion")
+        self.assertGreaterEqual(result.confidence, 0.90)
+
+    def test_disk_space(self):
+        result = ci_failure_classifier.classify_text(LOG_DISK_SPACE)
+        self.assertEqual(result.category, "resource_exhaustion")
+
+    def test_fd_limit(self):
+        result = ci_failure_classifier.classify_text(LOG_FD_LIMIT)
+        self.assertEqual(result.category, "resource_exhaustion")
+
+    def test_lima_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_LIMA_FAILURE)
+        self.assertEqual(result.category, "infrastructure_failure")
+
+    def test_runner_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_RUNNER_FAILURE)
+        self.assertEqual(result.category, "infrastructure_failure")
+
+    def test_dns_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_DNS_FAILURE)
+        self.assertEqual(result.category, "network_error")
+
+    def test_connection_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_CONNECTION_FAILURE)
+        self.assertEqual(result.category, "network_error")
+
+    def test_image_pull(self):
+        result = ci_failure_classifier.classify_text(LOG_IMAGE_PULL)
+        self.assertEqual(result.category, "image_pull_failure")
+
+    def test_crun_error(self):
+        result = ci_failure_classifier.classify_text(LOG_CRUN_ERROR)
+        self.assertEqual(result.category, "container_runtime_error")
+
+    def test_build_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_BUILD_FAILURE)
+        self.assertEqual(result.category, "build_failure")
+
+    def test_dependency_failure(self):
+        result = ci_failure_classifier.classify_text(LOG_DEPENDENCY_FAILURE)
+        self.assertEqual(result.category, "dependency_failure")
+
+    def test_permission_error(self):
+        result = ci_failure_classifier.classify_text(LOG_PERMISSION_ERROR)
+        self.assertEqual(result.category, "permission_error")
+
+    def test_clean_log_returns_unknown(self):
+        result = ci_failure_classifier.classify_text(LOG_CLEAN)
+        self.assertEqual(result.category, "unknown")
+
+    def test_empty_text_returns_unknown(self):
+        result = ci_failure_classifier.classify_text("")
+        self.assertEqual(result.category, "unknown")
+        self.assertEqual(result.confidence, 0.0)
+
+
+class TestPriorityResolution(unittest.TestCase):
+    """Tests that higher-priority rules win when multiple rules match."""
+
+    def test_panic_beats_assertion(self):
+        """A log with both panic and assertion markers should classify as panic."""
+        text = LOG_GO_PANIC + "\n" + LOG_GINKGO_ASSERTION
+        result = ci_failure_classifier.classify_text(text)
+        self.assertEqual(result.category, "panic")
+
+    def test_timeout_beats_assertion(self):
+        """Timeout is more specific than assertion failure."""
+        text = LOG_TIMEOUT + "\n" + LOG_BATS_ASSERTION
+        result = ci_failure_classifier.classify_text(text)
+        self.assertEqual(result.category, "timeout")
+
+    def test_oom_beats_assertion(self):
+        """OOM is more specific than assertion failure."""
+        text = LOG_OOM + "\n" + LOG_GINKGO_ASSERTION
+        result = ci_failure_classifier.classify_text(text)
+        self.assertEqual(result.category, "resource_exhaustion")
+
+    def test_all_matches_tracked(self):
+        """When multiple rules match, all are recorded."""
+        text = LOG_GO_PANIC + "\n" + LOG_GINKGO_ASSERTION
+        result = ci_failure_classifier.classify_text(text)
+        self.assertGreater(len(result.all_matches), 1)
+
+
+class TestClassifyFailureRecord(unittest.TestCase):
+    """Tests for classify_failure_record with FailureRecord dicts."""
+
+    def test_classifies_from_failure_sections(self):
+        record = {
+            "run_id": 12345,
+            "run_number": 100,
+            "workflow": "ci",
+            "job_name": "sys local root fedora-current",
+            "job_id": 90001,
+            "step_name": "Run test on lima",
+            "branch": "main",
+            "commit_sha": "abc123",
+            "commit_message": "test commit",
+            "event": "push",
+            "created_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com",
+            "failure_sections": [
+                {"type": "ginkgo_failure", "text": LOG_GINKGO_ASSERTION},
+            ],
+            "normalized_log_excerpt": "",
+            "raw_log_bytes": 1024,
+        }
+        result = ci_failure_classifier.classify_failure_record(record)
+        clf = result["classification"]
+        self.assertEqual(clf["category"], "test_assertion_failure")
+        self.assertGreater(clf["confidence"], 0.0)
+        self.assertIn("category_description", clf)
+
+    def test_classifies_from_log_excerpt(self):
+        """Falls back to normalized_log_excerpt if no failure_sections."""
+        record = {
+            "run_id": 12345,
+            "run_number": 100,
+            "workflow": "ci",
+            "job_name": "test-job",
+            "job_id": 90001,
+            "step_name": "step",
+            "branch": "main",
+            "commit_sha": "abc",
+            "commit_message": "msg",
+            "event": "push",
+            "created_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com",
+            "failure_sections": [],
+            "normalized_log_excerpt": LOG_GO_PANIC,
+            "raw_log_bytes": 512,
+        }
+        result = ci_failure_classifier.classify_failure_record(record)
+        self.assertEqual(result["classification"]["category"], "panic")
+
+    def test_unknown_when_no_content(self):
+        record = {
+            "run_id": 12345,
+            "run_number": 100,
+            "workflow": "ci",
+            "job_name": "test-job",
+            "job_id": 90001,
+            "step_name": "step",
+            "branch": "main",
+            "commit_sha": "abc",
+            "commit_message": "msg",
+            "event": "push",
+            "created_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com",
+            "failure_sections": [],
+            "normalized_log_excerpt": "",
+            "raw_log_bytes": 0,
+        }
+        result = ci_failure_classifier.classify_failure_record(record)
+        self.assertEqual(result["classification"]["category"], "unknown")
+
+    def test_preserves_original_fields(self):
+        """Classification should augment, not replace, original fields."""
+        record = {
+            "run_id": 12345,
+            "run_number": 100,
+            "workflow": "ci",
+            "job_name": "test-job",
+            "job_id": 90001,
+            "step_name": "step",
+            "branch": "main",
+            "commit_sha": "abc123",
+            "commit_message": "test",
+            "event": "push",
+            "created_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://example.com",
+            "failure_sections": [],
+            "normalized_log_excerpt": LOG_DNS_FAILURE,
+            "raw_log_bytes": 256,
+        }
+        result = ci_failure_classifier.classify_failure_record(record)
+        # Original fields preserved.
+        self.assertEqual(result["run_id"], 12345)
+        self.assertEqual(result["job_name"], "test-job")
+        self.assertEqual(result["commit_sha"], "abc123")
+        # Classification added.
+        self.assertIn("classification", result)
+        self.assertEqual(result["classification"]["category"], "network_error")
+
+
+class TestFormatSummary(unittest.TestCase):
+    """Tests for format_classification_summary."""
+
+    def test_groups_by_category(self):
+        records = [
+            {
+                "run_number": 1,
+                "job_name": "job-a",
+                "classification": {
+                    "category": "panic",
+                    "confidence": 0.95,
+                    "rule_name": "go_panic",
+                },
+            },
+            {
+                "run_number": 2,
+                "job_name": "job-b",
+                "classification": {
+                    "category": "panic",
+                    "confidence": 0.90,
+                    "rule_name": "go_panic",
+                },
+            },
+            {
+                "run_number": 3,
+                "job_name": "job-c",
+                "classification": {
+                    "category": "network_error",
+                    "confidence": 0.85,
+                    "rule_name": "dns_failure",
+                },
+            },
+        ]
+        output = ci_failure_classifier.format_classification_summary(records)
+        self.assertIn("panic (2)", output)
+        self.assertIn("network_error (1)", output)
+        self.assertIn("3 failures", output)
+
+    def test_empty_records(self):
+        output = ci_failure_classifier.format_classification_summary([])
+        self.assertIn("0 failures", output)
+
+
+class TestClassificationRule(unittest.TestCase):
+    """Tests for the ClassificationRule dataclass."""
+
+    def test_match_returns_evidence(self):
+        rule = ci_failure_classifier.ClassificationRule(
+            category="test",
+            name="test_rule",
+            patterns=[ci_failure_classifier.re.compile(r"FAIL")],
+            confidence=0.9,
+            priority=50,
+        )
+        result = rule.match("This test will FAIL here")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["category"], "test")
+        self.assertEqual(result["matched_text"], "FAIL")
+        self.assertIn("FAIL", result["evidence"])
+
+    def test_no_match_returns_none(self):
+        rule = ci_failure_classifier.ClassificationRule(
+            category="test",
+            name="test_rule",
+            patterns=[ci_failure_classifier.re.compile(r"NONEXISTENT")],
+            confidence=0.9,
+            priority=50,
+        )
+        result = rule.match("Nothing matches here")
+        self.assertIsNone(result)
+
+
+class TestCategoriesComplete(unittest.TestCase):
+    """Ensure all categories used in rules have descriptions."""
+
+    def test_all_rule_categories_have_descriptions(self):
+        for rule in ci_failure_classifier.RULES:
+            self.assertIn(
+                rule.category,
+                ci_failure_classifier.CATEGORIES,
+                f"Rule '{rule.name}' uses category '{rule.category}' "
+                f"which has no description in CATEGORIES.",
+            )
+
+    def test_unknown_category_exists(self):
+        self.assertIn("unknown", ci_failure_classifier.CATEGORIES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hack/ci/ci_flake_detector.py
+++ b/hack/ci/ci_flake_detector.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""
+ci_flake_detector - Detect flaky CI tests from classified failure records.
+
+Analyzes classified failure records across multiple CI runs to identify
+tests that fail intermittently (flakes) vs deterministically. Uses
+multiple signals: failure frequency, commit diversity, category
+correlation, and retry behavior.
+
+Usage:
+    # Analyze classified records from stdin
+    ./hack/ci/ci_failure_classifier.py --stdin < records.json | \
+        ./hack/ci/ci_flake_detector.py --stdin
+
+    # Full pipeline from collector through flake detection
+    ./hack/ci/ci_run_collector.py --branch main --status failure --limit 50 --json | \
+        ./hack/ci/ci_log_retriever.py --stdin | \
+        ./hack/ci/ci_failure_classifier.py --stdin | \
+        ./hack/ci/ci_flake_detector.py --stdin
+
+    # Analyze without log download (metadata-only mode)
+    ./hack/ci/ci_flake_detector.py --branch main --limit 50 --no-download
+
+Environment:
+    GITHUB_TOKEN       Required if fetching data from the API.
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import ci_failure_classifier
+import ci_log_retriever
+import ci_run_collector
+
+
+# Categories that strongly correlate with flakiness rather than
+# genuine code bugs. These failures are typically environmental.
+FLAKE_CORRELATED_CATEGORIES = {
+    "network_error",
+    "infrastructure_failure",
+    "image_pull_failure",
+    "resource_exhaustion",
+    "timeout",
+}
+
+# Categories that strongly suggest a genuine bug, not a flake.
+BUG_CORRELATED_CATEGORIES = {
+    "test_assertion_failure",
+    "build_failure",
+    "panic",
+}
+
+# Minimum number of failure records needed to compute meaningful
+# flake statistics for a given job.
+MIN_RECORDS_FOR_ANALYSIS = 2
+
+
+@dataclass
+class FlakeSignals:
+    """Individual signals that contribute to the flake score."""
+
+    # How many distinct commits triggered the same failure?
+    # More diverse commits → more likely a flake.
+    commit_diversity: float = 0.0
+    # What fraction of runs for this job failed?
+    # Very high or very low → less likely a flake.
+    failure_rate: float = 0.0
+    # Is the failure category correlated with flakiness?
+    category_flake_correlation: float = 0.0
+    # Was this failure retried and did the retry succeed?
+    retry_signal: float = 0.0
+    # How many distinct run dates had this failure?
+    temporal_spread: float = 0.0
+
+
+@dataclass
+class FlakeReport:
+    """Flake analysis report for a single job/test."""
+
+    job_name: str
+    flake_score: float  # 0.0 (definitely not flaky) to 1.0 (definitely flaky)
+    is_flaky: bool
+    total_failures: int
+    unique_commits: int
+    unique_dates: int
+    categories: dict  # category → count
+    signals: dict
+    sample_failures: list = field(default_factory=list)
+
+
+def _extract_date(timestamp: str) -> str:
+    """Extract YYYY-MM-DD from an ISO timestamp."""
+    if timestamp and len(timestamp) >= 10:
+        return timestamp[:10]
+    return ""
+
+
+def compute_flake_signals(records: list) -> FlakeSignals:
+    """
+    Compute flake signals from a set of failure records for
+    the same job name.
+    """
+    if not records:
+        return FlakeSignals()
+
+    signals = FlakeSignals()
+
+    # --- Commit diversity ---
+    # If failures span many different commits, it's less likely
+    # that a single commit caused the failure → probably a flake.
+    commits = set()
+    for r in records:
+        sha = r.get("commit_sha", "")
+        if sha:
+            commits.add(sha)
+
+    n_commits = len(commits)
+    if n_commits >= 5:
+        signals.commit_diversity = 1.0
+    elif n_commits >= 3:
+        signals.commit_diversity = 0.7
+    elif n_commits >= 2:
+        signals.commit_diversity = 0.4
+    else:
+        signals.commit_diversity = 0.0
+
+    # --- Failure rate ---
+    # A failure rate between 10% and 80% is the "flake zone".
+    # Always-failing or never-failing isn't flaky.
+    # Note: We only have failed records, so we approximate using
+    # the diversity of commits as a proxy.
+    n_records = len(records)
+    if n_records >= 10 and n_commits >= 5:
+        # Many failures across many commits → persistent flake.
+        signals.failure_rate = 0.8
+    elif n_records >= 5 and n_commits >= 3:
+        signals.failure_rate = 0.6
+    elif n_records >= 2:
+        signals.failure_rate = 0.3
+    else:
+        signals.failure_rate = 0.1
+
+    # --- Category correlation ---
+    # Aggregate categories across all records.
+    categories = defaultdict(int)
+    for r in records:
+        cat = r.get("classification", {}).get("category", "unknown")
+        categories[cat] += 1
+
+    total = sum(categories.values())
+    flake_count = sum(
+        categories.get(c, 0) for c in FLAKE_CORRELATED_CATEGORIES
+    )
+    bug_count = sum(
+        categories.get(c, 0) for c in BUG_CORRELATED_CATEGORIES
+    )
+
+    if total > 0:
+        flake_ratio = flake_count / total
+        bug_ratio = bug_count / total
+        # Flake-correlated categories push the score up;
+        # bug-correlated categories push it down.
+        signals.category_flake_correlation = max(
+            0.0, min(1.0, flake_ratio - bug_ratio * 0.5 + 0.3)
+        )
+
+    # --- Retry signal ---
+    # If any record has run_attempt > 1, the CI system already
+    # considered it worth retrying.
+    retry_records = [
+        r for r in records if r.get("run_attempt", 1) > 1
+    ]
+    if retry_records:
+        signals.retry_signal = min(1.0, len(retry_records) / len(records) + 0.3)
+
+    # --- Temporal spread ---
+    # Failures spread across many days are more likely flakes.
+    dates = set()
+    for r in records:
+        d = _extract_date(r.get("created_at", ""))
+        if d:
+            dates.add(d)
+
+    n_dates = len(dates)
+    if n_dates >= 7:
+        signals.temporal_spread = 1.0
+    elif n_dates >= 4:
+        signals.temporal_spread = 0.7
+    elif n_dates >= 2:
+        signals.temporal_spread = 0.4
+    else:
+        signals.temporal_spread = 0.0
+
+    return signals
+
+
+def compute_flake_score(signals: FlakeSignals) -> float:
+    """
+    Combine individual signals into a single flake score.
+
+    Uses weighted averaging with signal-specific weights that
+    reflect their reliability as flake indicators.
+    """
+    weights = {
+        "commit_diversity": 0.30,
+        "category_flake_correlation": 0.25,
+        "temporal_spread": 0.20,
+        "failure_rate": 0.15,
+        "retry_signal": 0.10,
+    }
+
+    score = (
+        weights["commit_diversity"] * signals.commit_diversity
+        + weights["category_flake_correlation"] * signals.category_flake_correlation
+        + weights["temporal_spread"] * signals.temporal_spread
+        + weights["failure_rate"] * signals.failure_rate
+        + weights["retry_signal"] * signals.retry_signal
+    )
+
+    return round(min(1.0, max(0.0, score)), 3)
+
+
+# Threshold above which a job is considered flaky.
+FLAKE_THRESHOLD = 0.45
+
+
+def analyze_flakes(
+    records: list, threshold: float = FLAKE_THRESHOLD
+) -> list:
+    """
+    Analyze a list of classified failure records for flakiness.
+
+    Groups records by job name and computes flake signals and scores
+    for each job. Returns a list of FlakeReport dicts, sorted by
+    flake score descending.
+    """
+    # Group by job name.
+    by_job = defaultdict(list)
+    for r in records:
+        job_name = r.get("job_name", "unknown")
+        by_job[job_name].append(r)
+
+    reports = []
+    for job_name, job_records in by_job.items():
+        signals = compute_flake_signals(job_records)
+        score = compute_flake_score(signals)
+
+        # Aggregate categories.
+        categories = defaultdict(int)
+        for r in job_records:
+            cat = r.get("classification", {}).get("category", "unknown")
+            categories[cat] += 1
+
+        # Unique commits and dates.
+        commits = set(
+            r.get("commit_sha", "") for r in job_records if r.get("commit_sha")
+        )
+        dates = set(
+            _extract_date(r.get("created_at", ""))
+            for r in job_records
+            if r.get("created_at")
+        )
+
+        # Sample failures for context (up to 3).
+        samples = []
+        for r in job_records[:3]:
+            samples.append({
+                "run_id": r.get("run_id"),
+                "run_number": r.get("run_number"),
+                "commit_sha": r.get("commit_sha", "")[:12],
+                "created_at": r.get("created_at", ""),
+                "category": r.get("classification", {}).get("category", "unknown"),
+                "evidence": r.get("classification", {}).get("evidence", "")[:200],
+            })
+
+        report = FlakeReport(
+            job_name=job_name,
+            flake_score=score,
+            is_flaky=score >= threshold,
+            total_failures=len(job_records),
+            unique_commits=len(commits),
+            unique_dates=len(dates - {""}),
+            categories=dict(categories),
+            signals=asdict(signals),
+            sample_failures=samples,
+        )
+        reports.append(asdict(report))
+
+    # Sort by flake score descending, then by total failures.
+    reports.sort(
+        key=lambda r: (r["flake_score"], r["total_failures"]),
+        reverse=True,
+    )
+
+    return reports
+
+
+def format_flake_report(reports: list) -> str:
+    """Format flake analysis as a human-readable report."""
+    lines = []
+    flaky = [r for r in reports if r["is_flaky"]]
+    non_flaky = [r for r in reports if not r["is_flaky"]]
+
+    lines.append(f"Flake Analysis Report")
+    lines.append(f"{'=' * 60}")
+    lines.append(
+        f"Total jobs analyzed: {len(reports)}, "
+        f"Flaky: {len(flaky)}, "
+        f"Non-flaky: {len(non_flaky)}"
+    )
+
+    if flaky:
+        lines.append(f"\n{'─' * 60}")
+        lines.append("FLAKY JOBS (likely intermittent failures)")
+        lines.append(f"{'─' * 60}")
+        for r in flaky:
+            lines.append(
+                f"\n  {r['job_name']}"
+            )
+            lines.append(
+                f"    Score: {r['flake_score']:.0%} | "
+                f"Failures: {r['total_failures']} | "
+                f"Commits: {r['unique_commits']} | "
+                f"Days: {r['unique_dates']}"
+            )
+            cats = ", ".join(
+                f"{k}({v})" for k, v in sorted(
+                    r["categories"].items(),
+                    key=lambda x: x[1],
+                    reverse=True,
+                )
+            )
+            lines.append(f"    Categories: {cats}")
+
+            # Show signal breakdown.
+            sigs = r["signals"]
+            sig_parts = []
+            for k in ["commit_diversity", "category_flake_correlation",
+                       "temporal_spread", "failure_rate", "retry_signal"]:
+                v = sigs.get(k, 0)
+                if v > 0:
+                    sig_parts.append(f"{k}={v:.1f}")
+            if sig_parts:
+                lines.append(f"    Signals: {', '.join(sig_parts)}")
+
+    if non_flaky:
+        lines.append(f"\n{'─' * 60}")
+        lines.append("NON-FLAKY JOBS (likely deterministic failures)")
+        lines.append(f"{'─' * 60}")
+        for r in non_flaky:
+            cats = ", ".join(
+                f"{k}({v})" for k, v in sorted(
+                    r["categories"].items(),
+                    key=lambda x: x[1],
+                    reverse=True,
+                )
+            )
+            lines.append(
+                f"  {r['job_name']}: "
+                f"score={r['flake_score']:.0%}, "
+                f"failures={r['total_failures']}, "
+                f"cats=[{cats}]"
+            )
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect flaky CI tests from classified failure records.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", ci_log_retriever.DEFAULT_REPO),
+        help="GitHub repository",
+    )
+    parser.add_argument(
+        "--branch",
+        default="main",
+        help="Branch to analyze (default: main)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Number of failed runs to analyze (default: 50)",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read classified records from stdin (JSON)",
+    )
+    parser.add_argument(
+        "--no-download",
+        action="store_true",
+        help="Skip log download (classify from metadata only)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=FLAKE_THRESHOLD,
+        help=f"Flake score threshold (default: {FLAKE_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        if args.stdin:
+            records = json.load(sys.stdin)
+            if isinstance(records, dict):
+                records = [records]
+        else:
+            # Full pipeline: collect → retrieve → classify.
+            raw_runs = ci_run_collector.collect_failed_runs(
+                repo=args.repo,
+                branch=args.branch,
+                limit=args.limit,
+                token=token,
+            )
+            records = []
+            for run_data in raw_runs:
+                failure_records = ci_log_retriever.build_failure_records(
+                    run_data,
+                    repo=args.repo,
+                    token=token,
+                    download_logs=not args.no_download,
+                )
+                for fr in failure_records:
+                    classified = ci_failure_classifier.classify_failure_record(fr)
+                    records.append(classified)
+
+        reports = analyze_flakes(records, threshold=args.threshold)
+
+        if args.json_output:
+            json.dump(reports, sys.stdout, indent=2)
+            print()
+        else:
+            if not reports:
+                print("No failure records to analyze.")
+            else:
+                print(format_flake_report(reports))
+
+    except ci_run_collector.GitHubAPIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except (json.JSONDecodeError, KeyError) as e:
+        print(f"Error: Invalid input data: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_flake_detector_test.py
+++ b/hack/ci/ci_flake_detector_test.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_flake_detector.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_flake_detector_test.py -v
+    python3 hack/ci/ci_flake_detector_test.py
+"""
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_flake_detector
+
+
+# --- Test fixtures ---
+
+def _make_record(
+    job_name="test-job",
+    commit_sha="abc123",
+    created_at="2026-08-01T10:00:00Z",
+    category="test_assertion_failure",
+    run_id=1,
+    run_number=1,
+    run_attempt=1,
+    evidence="",
+):
+    """Create a minimal classified failure record for testing."""
+    return {
+        "run_id": run_id,
+        "run_number": run_number,
+        "run_attempt": run_attempt,
+        "workflow": "ci",
+        "job_name": job_name,
+        "job_id": 90000 + run_id,
+        "step_name": "Run test",
+        "branch": "main",
+        "commit_sha": commit_sha,
+        "commit_message": f"commit {commit_sha}",
+        "event": "push",
+        "created_at": created_at,
+        "html_url": f"https://example.com/run/{run_id}",
+        "failure_sections": [],
+        "normalized_log_excerpt": "",
+        "raw_log_bytes": 0,
+        "classification": {
+            "category": category,
+            "category_description": "",
+            "confidence": 0.9,
+            "rule_name": "test",
+            "matched_text": "",
+            "evidence": evidence,
+            "all_matches_count": 1,
+        },
+    }
+
+
+# Scenario 1: Classic flake — same job fails on many different commits
+# and dates with infrastructure-correlated categories.
+FLAKY_JOB_RECORDS = [
+    _make_record(
+        job_name="sys local root fedora / lima",
+        commit_sha=f"commit_{i:040d}",
+        created_at=f"2026-08-{i+1:02d}T10:00:00Z",
+        category="network_error",
+        run_id=i,
+        run_number=100 + i,
+    )
+    for i in range(8)
+]
+
+# Scenario 2: Deterministic bug — same job fails on a single commit
+# with assertion failure.
+BUG_JOB_RECORDS = [
+    _make_record(
+        job_name="unit-test-fedora",
+        commit_sha="deadbeef" * 5,
+        created_at="2026-08-10T10:00:00Z",
+        category="test_assertion_failure",
+        run_id=100,
+        run_number=200,
+    ),
+]
+
+# Scenario 3: Retry-detected flake — run_attempt > 1.
+RETRY_FLAKE_RECORDS = [
+    _make_record(
+        job_name="int local rootless ubuntu / lima",
+        commit_sha=f"retry_{i:040d}",
+        created_at=f"2026-08-{i+1:02d}T12:00:00Z",
+        category="timeout",
+        run_id=200 + i,
+        run_number=300 + i,
+        run_attempt=2,
+    )
+    for i in range(5)
+]
+
+# Scenario 4: Mixed categories across multiple commits.
+MIXED_RECORDS = [
+    _make_record(
+        job_name="sys remote root fedora / lima",
+        commit_sha=f"mixed_{i:040d}",
+        created_at=f"2026-08-{i+1:02d}T14:00:00Z",
+        category=["network_error", "test_assertion_failure", "timeout",
+                  "infrastructure_failure", "image_pull_failure"][i % 5],
+        run_id=300 + i,
+        run_number=400 + i,
+    )
+    for i in range(10)
+]
+
+
+class TestExtractDate(unittest.TestCase):
+    """Tests for _extract_date."""
+
+    def test_iso_timestamp(self):
+        self.assertEqual(
+            ci_flake_detector._extract_date("2026-08-14T15:09:38Z"),
+            "2026-08-14",
+        )
+
+    def test_short_string(self):
+        self.assertEqual(ci_flake_detector._extract_date("2026"), "")
+
+    def test_empty_string(self):
+        self.assertEqual(ci_flake_detector._extract_date(""), "")
+
+
+class TestComputeFlakeSignals(unittest.TestCase):
+    """Tests for compute_flake_signals."""
+
+    def test_high_commit_diversity(self):
+        signals = ci_flake_detector.compute_flake_signals(FLAKY_JOB_RECORDS)
+        self.assertGreaterEqual(signals.commit_diversity, 0.7)
+
+    def test_low_commit_diversity_single_commit(self):
+        signals = ci_flake_detector.compute_flake_signals(BUG_JOB_RECORDS)
+        self.assertEqual(signals.commit_diversity, 0.0)
+
+    def test_category_correlation_network(self):
+        signals = ci_flake_detector.compute_flake_signals(FLAKY_JOB_RECORDS)
+        self.assertGreater(signals.category_flake_correlation, 0.5)
+
+    def test_category_correlation_assertion(self):
+        signals = ci_flake_detector.compute_flake_signals(BUG_JOB_RECORDS)
+        # Bug-correlated categories should push correlation down.
+        self.assertLess(signals.category_flake_correlation, 0.5)
+
+    def test_retry_signal(self):
+        signals = ci_flake_detector.compute_flake_signals(RETRY_FLAKE_RECORDS)
+        self.assertGreater(signals.retry_signal, 0.0)
+
+    def test_no_retry_signal(self):
+        signals = ci_flake_detector.compute_flake_signals(FLAKY_JOB_RECORDS)
+        self.assertEqual(signals.retry_signal, 0.0)
+
+    def test_temporal_spread_many_days(self):
+        signals = ci_flake_detector.compute_flake_signals(FLAKY_JOB_RECORDS)
+        self.assertGreaterEqual(signals.temporal_spread, 0.7)
+
+    def test_temporal_spread_single_day(self):
+        signals = ci_flake_detector.compute_flake_signals(BUG_JOB_RECORDS)
+        self.assertEqual(signals.temporal_spread, 0.0)
+
+    def test_empty_records(self):
+        signals = ci_flake_detector.compute_flake_signals([])
+        self.assertEqual(signals.commit_diversity, 0.0)
+        self.assertEqual(signals.failure_rate, 0.0)
+
+    def test_mixed_categories(self):
+        signals = ci_flake_detector.compute_flake_signals(MIXED_RECORDS)
+        # Should have moderate correlation (mix of flake and bug categories).
+        self.assertGreater(signals.category_flake_correlation, 0.0)
+
+
+class TestComputeFlakeScore(unittest.TestCase):
+    """Tests for compute_flake_score."""
+
+    def test_high_score_for_flaky_signals(self):
+        signals = ci_flake_detector.FlakeSignals(
+            commit_diversity=1.0,
+            failure_rate=0.8,
+            category_flake_correlation=0.9,
+            retry_signal=0.5,
+            temporal_spread=1.0,
+        )
+        score = ci_flake_detector.compute_flake_score(signals)
+        self.assertGreater(score, 0.7)
+
+    def test_low_score_for_bug_signals(self):
+        signals = ci_flake_detector.FlakeSignals(
+            commit_diversity=0.0,
+            failure_rate=0.1,
+            category_flake_correlation=0.0,
+            retry_signal=0.0,
+            temporal_spread=0.0,
+        )
+        score = ci_flake_detector.compute_flake_score(signals)
+        self.assertLess(score, 0.1)
+
+    def test_score_bounded_0_1(self):
+        signals = ci_flake_detector.FlakeSignals(
+            commit_diversity=2.0,
+            failure_rate=2.0,
+            category_flake_correlation=2.0,
+            retry_signal=2.0,
+            temporal_spread=2.0,
+        )
+        score = ci_flake_detector.compute_flake_score(signals)
+        self.assertLessEqual(score, 1.0)
+        self.assertGreaterEqual(score, 0.0)
+
+    def test_zero_signals_zero_score(self):
+        signals = ci_flake_detector.FlakeSignals()
+        score = ci_flake_detector.compute_flake_score(signals)
+        self.assertEqual(score, 0.0)
+
+
+class TestAnalyzeFlakes(unittest.TestCase):
+    """Tests for analyze_flakes."""
+
+    def test_identifies_flaky_job(self):
+        reports = ci_flake_detector.analyze_flakes(FLAKY_JOB_RECORDS)
+        self.assertEqual(len(reports), 1)
+        self.assertTrue(reports[0]["is_flaky"])
+        self.assertGreater(reports[0]["flake_score"], 0.45)
+
+    def test_identifies_non_flaky_bug(self):
+        reports = ci_flake_detector.analyze_flakes(BUG_JOB_RECORDS)
+        self.assertEqual(len(reports), 1)
+        self.assertFalse(reports[0]["is_flaky"])
+
+    def test_groups_by_job_name(self):
+        all_records = FLAKY_JOB_RECORDS + BUG_JOB_RECORDS
+        reports = ci_flake_detector.analyze_flakes(all_records)
+        self.assertEqual(len(reports), 2)
+        job_names = {r["job_name"] for r in reports}
+        self.assertIn("sys local root fedora / lima", job_names)
+        self.assertIn("unit-test-fedora", job_names)
+
+    def test_sorted_by_flake_score(self):
+        all_records = FLAKY_JOB_RECORDS + BUG_JOB_RECORDS + RETRY_FLAKE_RECORDS
+        reports = ci_flake_detector.analyze_flakes(all_records)
+        scores = [r["flake_score"] for r in reports]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_includes_sample_failures(self):
+        reports = ci_flake_detector.analyze_flakes(FLAKY_JOB_RECORDS)
+        self.assertGreater(len(reports[0]["sample_failures"]), 0)
+        self.assertLessEqual(len(reports[0]["sample_failures"]), 3)
+
+    def test_includes_categories(self):
+        reports = ci_flake_detector.analyze_flakes(FLAKY_JOB_RECORDS)
+        self.assertIn("network_error", reports[0]["categories"])
+
+    def test_tracks_unique_commits(self):
+        reports = ci_flake_detector.analyze_flakes(FLAKY_JOB_RECORDS)
+        self.assertEqual(reports[0]["unique_commits"], 8)
+
+    def test_tracks_unique_dates(self):
+        reports = ci_flake_detector.analyze_flakes(FLAKY_JOB_RECORDS)
+        self.assertEqual(reports[0]["unique_dates"], 8)
+
+    def test_retry_records_detected_as_flaky(self):
+        reports = ci_flake_detector.analyze_flakes(RETRY_FLAKE_RECORDS)
+        self.assertEqual(len(reports), 1)
+        self.assertTrue(reports[0]["is_flaky"])
+
+    def test_empty_records(self):
+        reports = ci_flake_detector.analyze_flakes([])
+        self.assertEqual(len(reports), 0)
+
+    def test_custom_threshold(self):
+        # With a very high threshold, nothing should be flaky.
+        reports = ci_flake_detector.analyze_flakes(
+            FLAKY_JOB_RECORDS, threshold=0.99
+        )
+        self.assertFalse(reports[0]["is_flaky"])
+
+    def test_report_has_signals(self):
+        reports = ci_flake_detector.analyze_flakes(FLAKY_JOB_RECORDS)
+        signals = reports[0]["signals"]
+        self.assertIn("commit_diversity", signals)
+        self.assertIn("category_flake_correlation", signals)
+        self.assertIn("temporal_spread", signals)
+
+
+class TestFormatFlakeReport(unittest.TestCase):
+    """Tests for format_flake_report."""
+
+    def test_format_with_flaky_and_non_flaky(self):
+        all_records = FLAKY_JOB_RECORDS + BUG_JOB_RECORDS
+        reports = ci_flake_detector.analyze_flakes(all_records)
+        output = ci_flake_detector.format_flake_report(reports)
+        self.assertIn("Flake Analysis Report", output)
+        self.assertIn("FLAKY JOBS", output)
+        self.assertIn("NON-FLAKY JOBS", output)
+        self.assertIn("sys local root fedora / lima", output)
+
+    def test_format_no_flaky_jobs(self):
+        reports = ci_flake_detector.analyze_flakes(BUG_JOB_RECORDS)
+        output = ci_flake_detector.format_flake_report(reports)
+        self.assertIn("Flaky: 0", output)
+        # The "FLAKY JOBS (likely intermittent" header should not appear.
+        self.assertNotIn("FLAKY JOBS (likely intermittent", output)
+
+    def test_format_empty(self):
+        output = ci_flake_detector.format_flake_report([])
+        self.assertIn("0", output)
+
+
+class TestFlakeCorrelatedCategories(unittest.TestCase):
+    """Ensure category sets are consistent."""
+
+    def test_no_overlap_between_flake_and_bug(self):
+        overlap = (
+            ci_flake_detector.FLAKE_CORRELATED_CATEGORIES
+            & ci_flake_detector.BUG_CORRELATED_CATEGORIES
+        )
+        self.assertEqual(
+            len(overlap),
+            0,
+            f"Categories overlap: {overlap}",
+        )
+
+    def test_categories_exist_in_classifier(self):
+        import ci_failure_classifier
+
+        all_categories = set(ci_failure_classifier.CATEGORIES.keys())
+        for cat in ci_flake_detector.FLAKE_CORRELATED_CATEGORIES:
+            self.assertIn(
+                cat, all_categories,
+                f"Flake category '{cat}' not defined in classifier",
+            )
+        for cat in ci_flake_detector.BUG_CORRELATED_CATEGORIES:
+            self.assertIn(
+                cat, all_categories,
+                f"Bug category '{cat}' not defined in classifier",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hack/ci/ci_flake_suite_test.py
+++ b/hack/ci/ci_flake_suite_test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+ci_flake_suite_test - Unified test runner for all CI failure & flake analysis modules.
+
+Discovers and executes all unit test suites in hack/ci/ related to the CI flake
+categorization, retrieval, classification, detection, agentic analysis, and reporting suite.
+
+Usage:
+    python3 hack/ci/ci_flake_suite_test.py
+    python3 hack/ci/ci_flake_suite_test.py -v
+"""
+
+import os
+import sys
+import unittest
+
+# Ensure hack/ci is in search path
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+# Import all module test suites
+import ci_run_collector_test
+import ci_log_retriever_test
+import ci_failure_classifier_test
+import ci_flake_detector_test
+import ci_agentic_analyzer_test
+import ci_reporter_test
+
+
+def suite() -> unittest.TestSuite:
+    """Build the consolidated test suite."""
+    loader = unittest.TestLoader()
+    test_suite = unittest.TestSuite()
+
+    modules = [
+        ci_run_collector_test,
+        ci_log_retriever_test,
+        ci_failure_classifier_test,
+        ci_flake_detector_test,
+        ci_agentic_analyzer_test,
+        ci_reporter_test,
+    ]
+
+    for mod in modules:
+        test_suite.addTests(loader.loadTestsFromModule(mod))
+
+    return test_suite
+
+
+def main():
+    verbosity = 2 if "-v" in sys.argv or "--verbose" in sys.argv else 1
+    runner = unittest.TextTestRunner(verbosity=verbosity)
+    result = runner.run(suite())
+    sys.exit(0 if result.wasSuccessful() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_log_retriever.py
+++ b/hack/ci/ci_log_retriever.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+ci_log_retriever - Retrieve and normalize CI failure logs from GitHub Actions.
+
+Downloads raw job logs via the GitHub Actions API, strips noise
+(ANSI escapes, timestamps, GitHub Actions markup), extracts
+failure-relevant sections, and produces structured failure records
+suitable for downstream classification and flake detection.
+
+Usage:
+    # Retrieve logs for failed jobs from a specific run
+    ./hack/ci/ci_log_retriever.py --run-id 31813098642
+
+    # Pipe from ci_run_collector for batch processing
+    ./hack/ci/ci_run_collector.py --branch main --status failure --limit 5 --json | \
+        ./hack/ci/ci_log_retriever.py --stdin
+
+Environment:
+    GITHUB_TOKEN       Required for log downloads (API returns 302 redirects).
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+"""
+
+import argparse
+import io
+import json
+import os
+import re
+import sys
+import zipfile
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+# Import the API layer from PR 1.
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import ci_run_collector
+
+# Default repository.
+DEFAULT_REPO = "podman-container-tools/podman"
+# Maximum bytes of raw log to process per job (10 MB).
+MAX_LOG_BYTES = 10 * 1024 * 1024
+# Maximum bytes of extracted failure context to keep per record.
+MAX_FAILURE_EXCERPT_BYTES = 64 * 1024
+
+
+# --- ANSI / GHA noise stripping ---
+
+# ANSI escape sequences (colors, cursor movement, etc.).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?\x07")
+# GitHub Actions timestamp prefix: "2024-08-14T15:12:34.1234567Z "
+_GHA_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s?")
+# GitHub Actions group markers.
+_GHA_GROUP_RE = re.compile(r"^##\[(?:group|endgroup|command|error|warning|notice)\]")
+# Logformatter timestamp: "[+NNNs] "
+_LOGFORMATTER_TS_RE = re.compile(r"^\[\+\d+s\]\s?")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text."""
+    return _ANSI_RE.sub("", text)
+
+
+def strip_gha_timestamps(text: str) -> str:
+    """Remove GitHub Actions timestamp prefixes from each line."""
+    return "\n".join(
+        _GHA_TIMESTAMP_RE.sub("", line) for line in text.split("\n")
+    )
+
+
+def strip_gha_markup(text: str) -> str:
+    """Remove GitHub Actions workflow command markup (##[group], etc.)."""
+    return "\n".join(
+        line for line in text.split("\n") if not _GHA_GROUP_RE.match(line)
+    )
+
+
+def strip_logformatter_timestamps(text: str) -> str:
+    """Remove logformatter [+NNNs] timestamp prefixes."""
+    return "\n".join(
+        _LOGFORMATTER_TS_RE.sub("", line) for line in text.split("\n")
+    )
+
+
+# --- Secret redaction ---
+
+def _redact_hex_token(match: re.Match) -> str:
+    """
+    Selectively redact long hex strings that look like tokens.
+
+    Preserves git commit SHAs (exactly 40 hex chars in git context)
+    and container image digests. Only redacts if the pattern is
+    unlikely to be a legitimate identifier.
+    """
+    value = match.group(0)
+    # Preserve 40-char strings that look like git SHAs.
+    if len(value) == 40:
+        return value
+    # Preserve sha256 digest prefixes (64 chars).
+    if len(value) == 64:
+        return value
+    # Redact everything else.
+    return f"[REDACTED_TOKEN_{len(value)}chars]"
+
+
+# Common secret patterns to redact from logs before analysis.
+_SECRET_PATTERNS = [
+    # GitHub tokens (classic and fine-grained).
+    (re.compile(r"ghp_[A-Za-z0-9]{36,}"), "[REDACTED_GH_TOKEN]"),
+    (re.compile(r"ghs_[A-Za-z0-9]{36,}"), "[REDACTED_GH_TOKEN]"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{80,}"), "[REDACTED_GH_TOKEN]"),
+    # Bearer/Basic auth headers.
+    (re.compile(r"(?i)(Bearer|Basic)\s+[A-Za-z0-9+/=_-]{20,}"), "[REDACTED_AUTH]"),
+    # URLs with embedded credentials.
+    (re.compile(r"https?://[^@\s]+:[^@\s]+@"), "https://[REDACTED]@"),
+    # AWS-style keys.
+    (re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}"), "[REDACTED_AWS_KEY]"),
+    # Generic long hex tokens (40+ chars, like SHA tokens).
+    (re.compile(r"(?<![a-fA-F0-9])[a-fA-F0-9]{40,}(?![a-fA-F0-9])"), _redact_hex_token),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Redact potential secrets and credentials from log text."""
+    for pattern, replacement in _SECRET_PATTERNS:
+        if callable(replacement):
+            text = pattern.sub(replacement, text)
+        else:
+            text = pattern.sub(replacement, text)
+    return text
+
+
+# --- Log normalization pipeline ---
+
+def normalize_log(raw_log: str) -> str:
+    """
+    Apply the full normalization pipeline to raw log content.
+
+    Order matters: strip ANSI first (it can interfere with other
+    patterns), then timestamps, then markup, then redact secrets.
+    """
+    text = strip_ansi(raw_log)
+    text = strip_gha_timestamps(text)
+    text = strip_gha_markup(text)
+    text = strip_logformatter_timestamps(text)
+    text = redact_secrets(text)
+    # Collapse excessive blank lines.
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+    return text
+
+
+# --- Failure section extraction ---
+
+# Ginkgo failure block markers.
+_GINKGO_FAIL_START_RE = re.compile(
+    r"^(?:\[FAIL\]|Failure \[|•! Failure|FAIL!)"
+    r"|^Unexpected error:|^Expected\s",
+    re.MULTILINE,
+)
+_GINKGO_DIVIDER_RE = re.compile(r"^-{5,}$", re.MULTILINE)
+# BATS failure markers.
+_BATS_FAIL_RE = re.compile(r"^not ok\s+\d+", re.MULTILINE)
+# Generic panic/fatal markers.
+_PANIC_RE = re.compile(r"^(?:panic:|fatal error:|SIGSEGV|goroutine \d+)", re.MULTILINE)
+# Ginkgo summary line with failure count.
+_GINKGO_SUMMARY_RE = re.compile(
+    r"^(?:FAIL!|SUCCESS!)\s+--\s+.*\d+\s+Passed", re.MULTILINE
+)
+
+
+def extract_failure_sections(log_text: str) -> list:
+    """
+    Extract failure-relevant sections from normalized log text.
+
+    Returns a list of (section_type, text) tuples.
+    Attempts to extract meaningful context around each failure
+    rather than returning the entire (potentially huge) log.
+    """
+    sections = []
+    lines = log_text.split("\n")
+
+    # Strategy: scan for failure markers, then capture context window.
+    for i, line in enumerate(lines):
+        section_type = None
+
+        if _GINKGO_FAIL_START_RE.search(line):
+            section_type = "ginkgo_failure"
+        elif _BATS_FAIL_RE.search(line):
+            section_type = "bats_failure"
+        elif _PANIC_RE.search(line):
+            section_type = "panic"
+        elif _GINKGO_SUMMARY_RE.search(line):
+            section_type = "ginkgo_summary"
+
+        if section_type:
+            # Capture context: 5 lines before, the match, and 30 lines after.
+            start = max(0, i - 5)
+            end = min(len(lines), i + 31)
+            context = "\n".join(lines[start:end])
+
+            # Avoid duplicate captures: skip if this overlaps with
+            # the previous section.
+            if sections and sections[-1][2] >= start:
+                # Extend the previous section instead.
+                prev_type, prev_text, prev_end = sections[-1]
+                if end > prev_end:
+                    extended = "\n".join(lines[prev_end:end])
+                    sections[-1] = (
+                        prev_type,
+                        prev_text + "\n" + extended,
+                        end,
+                    )
+                continue
+
+            sections.append((section_type, context, end))
+
+    # Strip internal end-index tracking before returning.
+    return [(t, text) for t, text, _ in sections]
+
+
+# --- Structured failure record ---
+
+@dataclass
+class FailureRecord:
+    """A structured record of a single CI failure."""
+
+    run_id: int
+    run_number: int
+    workflow: str
+    job_name: str
+    job_id: int
+    step_name: str
+    branch: str
+    commit_sha: str
+    commit_message: str
+    event: str
+    created_at: str
+    html_url: str
+    failure_sections: list = field(default_factory=list)
+    normalized_log_excerpt: str = ""
+    raw_log_bytes: int = 0
+
+
+# --- Log retrieval from GitHub Actions API ---
+
+def download_job_log(
+    repo: str, job_id: int, token: Optional[str] = None
+) -> Optional[str]:
+    """
+    Download the raw log for a specific job via the GitHub Actions API.
+
+    The API returns a 302 redirect to a time-limited URL for a zip
+    file containing the log. We follow the redirect and extract the
+    text content.
+
+    Returns the log as a string, or None if retrieval fails.
+    """
+    import urllib.request
+    import urllib.error
+
+    url = f"{ci_run_collector.API_BASE}/repos/{repo}/actions/jobs/{job_id}/logs"
+    headers = ci_run_collector._build_headers(token)
+
+    try:
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            content_type = resp.headers.get("Content-Type", "")
+            raw_bytes = resp.read(MAX_LOG_BYTES)
+
+            # The API may return a zip file or plain text depending
+            # on the redirect target.
+            if content_type == "application/zip" or raw_bytes[:4] == b"PK\x03\x04":
+                return _extract_zip_log(raw_bytes)
+            return raw_bytes.decode("utf-8", errors="replace")
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+        print(
+            f"Warning: Failed to download log for job {job_id}: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _extract_zip_log(zip_bytes: bytes) -> str:
+    """Extract text content from a zip file containing log data."""
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            # Concatenate all text files in the zip.
+            parts = []
+            for name in sorted(zf.namelist()):
+                try:
+                    content = zf.read(name).decode("utf-8", errors="replace")
+                    parts.append(f"=== {name} ===\n{content}")
+                except Exception:
+                    continue
+            return "\n".join(parts)
+    except zipfile.BadZipFile:
+        return zip_bytes.decode("utf-8", errors="replace")
+
+
+def build_failure_records(
+    run_data: dict,
+    repo: str = DEFAULT_REPO,
+    token: Optional[str] = None,
+    download_logs: bool = True,
+) -> list:
+    """
+    Build structured failure records from a single run's data.
+
+    Takes a run dict (as output by ci_run_collector) and produces
+    a list of FailureRecord dicts, one per failed job.
+    """
+    records = []
+    failed_jobs = [
+        j for j in run_data.get("jobs", []) if j.get("conclusion") == "failure"
+    ]
+
+    for job in failed_jobs:
+        failed_steps = job.get("failed_steps", [])
+        step_name = failed_steps[0]["name"] if failed_steps else "unknown"
+
+        record = FailureRecord(
+            run_id=run_data["run_id"],
+            run_number=run_data.get("run_number", 0),
+            workflow=run_data.get("workflow", ""),
+            job_name=job["name"],
+            job_id=job["job_id"],
+            step_name=step_name,
+            branch=run_data.get("branch", ""),
+            commit_sha=run_data.get("commit_sha", ""),
+            commit_message=run_data.get("commit_message", "").split("\n")[0],
+            event=run_data.get("event", ""),
+            created_at=run_data.get("created_at", ""),
+            html_url=job.get("html_url", ""),
+        )
+
+        if download_logs:
+            raw_log = download_job_log(repo, job["job_id"], token)
+            if raw_log:
+                record.raw_log_bytes = len(raw_log.encode("utf-8"))
+                normalized = normalize_log(raw_log)
+                # Extract failure sections.
+                sections = extract_failure_sections(normalized)
+                record.failure_sections = [
+                    {"type": t, "text": text[:MAX_FAILURE_EXCERPT_BYTES]}
+                    for t, text in sections
+                ]
+                # Keep a bounded excerpt of the full normalized log.
+                record.normalized_log_excerpt = normalized[
+                    :MAX_FAILURE_EXCERPT_BYTES
+                ]
+
+        records.append(asdict(record))
+
+    return records
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Retrieve and normalize CI failure logs.",
+        epilog="Requires GITHUB_TOKEN for log downloads.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=int,
+        help="Retrieve logs for a specific run ID",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read run data from stdin (JSON from ci_run_collector.py --json)",
+    )
+    parser.add_argument(
+        "--no-download",
+        action="store_true",
+        help="Skip log download (produce records from metadata only)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON (default)",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        if args.stdin:
+            run_data_list = json.load(sys.stdin)
+            if isinstance(run_data_list, dict):
+                run_data_list = [run_data_list]
+        elif args.run_id:
+            run_data = ci_run_collector.collect_single_run(
+                args.repo, args.run_id, token
+            )
+            run_data_list = [run_data]
+        else:
+            parser.error("Specify --run-id or --stdin")
+            return
+
+        all_records = []
+        for run_data in run_data_list:
+            records = build_failure_records(
+                run_data,
+                repo=args.repo,
+                token=token,
+                download_logs=not args.no_download,
+            )
+            all_records.extend(records)
+
+        json.dump(all_records, sys.stdout, indent=2)
+        print()
+
+    except ci_run_collector.RateLimitError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+    except ci_run_collector.GitHubAPIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except (json.JSONDecodeError, KeyError) as e:
+        print(f"Error: Invalid input data: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_log_retriever_test.py
+++ b/hack/ci/ci_log_retriever_test.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_log_retriever.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_log_retriever_test.py -v
+    python3 hack/ci/ci_log_retriever_test.py
+"""
+
+import io
+import json
+import os
+import sys
+import unittest
+import zipfile
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_log_retriever
+
+
+# --- Test fixtures: sample log content ---
+
+SAMPLE_RAW_LOG_GINKGO = """\
+2026-08-14T15:12:34.1234567Z ##[group]Run test on lima
+2026-08-14T15:12:34.2345678Z ./hack/ci/ci.sh sys local root fedora-current
+2026-08-14T15:12:34.3456789Z ##[endgroup]
+2026-08-14T15:12:35.0000000Z \x1b[1m\x1b[32mRunner executing test as root user\x1b[0m
+2026-08-14T15:12:36.0000000Z [+12s] Running integration test suite
+2026-08-14T15:12:40.0000000Z [+16s] Podman run with --rm
+2026-08-14T15:12:40.1000000Z [+16s]     Expected container to be removed
+2026-08-14T15:12:41.0000000Z [+17s] -----
+2026-08-14T15:12:42.0000000Z [+18s] [FAIL] Podman run with volume
+2026-08-14T15:12:43.0000000Z [+19s] Expected
+2026-08-14T15:12:44.0000000Z [+20s]     <string>: /tmp/testdir
+2026-08-14T15:12:45.0000000Z [+21s] to equal
+2026-08-14T15:12:46.0000000Z [+22s]     <string>: /tmp/expected
+2026-08-14T15:12:47.0000000Z [+23s] -----
+2026-08-14T15:12:50.0000000Z [+26s] FAIL! -- 45 Passed | 1 Failed | 0 Pending | 3 Skipped
+"""
+
+SAMPLE_RAW_LOG_BATS = """\
+2026-08-14T16:00:00.0000000Z [+1s] 1..50
+2026-08-14T16:00:01.0000000Z [+2s] ok 1 podman ps
+2026-08-14T16:00:02.0000000Z [+3s] ok 2 podman images
+2026-08-14T16:00:03.0000000Z [+4s] not ok 3 podman run with networking
+2026-08-14T16:00:04.0000000Z [+5s] # (in test file test/system/500-networking.bats, line 42)
+2026-08-14T16:00:05.0000000Z [+6s] #   `run_podman run --rm --net=host alpine wget -qO- http://localhost:8080' failed
+2026-08-14T16:00:06.0000000Z [+7s] #   expected: 0
+2026-08-14T16:00:07.0000000Z [+8s] #   actual:   7
+2026-08-14T16:00:08.0000000Z [+9s] ok 4 podman stop
+"""
+
+SAMPLE_RAW_LOG_PANIC = """\
+2026-08-14T17:00:00.0000000Z some normal output
+2026-08-14T17:00:01.0000000Z panic: runtime error: invalid memory address or nil pointer dereference
+2026-08-14T17:00:02.0000000Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1234]
+2026-08-14T17:00:03.0000000Z
+2026-08-14T17:00:04.0000000Z goroutine 1 [running]:
+2026-08-14T17:00:05.0000000Z main.(*Runtime).Start(0x0, 0xc000123456)
+2026-08-14T17:00:06.0000000Z     /go/src/podman/libpod/runtime.go:123 +0x45
+"""
+
+SAMPLE_LOG_WITH_SECRETS = """\
+Authenticating with token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklm
+Pulling from https://user:p4ssw0rd@registry.example.com/image
+Using key AKIAIOSFODNN7EXAMPLE to access bucket
+Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc123.xyz
+"""
+
+SAMPLE_RUN_DATA = {
+    "run_id": 31813098642,
+    "run_number": 1503,
+    "workflow": "ci",
+    "branch": "main",
+    "commit_sha": "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8",
+    "commit_message": "Merge pull request #29279\n\nlibpod: fix prune race",
+    "event": "push",
+    "created_at": "2026-08-14T15:09:38Z",
+    "jobs": [
+        {
+            "job_id": 90001,
+            "name": "validate-source",
+            "conclusion": "success",
+            "html_url": "https://example.com/job/90001",
+            "failed_steps": [],
+        },
+        {
+            "job_id": 90002,
+            "name": "sys local root fedora-current / lima",
+            "conclusion": "failure",
+            "html_url": "https://example.com/job/90002",
+            "failed_steps": [
+                {"name": "Run test on lima", "number": 4, "conclusion": "failure"},
+            ],
+        },
+    ],
+}
+
+
+class TestStripAnsi(unittest.TestCase):
+    """Tests for ANSI escape code stripping."""
+
+    def test_removes_color_codes(self):
+        text = "\x1b[1m\x1b[32mGreen bold\x1b[0m normal"
+        self.assertEqual(ci_log_retriever.strip_ansi(text), "Green bold normal")
+
+    def test_removes_osc_sequences(self):
+        text = "before\x1b]0;title\x07after"
+        self.assertEqual(ci_log_retriever.strip_ansi(text), "beforeafter")
+
+    def test_preserves_plain_text(self):
+        text = "No escapes here"
+        self.assertEqual(ci_log_retriever.strip_ansi(text), text)
+
+    def test_empty_string(self):
+        self.assertEqual(ci_log_retriever.strip_ansi(""), "")
+
+
+class TestStripGhaTimestamps(unittest.TestCase):
+    """Tests for GitHub Actions timestamp removal."""
+
+    def test_removes_timestamps(self):
+        text = "2026-08-14T15:12:34.1234567Z Hello world"
+        self.assertEqual(
+            ci_log_retriever.strip_gha_timestamps(text), "Hello world"
+        )
+
+    def test_multiline(self):
+        text = (
+            "2026-08-14T15:12:34.1234567Z line 1\n"
+            "2026-08-14T15:12:35.0000000Z line 2\n"
+            "no timestamp line 3"
+        )
+        result = ci_log_retriever.strip_gha_timestamps(text)
+        self.assertEqual(result, "line 1\nline 2\nno timestamp line 3")
+
+    def test_preserves_non_timestamp_lines(self):
+        text = "Just a normal line"
+        self.assertEqual(ci_log_retriever.strip_gha_timestamps(text), text)
+
+
+class TestStripGhaMarkup(unittest.TestCase):
+    """Tests for GitHub Actions markup removal."""
+
+    def test_removes_group_markers(self):
+        text = "##[group]Test Setup\nactual output\n##[endgroup]"
+        result = ci_log_retriever.strip_gha_markup(text)
+        self.assertEqual(result, "actual output")
+
+    def test_removes_error_notices(self):
+        text = "##[error]Something failed\nDetails here"
+        result = ci_log_retriever.strip_gha_markup(text)
+        self.assertEqual(result, "Details here")
+
+    def test_preserves_normal_hashes(self):
+        text = "## This is markdown\n### Not GHA markup"
+        self.assertEqual(ci_log_retriever.strip_gha_markup(text), text)
+
+
+class TestStripLogformatterTimestamps(unittest.TestCase):
+    """Tests for logformatter [+NNNs] timestamp removal."""
+
+    def test_removes_timestamps(self):
+        text = "[+12s] Running test\n[+100s] Done"
+        result = ci_log_retriever.strip_logformatter_timestamps(text)
+        self.assertEqual(result, "Running test\nDone")
+
+    def test_preserves_non_timestamp_brackets(self):
+        text = "[FAIL] test failed"
+        result = ci_log_retriever.strip_logformatter_timestamps(text)
+        self.assertEqual(result, text)
+
+
+class TestRedactSecrets(unittest.TestCase):
+    """Tests for secret redaction."""
+
+    def test_redacts_github_token(self):
+        text = "token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklm"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertNotIn("ghp_", result)
+        self.assertIn("[REDACTED_GH_TOKEN]", result)
+
+    def test_redacts_url_credentials(self):
+        text = "pulling https://user:pass@registry.com/image"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertNotIn("user:pass", result)
+        self.assertIn("[REDACTED]", result)
+
+    def test_redacts_bearer_token(self):
+        text = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abc"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertNotIn("eyJhbG", result)
+        self.assertIn("[REDACTED_AUTH]", result)
+
+    def test_redacts_aws_keys(self):
+        text = "key: AKIAIOSFODNN7EXAMPLE"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", result)
+        self.assertIn("[REDACTED_AWS_KEY]", result)
+
+    def test_preserves_git_shas(self):
+        """40-char hex strings that look like git SHAs should be preserved."""
+        sha = "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8"
+        text = f"commit {sha}"
+        result = ci_log_retriever.redact_secrets(text)
+        self.assertIn(sha, result)
+
+    def test_preserves_normal_text(self):
+        text = "No secrets here, just normal CI output."
+        self.assertEqual(ci_log_retriever.redact_secrets(text), text)
+
+
+class TestNormalizeLog(unittest.TestCase):
+    """Tests for the full normalization pipeline."""
+
+    def test_ginkgo_log_normalization(self):
+        result = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_GINKGO)
+        # ANSI codes should be gone.
+        self.assertNotIn("\x1b[", result)
+        # GHA timestamps should be gone.
+        self.assertNotIn("2026-08-14T15:12", result)
+        # GHA markup should be gone.
+        self.assertNotIn("##[group]", result)
+        # Logformatter timestamps should be gone.
+        self.assertNotIn("[+12s]", result)
+        # Actual content should remain.
+        self.assertIn("[FAIL] Podman run with volume", result)
+        self.assertIn("FAIL!", result)
+
+    def test_bats_log_normalization(self):
+        result = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_BATS)
+        self.assertIn("not ok 3 podman run with networking", result)
+        self.assertNotIn("2026-08-14T16:00", result)
+
+    def test_collapses_excessive_blank_lines(self):
+        text = "line1\n\n\n\n\n\n\nline2"
+        result = ci_log_retriever.normalize_log(text)
+        self.assertEqual(result.count("\n\n\n\n"), 0)
+        self.assertIn("line1", result)
+        self.assertIn("line2", result)
+
+
+class TestExtractFailureSections(unittest.TestCase):
+    """Tests for failure section extraction."""
+
+    def test_extracts_ginkgo_failure(self):
+        normalized = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_GINKGO)
+        sections = ci_log_retriever.extract_failure_sections(normalized)
+        self.assertTrue(len(sections) > 0)
+        types = [t for t, _ in sections]
+        self.assertIn("ginkgo_failure", types)
+
+    def test_extracts_bats_failure(self):
+        normalized = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_BATS)
+        sections = ci_log_retriever.extract_failure_sections(normalized)
+        self.assertTrue(len(sections) > 0)
+        types = [t for t, _ in sections]
+        self.assertIn("bats_failure", types)
+
+    def test_extracts_panic(self):
+        normalized = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_PANIC)
+        sections = ci_log_retriever.extract_failure_sections(normalized)
+        self.assertTrue(len(sections) > 0)
+        types = [t for t, _ in sections]
+        self.assertIn("panic", types)
+
+    def test_extracts_ginkgo_summary(self):
+        normalized = ci_log_retriever.normalize_log(SAMPLE_RAW_LOG_GINKGO)
+        sections = ci_log_retriever.extract_failure_sections(normalized)
+        types = [t for t, _ in sections]
+        # Should find the FAIL! summary line.
+        self.assertTrue(
+            "ginkgo_summary" in types or "ginkgo_failure" in types,
+            f"Expected ginkgo_summary or ginkgo_failure in {types}",
+        )
+
+    def test_no_false_positives_on_clean_log(self):
+        clean_log = "All tests passed\nok 1 test\nok 2 test\nSUCCESS!"
+        sections = ci_log_retriever.extract_failure_sections(clean_log)
+        self.assertEqual(len(sections), 0)
+
+    def test_deduplicates_overlapping_sections(self):
+        """Adjacent failure markers should be merged, not duplicated."""
+        log = "[FAIL] test1\nExpected foo\nto equal bar\n[FAIL] test2\nExpected baz"
+        sections = ci_log_retriever.extract_failure_sections(log)
+        # All failure content should be captured, possibly merged.
+        all_text = "\n".join(text for _, text in sections)
+        self.assertIn("test1", all_text)
+        self.assertIn("test2", all_text)
+
+
+class TestExtractZipLog(unittest.TestCase):
+    """Tests for zip file extraction."""
+
+    def test_extracts_from_valid_zip(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("step_1.txt", "Step 1 output")
+            zf.writestr("step_2.txt", "Step 2 output")
+        result = ci_log_retriever._extract_zip_log(buf.getvalue())
+        self.assertIn("Step 1 output", result)
+        self.assertIn("Step 2 output", result)
+
+    def test_handles_invalid_zip(self):
+        result = ci_log_retriever._extract_zip_log(b"not a zip file")
+        self.assertIn("not a zip file", result)
+
+
+class TestBuildFailureRecords(unittest.TestCase):
+    """Tests for build_failure_records (no log download)."""
+
+    def test_creates_record_for_failed_job(self):
+        records = ci_log_retriever.build_failure_records(
+            SAMPLE_RUN_DATA, download_logs=False
+        )
+        self.assertEqual(len(records), 1)
+
+        rec = records[0]
+        self.assertEqual(rec["run_id"], 31813098642)
+        self.assertEqual(rec["job_name"], "sys local root fedora-current / lima")
+        self.assertEqual(rec["step_name"], "Run test on lima")
+        self.assertEqual(rec["branch"], "main")
+        self.assertEqual(rec["commit_message"], "Merge pull request #29279")
+
+    def test_skips_successful_jobs(self):
+        run_data = {
+            **SAMPLE_RUN_DATA,
+            "jobs": [SAMPLE_RUN_DATA["jobs"][0]],  # Only the passing job.
+        }
+        records = ci_log_retriever.build_failure_records(
+            run_data, download_logs=False
+        )
+        self.assertEqual(len(records), 0)
+
+    def test_handles_no_failed_steps(self):
+        """A failed job with no identified failed steps."""
+        job = {
+            "job_id": 99999,
+            "name": "cancelled-job",
+            "conclusion": "failure",
+            "html_url": "https://example.com",
+            "failed_steps": [],
+        }
+        run_data = {**SAMPLE_RUN_DATA, "jobs": [job]}
+        records = ci_log_retriever.build_failure_records(
+            run_data, download_logs=False
+        )
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["step_name"], "unknown")
+
+    @patch("ci_log_retriever.download_job_log")
+    def test_with_log_download(self, mock_download):
+        mock_download.return_value = SAMPLE_RAW_LOG_GINKGO
+        records = ci_log_retriever.build_failure_records(
+            SAMPLE_RUN_DATA, download_logs=True
+        )
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertGreater(rec["raw_log_bytes"], 0)
+        self.assertGreater(len(rec["normalized_log_excerpt"]), 0)
+        self.assertGreater(len(rec["failure_sections"]), 0)
+        # Verify failure sections have correct structure.
+        for section in rec["failure_sections"]:
+            self.assertIn("type", section)
+            self.assertIn("text", section)
+
+    @patch("ci_log_retriever.download_job_log")
+    def test_handles_log_download_failure(self, mock_download):
+        mock_download.return_value = None
+        records = ci_log_retriever.build_failure_records(
+            SAMPLE_RUN_DATA, download_logs=True
+        )
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["raw_log_bytes"], 0)
+        self.assertEqual(rec["normalized_log_excerpt"], "")
+        self.assertEqual(rec["failure_sections"], [])
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Integration tests for the full pipeline (without network)."""
+
+    @patch("ci_log_retriever.download_job_log")
+    def test_full_pipeline_ginkgo(self, mock_download):
+        mock_download.return_value = SAMPLE_RAW_LOG_GINKGO
+        records = ci_log_retriever.build_failure_records(SAMPLE_RUN_DATA)
+
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        # Metadata is correct.
+        self.assertEqual(rec["workflow"], "ci")
+        self.assertEqual(rec["branch"], "main")
+        # Log was normalized (no ANSI, no GHA timestamps).
+        self.assertNotIn("\x1b[", rec["normalized_log_excerpt"])
+        self.assertNotIn("2026-08-14T15:12", rec["normalized_log_excerpt"])
+        # Failure sections were extracted.
+        self.assertGreater(len(rec["failure_sections"]), 0)
+
+    @patch("ci_log_retriever.download_job_log")
+    def test_full_pipeline_with_secrets(self, mock_download):
+        mock_download.return_value = SAMPLE_LOG_WITH_SECRETS
+        records = ci_log_retriever.build_failure_records(SAMPLE_RUN_DATA)
+
+        rec = records[0]
+        excerpt = rec["normalized_log_excerpt"]
+        # Secrets should be redacted.
+        self.assertNotIn("ghp_", excerpt)
+        self.assertNotIn("p4ssw0rd", excerpt)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", excerpt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hack/ci/ci_reporter.py
+++ b/hack/ci/ci_reporter.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""
+ci_reporter - Generate reports and integrate CI failure analysis with GitHub.
+
+Formats failure classifications and flake analysis reports into:
+- GitHub Actions Step Summaries ($GITHUB_STEP_SUMMARY)
+- GitHub Issue bodies for tracking intermittent test flakes (with dedup)
+- GitHub PR triage comments
+- Periodic / weekly flake digests
+
+Usage:
+    # Generate GitHub step summary from classified records / flake reports
+    ./hack/ci/ci_flake_detector.py --branch main --limit 30 --json | \
+        ./hack/ci/ci_reporter.py --stdin --format step-summary
+
+    # Write step summary directly to GITHUB_STEP_SUMMARY environment file
+    ./hack/ci/ci_reporter.py --stdin --format step-summary --write-step-summary < analysis.json
+
+    # Generate issue body for a specific flake
+    ./hack/ci/ci_reporter.py --stdin --format issue-body < flake_report.json
+
+    # Post or dry-run PR comment
+    ./hack/ci/ci_reporter.py --stdin --format pr-comment --pr 29279 --dry-run < analysis.json
+
+Environment:
+    GITHUB_TOKEN       Required for creating issues or posting comments.
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+    GITHUB_STEP_SUMMARY Optional. Path to GitHub Actions step summary file.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import ci_failure_classifier
+import ci_flake_detector
+import ci_run_collector
+
+# Default repository.
+DEFAULT_REPO = "podman-container-tools/podman"
+# Marker tag embedded in issue bodies for reliable deduplication.
+FINGERPRINT_PREFIX = "<!-- ci-flake-fingerprint:"
+# Marker tag embedded in PR comments for updating existing bot comments.
+PR_COMMENT_MARKER = "<!-- podman-ci-failure-analysis -->"
+# Maximum new issues created in a single batch to prevent runaway spam.
+DEFAULT_MAX_ISSUES = 5
+# GitHub issue label for automated flake tracking.
+FLAKE_LABEL = "ci-flake"
+
+
+def compute_fingerprint(job_name: str, primary_category: str = "") -> str:
+    """
+    Generate a deterministic SHA-256 fingerprint for a job/category combination.
+    Used to deduplicate GitHub issues and comments across runs.
+    """
+    raw = f"{job_name.strip()}::{primary_category.strip()}".lower()
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def format_step_summary(
+    records: Optional[List[dict]] = None,
+    flake_reports: Optional[List[dict]] = None,
+) -> str:
+    """
+    Generate GitHub Actions Step Summary markdown.
+
+    Produces a clean, structured dashboard showing failure counts,
+    classification breakdown, flake alerts, and drill-down details.
+    """
+    records = records or []
+    flake_reports = flake_reports or []
+
+    lines = ["## 🧪 CI Failure & Flake Analysis Dashboard", ""]
+
+    if not records and not flake_reports:
+        lines.append("✅ No CI failures or flakes detected in the analyzed runs.")
+        return "\n".join(lines)
+
+    # --- Summary Metrics ---
+    total_failures = len(records)
+    flaky_jobs = [r for r in flake_reports if r.get("is_flaky")]
+    non_flaky_jobs = [r for r in flake_reports if not r.get("is_flaky")]
+
+    lines.append("| Metric | Count | Status |")
+    lines.append("| :--- | :--- | :--- |")
+    lines.append(f"| **Total Failed Jobs Analyzed** | `{total_failures}` | 🔍 |")
+    if flake_reports:
+        lines.append(f"| **Suspected Flaky Jobs** | `{len(flaky_jobs)}` | {'⚠️ High Attention' if flaky_jobs else '✅ None'} |")
+        lines.append(f"| **Deterministic / Genuine Failures** | `{len(non_flaky_jobs)}` | ℹ️ |")
+    lines.append("")
+
+    # --- Flake Alerts ---
+    if flaky_jobs:
+        lines.append("### ⚠️ Flaky Test Warnings")
+        lines.append("")
+        lines.append("> [!WARNING]")
+        lines.append("> The following jobs exhibit intermittent failure patterns across multiple commits or retries.")
+        lines.append("")
+        lines.append("| Job Name | Flake Score | Failures | Commits | Top Categories |")
+        lines.append("| :--- | :--- | :--- | :--- | :--- |")
+        for f in flaky_jobs:
+            score = f.get("flake_score", 0.0)
+            score_pct = f"{score:.0%}"
+            cats = ", ".join(f"`{k}` ({v})" for k, v in sorted(f.get("categories", {}).items(), key=lambda x: x[1], reverse=True)[:2])
+            lines.append(f"| **{f.get('job_name')}** | **`{score_pct}`** | {f.get('total_failures')} | {f.get('unique_commits')} | {cats or 'N/A'} |")
+        lines.append("")
+
+    # --- Category Breakdown ---
+    if records:
+        category_counts = {}
+        for r in records:
+            clf = r.get("classification", {})
+            cat = clf.get("category", "unknown")
+            category_counts[cat] = category_counts.get(cat, 0) + 1
+
+        lines.append("### 📊 Failure Classification Breakdown")
+        lines.append("")
+        lines.append("| Category | Description | Count | % of Failures |")
+        lines.append("| :--- | :--- | :--- | :--- |")
+        for cat, cnt in sorted(category_counts.items(), key=lambda x: x[1], reverse=True):
+            desc = ci_failure_classifier.CATEGORIES.get(cat, "No description")
+            pct = f"{(cnt / total_failures):.1%}"
+            lines.append(f"| `{cat}` | {desc} | **{cnt}** | {pct} |")
+        lines.append("")
+
+    # --- Detailed Failure Table ---
+    if records:
+        lines.append("<details><summary><b>🔍 View Individual Failure Details</b> (Click to expand)</summary>")
+        lines.append("")
+        lines.append("| Run # | Job | Step | Category | Confidence | Root Cause / LLM Refinement |")
+        lines.append("| :--- | :--- | :--- | :--- | :--- | :--- |")
+        for r in records:
+            run_num = r.get("run_number", "?")
+            job_name = r.get("job_name", "unknown")
+            step_name = r.get("step_name", "unknown")
+            clf = r.get("classification", {})
+            cat = clf.get("category", "unknown")
+            conf = clf.get("confidence", 0.0)
+
+            aa = r.get("agentic_analysis", {})
+            if aa and aa.get("status") == "success":
+                llm_note = f"**LLM:** {aa.get('root_cause', '')} *(Action: {aa.get('suggested_action', '')})*"
+            else:
+                evidence = clf.get("matched_text", "")
+                llm_note = f"`{evidence[:80]}`" if evidence else "Rule match"
+
+            lines.append(f"| #{run_num} | `{job_name}` | `{step_name}` | `{cat}` | {conf:.0%} | {llm_note} |")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_flake_issue_body(
+    flake_report: dict,
+    repo: str = DEFAULT_REPO,
+) -> Tuple[str, str]:
+    """
+    Generate issue title and markdown body for a flaky test.
+
+    Includes machine-readable fingerprint comment for deduplication.
+    """
+    job_name = flake_report.get("job_name", "Unknown Job")
+    score = flake_report.get("flake_score", 0.0)
+    total_failures = flake_report.get("total_failures", 0)
+    unique_commits = flake_report.get("unique_commits", 0)
+    categories = flake_report.get("categories", {})
+    signals = flake_report.get("signals", {})
+    samples = flake_report.get("sample_failures", [])
+
+    primary_category = max(categories, key=categories.get) if categories else "unknown"
+    fingerprint = compute_fingerprint(job_name, primary_category)
+
+    title = f"CI Flake: `{job_name}` failing intermittently ({primary_category})"
+
+    lines = [
+        f"{FINGERPRINT_PREFIX} {fingerprint} -->",
+        f"## CI Flake Report: `{job_name}`",
+        "",
+        "> [!IMPORTANT]",
+        f"> Automated CI flake detection identified intermittent failures in **`{job_name}`**.",
+        "",
+        "### 📈 Flake Summary",
+        f"- **Flake Score:** `{score:.0%}` (Threshold: `{ci_flake_detector.FLAKE_THRESHOLD:.0%}`)",
+        f"- **Total Recorded Failures:** `{total_failures}`",
+        f"- **Unique Commits Affected:** `{unique_commits}`",
+        f"- **Primary Category:** `{primary_category}`",
+        "",
+        "### 🔬 Signal Breakdown",
+        f"- **Commit Diversity:** `{signals.get('commit_diversity', 0.0):.2f}`",
+        f"- **Category Correlation:** `{signals.get('category_flake_correlation', 0.0):.2f}`",
+        f"- **Temporal Spread:** `{signals.get('temporal_spread', 0.0):.2f}`",
+        f"- **Failure Rate:** `{signals.get('failure_rate', 0.0):.2f}`",
+        f"- **Retry Signal:** `{signals.get('retry_signal', 0.0):.2f}`",
+        "",
+        "### 🏷️ Failure Categories",
+    ]
+    for cat, count in sorted(categories.items(), key=lambda x: x[1], reverse=True):
+        lines.append(f"- `{cat}`: {count} failure(s)")
+
+    if samples:
+        lines.append("")
+        lines.append("### 📝 Recent Failure Samples")
+        for s in samples[:3]:
+            run_id = s.get("run_id")
+            run_num = s.get("run_number", "?")
+            commit = s.get("commit_sha", "")
+            cat = s.get("category", "")
+            evidence = s.get("evidence", "")
+            url = f"https://github.com/{repo}/actions/runs/{run_id}" if run_id else ""
+
+            lines.append(f"- **Run #{run_num}** ({f'[{commit}]({url})' if url else commit}) — `{cat}`")
+            if evidence:
+                lines.append(f"  ```\n  {evidence[:300].strip()}\n  ```")
+
+    lines.extend([
+        "",
+        "### 🛠️ Recommended Actions for Maintainers",
+        "- [ ] Check if the test relies on external network resources or timing constraints",
+        "- [ ] Inspect lima VM / runner setup if category is `infrastructure_failure`",
+        "- [ ] Check if temporary skip or test refactoring is needed",
+        "",
+        "---",
+        "*Automated report generated by Podman CI Flake Categorization & Analysis system.*",
+    ])
+
+    return title, "\n".join(lines)
+
+
+def generate_pr_comment(
+    records: List[dict],
+    flake_reports: Optional[List[dict]] = None,
+) -> str:
+    """
+    Generate a factual, concise PR comment summarizing CI failures.
+    Strictly follows LLM_POLICY.md guidelines: concise, helpful, objective.
+    """
+    flake_reports = flake_reports or []
+    flaky_job_names = {f.get("job_name"): f for f in flake_reports if f.get("is_flaky")}
+
+    lines = [
+        PR_COMMENT_MARKER,
+        "### 🤖 Podman CI Failure Triage",
+        "",
+    ]
+
+    failed_jobs = records
+    if not failed_jobs:
+        lines.append("All CI jobs passed or no failures analyzed.")
+        return "\n".join(lines)
+
+    lines.append(f"Found **{len(failed_jobs)} failed job(s)** in recent CI run:")
+    lines.append("")
+
+    for r in failed_jobs:
+        job_name = r.get("job_name", "unknown")
+        step_name = r.get("step_name", "unknown")
+        clf = r.get("classification", {})
+        cat = clf.get("category", "unknown")
+        url = r.get("html_url", "")
+
+        is_known_flake = job_name in flaky_job_names
+        flake_note = " ⚠️ *(Matches known historical flake pattern)*" if is_known_flake else ""
+
+        link = f"[{job_name}]({url})" if url else f"`{job_name}`"
+        lines.append(f"- **Job:** {link}{flake_note}")
+        lines.append(f"  - **Step:** `{step_name}`")
+        lines.append(f"  - **Category:** `{cat}` ({clf.get('confidence', 0):.0%})")
+
+        aa = r.get("agentic_analysis", {})
+        if aa and aa.get("status") == "success":
+            lines.append(f"  - **Root Cause:** {aa.get('root_cause', '')}")
+            if aa.get("suggested_action"):
+                lines.append(f"  - **Action:** {aa.get('suggested_action')}")
+        elif clf.get("matched_text"):
+            lines.append(f"  - **Pattern:** `{clf.get('matched_text', '')[:100]}`")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("*Triage generated by `hack/ci` automated analysis tooling.*")
+
+    return "\n".join(lines)
+
+
+# --- GitHub API Helpers for Issues and Comments ---
+
+def find_existing_flake_issue(
+    repo: str,
+    fingerprint: str,
+    token: Optional[str] = None,
+) -> Optional[dict]:
+    """
+    Search for an existing open issue with the given flake fingerprint.
+    """
+    url = f"{ci_run_collector.API_BASE}/repos/{repo}/issues?state=open&labels={FLAKE_LABEL}&per_page=100"
+    try:
+        data = ci_run_collector.api_request(url, token=token)
+        if isinstance(data, list):
+            target_str = f"{FINGERPRINT_PREFIX} {fingerprint}"
+            for issue in data:
+                body = issue.get("body", "") or ""
+                if target_str in body:
+                    return issue
+    except ci_run_collector.GitHubAPIError as e:
+        print(f"Warning: Failed searching issues: {e}", file=sys.stderr)
+    return None
+
+
+def create_or_update_flake_issue(
+    repo: str,
+    flake_report: dict,
+    token: Optional[str] = None,
+    dry_run: bool = True,
+) -> Tuple[str, dict]:
+    """
+    Create a new flake issue or update an existing one if a matching
+    fingerprint is found. Returns ('created'|'updated'|'dry_run', issue_dict).
+    """
+    job_name = flake_report.get("job_name", "Unknown Job")
+    categories = flake_report.get("categories", {})
+    primary_category = max(categories, key=categories.get) if categories else "unknown"
+    fingerprint = compute_fingerprint(job_name, primary_category)
+
+    title, body = generate_flake_issue_body(flake_report, repo=repo)
+
+    if dry_run or not token:
+        return "dry_run", {"title": title, "body": body, "fingerprint": fingerprint}
+
+    existing = find_existing_flake_issue(repo, fingerprint, token=token)
+    if existing:
+        issue_number = existing.get("number")
+        url = f"{ci_run_collector.API_BASE}/repos/{repo}/issues/{issue_number}"
+        # Post a comment to update the existing issue rather than spamming a new issue
+        comment_url = f"{url}/comments"
+        comment_body = f"🔁 **Flake recurrence update**: `{job_name}` failed again.\n\nLatest flake score: `{flake_report.get('flake_score', 0):.0%}`."
+        try:
+            req = urllib.request.Request(
+                comment_url,
+                data=json.dumps({"body": comment_body}).encode("utf-8"),
+                headers=ci_run_collector._build_headers(token),
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                res = json.loads(resp.read().decode("utf-8"))
+                return "updated", res
+        except Exception as e:
+            print(f"Warning: Failed updating issue #{issue_number}: {e}", file=sys.stderr)
+            return "error", {"error": str(e)}
+
+    # Create new issue
+    create_url = f"{ci_run_collector.API_BASE}/repos/{repo}/issues"
+    payload = {
+        "title": title,
+        "body": body,
+        "labels": [FLAKE_LABEL],
+    }
+    try:
+        req = urllib.request.Request(
+            create_url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=ci_run_collector._build_headers(token),
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            res = json.loads(resp.read().decode("utf-8"))
+            return "created", res
+    except Exception as e:
+        print(f"Warning: Failed creating issue for {job_name}: {e}", file=sys.stderr)
+        return "error", {"error": str(e)}
+
+
+def post_or_update_pr_comment(
+    repo: str,
+    pr_number: int,
+    comment_body: str,
+    token: Optional[str] = None,
+    dry_run: bool = True,
+) -> Tuple[str, dict]:
+    """
+    Post or update an existing analysis comment on a GitHub PR.
+    """
+    if dry_run or not token:
+        return "dry_run", {"pr_number": pr_number, "body": comment_body}
+
+    # Check for existing comment with marker
+    list_url = f"{ci_run_collector.API_BASE}/repos/{repo}/issues/{pr_number}/comments?per_page=100"
+    try:
+        existing_comments = ci_run_collector.api_request(list_url, token=token)
+        if isinstance(existing_comments, list):
+            for c in existing_comments:
+                if PR_COMMENT_MARKER in (c.get("body") or ""):
+                    comment_id = c.get("id")
+                    patch_url = f"{ci_run_collector.API_BASE}/repos/{repo}/issues/comments/{comment_id}"
+                    req = urllib.request.Request(
+                        patch_url,
+                        data=json.dumps({"body": comment_body}).encode("utf-8"),
+                        headers=ci_run_collector._build_headers(token),
+                        method="PATCH",
+                    )
+                    with urllib.request.urlopen(req, timeout=30) as resp:
+                        res = json.loads(resp.read().decode("utf-8"))
+                        return "updated", res
+    except Exception as e:
+        print(f"Warning: Failed checking existing PR comments: {e}", file=sys.stderr)
+
+    # Post new comment
+    post_url = f"{ci_run_collector.API_BASE}/repos/{repo}/issues/{pr_number}/comments"
+    try:
+        req = urllib.request.Request(
+            post_url,
+            data=json.dumps({"body": comment_body}).encode("utf-8"),
+            headers=ci_run_collector._build_headers(token),
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            res = json.loads(resp.read().decode("utf-8"))
+            return "created", res
+    except Exception as e:
+        print(f"Warning: Failed posting PR comment: {e}", file=sys.stderr)
+        return "error", {"error": str(e)}
+
+
+# --- CLI Interface ---
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Format CI failure analysis and integrate with GitHub Actions / Issues / PRs.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read input JSON records or flake reports from stdin",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["step-summary", "issue-body", "pr-comment", "json"],
+        default="step-summary",
+        help="Output format (default: step-summary)",
+    )
+    parser.add_argument(
+        "--write-step-summary",
+        action="store_true",
+        help="Append formatted output directly to $GITHUB_STEP_SUMMARY file",
+    )
+    parser.add_argument(
+        "--create-issues",
+        action="store_true",
+        help="Create/update GitHub issues for detected flakes",
+    )
+    parser.add_argument(
+        "--max-issues",
+        type=int,
+        default=DEFAULT_MAX_ISSUES,
+        help=f"Maximum issues to create in one run (default: {DEFAULT_MAX_ISSUES})",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        help="Post PR comment triage to specified PR number",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Simulate GitHub API write operations without creating issues/comments",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    # Load input data
+    input_data = []
+    if args.stdin:
+        try:
+            raw = sys.stdin.read().strip()
+            if raw:
+                input_data = json.loads(raw)
+                if isinstance(input_data, dict):
+                    input_data = [input_data]
+        except Exception as e:
+            print(f"Error reading JSON from stdin: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # Determine data shape (FailureRecord list vs FlakeReport list)
+    records = []
+    flake_reports = []
+
+    if input_data:
+        # Check if items are flake reports (contain 'flake_score') or failure records (contain 'job_name' + 'classification')
+        if any("flake_score" in item for item in input_data):
+            flake_reports = input_data
+        else:
+            records = input_data
+            flake_reports = ci_flake_detector.analyze_flakes(records)
+
+    # Format output
+    output_text = ""
+    if args.format == "step-summary":
+        output_text = format_step_summary(records, flake_reports)
+    elif args.format == "issue-body":
+        if flake_reports:
+            for rep in flake_reports:
+                title, body = generate_flake_issue_body(rep, repo=args.repo)
+                output_text += f"# {title}\n\n{body}\n\n{'='*60}\n\n"
+        else:
+            output_text = "No flake reports available to generate issue body."
+    elif args.format == "pr-comment":
+        output_text = generate_pr_comment(records, flake_reports)
+    elif args.format == "json":
+        output_text = json.dumps({"records": records, "flake_reports": flake_reports}, indent=2)
+
+    # Print to stdout
+    if output_text:
+        print(output_text)
+
+    # Write to GITHUB_STEP_SUMMARY if requested
+    if args.write_step_summary:
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            try:
+                with open(summary_path, "a", encoding="utf-8") as f:
+                    f.write("\n" + output_text + "\n")
+                print(f"Wrote summary to {summary_path}", file=sys.stderr)
+            except OSError as e:
+                print(f"Error writing to GITHUB_STEP_SUMMARY: {e}", file=sys.stderr)
+        else:
+            print("Warning: GITHUB_STEP_SUMMARY environment variable not set.", file=sys.stderr)
+
+    # Create issues if requested
+    if args.create_issues and flake_reports:
+        flaky_to_create = [f for f in flake_reports if f.get("is_flaky")][:args.max_issues]
+        print(f"Processing {len(flaky_to_create)} flaky issue(s)...", file=sys.stderr)
+        for f in flaky_to_create:
+            action, res = create_or_update_flake_issue(
+                args.repo, f, token=token, dry_run=args.dry_run
+            )
+            print(f"  [{action}] {f.get('job_name')}: {res.get('html_url') or res.get('title')}", file=sys.stderr)
+
+    # Post PR comment if requested
+    if args.pr:
+        pr_comment_body = generate_pr_comment(records, flake_reports)
+        action, res = post_or_update_pr_comment(
+            args.repo, args.pr, pr_comment_body, token=token, dry_run=args.dry_run
+        )
+        print(f"PR #{args.pr} comment action: [{action}]", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_reporter_test.py
+++ b/hack/ci/ci_reporter_test.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_reporter.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_reporter_test.py -v
+    python3 hack/ci/ci_reporter_test.py
+"""
+
+import json
+import os
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_reporter
+
+
+# --- Test Fixtures ---
+
+SAMPLE_RECORD = {
+    "run_id": 31813098642,
+    "run_number": 1503,
+    "workflow": "ci",
+    "job_name": "sys local root fedora-current / lima",
+    "job_id": 90002,
+    "step_name": "Run test on lima",
+    "branch": "main",
+    "commit_sha": "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8",
+    "commit_message": "Merge pull request #29279",
+    "event": "push",
+    "created_at": "2026-08-14T15:09:38Z",
+    "html_url": "https://example.com/job/90002",
+    "failure_sections": [
+        {"type": "ginkgo_failure", "text": "[FAIL] Podman run with volume"},
+    ],
+    "classification": {
+        "category": "test_assertion_failure",
+        "confidence": 0.85,
+        "rule_name": "ginkgo_assertion",
+        "matched_text": "[FAIL] Podman run with volume",
+        "evidence": "[FAIL] Podman run with volume",
+    },
+    "agentic_analysis": {
+        "status": "success",
+        "refined_category": "test_assertion_failure",
+        "root_cause": "Volume mount path mismatch in expected test fixture.",
+        "is_flake_assessment": "likely_bug",
+        "confidence": 0.9,
+        "suggested_action": "Fix hardcoded path in test.",
+    },
+}
+
+SAMPLE_FLAKE_REPORT = {
+    "job_name": "sys local root fedora-current / lima",
+    "flake_score": 0.82,
+    "is_flaky": True,
+    "total_failures": 8,
+    "unique_commits": 6,
+    "unique_dates": 5,
+    "categories": {
+        "network_error": 5,
+        "test_assertion_failure": 3,
+    },
+    "signals": {
+        "commit_diversity": 1.0,
+        "category_flake_correlation": 0.8,
+        "temporal_spread": 0.7,
+        "failure_rate": 0.6,
+        "retry_signal": 0.5,
+    },
+    "sample_failures": [
+        {
+            "run_id": 31813098642,
+            "run_number": 1503,
+            "commit_sha": "3a18c5e98f5c",
+            "created_at": "2026-08-14T15:09:38Z",
+            "category": "network_error",
+            "evidence": "dial tcp 10.0.2.15: connection refused",
+        },
+    ],
+}
+
+
+class TestComputeFingerprint(unittest.TestCase):
+    """Tests for fingerprint computation."""
+
+    def test_deterministic(self):
+        fp1 = ci_reporter.compute_fingerprint("sys local root fedora", "network_error")
+        fp2 = ci_reporter.compute_fingerprint("sys local root fedora", "network_error")
+        self.assertEqual(fp1, fp2)
+        self.assertEqual(len(fp1), 16)
+
+    def test_case_and_whitespace_insensitive(self):
+        fp1 = ci_reporter.compute_fingerprint("  sys local root fedora  ", "network_error")
+        fp2 = ci_reporter.compute_fingerprint("SYS LOCAL ROOT FEDORA", "NETWORK_ERROR")
+        self.assertEqual(fp1, fp2)
+
+    def test_distinct_for_different_jobs(self):
+        fp1 = ci_reporter.compute_fingerprint("job-a", "network_error")
+        fp2 = ci_reporter.compute_fingerprint("job-b", "network_error")
+        self.assertNotEqual(fp1, fp2)
+
+
+class TestFormatStepSummary(unittest.TestCase):
+    """Tests for format_step_summary."""
+
+    def test_empty_input(self):
+        summary = ci_reporter.format_step_summary([], [])
+        self.assertIn("No CI failures or flakes detected", summary)
+
+    def test_summary_with_records(self):
+        summary = ci_reporter.format_step_summary([SAMPLE_RECORD], [])
+        self.assertIn("CI Failure & Flake Analysis Dashboard", summary)
+        self.assertIn("Total Failed Jobs Analyzed", summary)
+        self.assertIn("`test_assertion_failure`", summary)
+        self.assertIn("Volume mount path mismatch", summary)
+        self.assertIn("<details><summary>", summary)
+
+    def test_summary_with_flake_reports(self):
+        summary = ci_reporter.format_step_summary([SAMPLE_RECORD], [SAMPLE_FLAKE_REPORT])
+        self.assertIn("Flaky Test Warnings", summary)
+        self.assertIn("82%", summary)
+        self.assertIn("sys local root fedora-current / lima", summary)
+        self.assertIn("Suspected Flaky Jobs", summary)
+
+
+class TestGenerateFlakeIssueBody(unittest.TestCase):
+    """Tests for generate_flake_issue_body."""
+
+    def test_generates_fingerprint_and_title(self):
+        title, body = ci_reporter.generate_flake_issue_body(SAMPLE_FLAKE_REPORT)
+        self.assertIn("CI Flake: `sys local root fedora-current / lima`", title)
+        self.assertIn(ci_reporter.FINGERPRINT_PREFIX, body)
+        self.assertIn("Flake Score:** `82%`", body)
+        self.assertIn("network_error", body)
+        self.assertIn("dial tcp 10.0.2.15", body)
+        self.assertIn("Recommended Actions for Maintainers", body)
+
+
+class TestGeneratePrComment(unittest.TestCase):
+    """Tests for generate_pr_comment."""
+
+    def test_empty_records(self):
+        comment = ci_reporter.generate_pr_comment([])
+        self.assertIn(ci_reporter.PR_COMMENT_MARKER, comment)
+        self.assertIn("All CI jobs passed", comment)
+
+    def test_with_records_and_flake_match(self):
+        comment = ci_reporter.generate_pr_comment([SAMPLE_RECORD], [SAMPLE_FLAKE_REPORT])
+        self.assertIn(ci_reporter.PR_COMMENT_MARKER, comment)
+        self.assertIn("Matches known historical flake pattern", comment)
+        self.assertIn("Volume mount path mismatch", comment)
+        self.assertIn("test_assertion_failure", comment)
+
+
+class TestFindExistingFlakeIssue(unittest.TestCase):
+    """Tests for finding existing flake issue by fingerprint."""
+
+    @patch("ci_run_collector.api_request")
+    def test_finds_matching_issue(self, mock_api):
+        fp = ci_reporter.compute_fingerprint("test-job", "network_error")
+        mock_api.return_value = [
+            {"number": 101, "title": "Old Flake", "body": "some issue"},
+            {"number": 102, "title": "Target Flake", "body": f"text {ci_reporter.FINGERPRINT_PREFIX} {fp} --> end"},
+        ]
+        res = ci_reporter.find_existing_flake_issue("podman/podman", fp, token="test-token")
+        self.assertIsNotNone(res)
+        self.assertEqual(res["number"], 102)
+
+    @patch("ci_run_collector.api_request")
+    def test_returns_none_when_not_found(self, mock_api):
+        mock_api.return_value = [{"number": 101, "body": "unrelated"}]
+        res = ci_reporter.find_existing_flake_issue("podman/podman", "missing_fp", token="test-token")
+        self.assertIsNone(res)
+
+
+class TestCreateOrUpdateFlakeIssue(unittest.TestCase):
+    """Tests for create_or_update_flake_issue."""
+
+    def test_dry_run_mode(self):
+        action, res = ci_reporter.create_or_update_flake_issue(
+            "podman/podman", SAMPLE_FLAKE_REPORT, token="test-token", dry_run=True
+        )
+        self.assertEqual(action, "dry_run")
+        self.assertIn("title", res)
+        self.assertIn("fingerprint", res)
+
+    @patch("ci_reporter.find_existing_flake_issue")
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_update_existing_issue(self, mock_urlopen, mock_find):
+        mock_find.return_value = {"number": 555}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"id": 12345}).encode("utf-8")
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        action, res = ci_reporter.create_or_update_flake_issue(
+            "podman/podman", SAMPLE_FLAKE_REPORT, token="test-token", dry_run=False
+        )
+        self.assertEqual(action, "updated")
+        self.assertEqual(res["id"], 12345)
+
+    @patch("ci_reporter.find_existing_flake_issue")
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_create_new_issue(self, mock_urlopen, mock_find):
+        mock_find.return_value = None
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"number": 600, "html_url": "https://github.com/issue/600"}).encode("utf-8")
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        action, res = ci_reporter.create_or_update_flake_issue(
+            "podman/podman", SAMPLE_FLAKE_REPORT, token="test-token", dry_run=False
+        )
+        self.assertEqual(action, "created")
+        self.assertEqual(res["number"], 600)
+
+
+class TestPostOrUpdatePrComment(unittest.TestCase):
+    """Tests for post_or_update_pr_comment."""
+
+    def test_dry_run_mode(self):
+        action, res = ci_reporter.post_or_update_pr_comment(
+            "podman/podman", 123, "test comment", token="test-token", dry_run=True
+        )
+        self.assertEqual(action, "dry_run")
+        self.assertEqual(res["pr_number"], 123)
+
+    @patch("ci_run_collector.api_request")
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_updates_existing_comment(self, mock_urlopen, mock_api):
+        mock_api.return_value = [
+            {"id": 999, "body": f"{ci_reporter.PR_COMMENT_MARKER}\nOld summary"}
+        ]
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"id": 999, "body": "updated"}).encode("utf-8")
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        action, res = ci_reporter.post_or_update_pr_comment(
+            "podman/podman", 123, "new body", token="test-token", dry_run=False
+        )
+        self.assertEqual(action, "updated")
+        self.assertEqual(res["id"], 999)
+
+    @patch("ci_run_collector.api_request")
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_creates_new_comment(self, mock_urlopen, mock_api):
+        mock_api.return_value = [{"id": 888, "body": "unrelated bot comment"}]
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"id": 1001, "body": "created"}).encode("utf-8")
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        action, res = ci_reporter.post_or_update_pr_comment(
+            "podman/podman", 123, "new body", token="test-token", dry_run=False
+        )
+        self.assertEqual(action, "created")
+        self.assertEqual(res["id"], 1001)
+
+
+class TestMainCLI(unittest.TestCase):
+    """Tests for main CLI execution."""
+
+    @patch("sys.stdin", StringIO(json.dumps([SAMPLE_RECORD])))
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_cli_step_summary(self, mock_stdout):
+        with patch.object(sys, "argv", ["ci_reporter.py", "--stdin", "--format", "step-summary"]):
+            ci_reporter.main()
+        output = mock_stdout.getvalue()
+        self.assertIn("CI Failure & Flake Analysis Dashboard", output)
+
+    @patch("sys.stdin", StringIO(json.dumps([SAMPLE_FLAKE_REPORT])))
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_cli_issue_body(self, mock_stdout):
+        with patch.object(sys, "argv", ["ci_reporter.py", "--stdin", "--format", "issue-body"]):
+            ci_reporter.main()
+        output = mock_stdout.getvalue()
+        self.assertIn("CI Flake Report", output)
+
+    @patch("sys.stdin", StringIO(json.dumps([SAMPLE_RECORD])))
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_cli_pr_comment(self, mock_stdout):
+        with patch.object(sys, "argv", ["ci_reporter.py", "--stdin", "--format", "pr-comment"]):
+            ci_reporter.main()
+        output = mock_stdout.getvalue()
+        self.assertIn("Podman CI Failure Triage", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hack/ci/ci_run_collector.py
+++ b/hack/ci/ci_run_collector.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+ci_run_collector - Collect GitHub Actions CI run data for failure analysis.
+
+Retrieves workflow run and job data from the GitHub Actions API,
+identifies failed runs, and outputs structured JSON suitable for
+downstream analysis (classification, flake detection, etc.).
+
+Usage:
+    # List recent failed CI runs on main branch
+    ./hack/ci/ci_run_collector.py --branch main --status failure --limit 10
+
+    # Get detailed job information for a specific run
+    ./hack/ci/ci_run_collector.py --run-id 31813098642
+
+    # Output as JSON for piping to other tools
+    ./hack/ci/ci_run_collector.py --branch main --status failure --json
+
+Environment:
+    GITHUB_TOKEN     Optional. GitHub API token for authentication.
+                     Without it, requests are subject to stricter rate limits.
+    GITHUB_REPOSITORY  Optional. Defaults to 'podman-container-tools/podman'.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+
+# Default repository; matches the upstream Podman project.
+DEFAULT_REPO = "podman-container-tools/podman"
+# Default workflow filename for the main CI pipeline.
+DEFAULT_WORKFLOW = "ci.yml"
+# GitHub API base URL.
+API_BASE = "https://api.github.com"
+# Maximum results per API page (GitHub caps at 100).
+MAX_PER_PAGE = 100
+# Default number of runs to retrieve.
+DEFAULT_LIMIT = 20
+# Maximum number of runs to retrieve in a single invocation to
+# avoid accidentally downloading huge amounts of data.
+MAX_LIMIT = 500
+# Seconds to wait before retrying after a rate-limit or transient error.
+RETRY_DELAYS = [1, 2, 4]
+
+
+@dataclass
+class FailedStep:
+    """A single failed step within a job."""
+
+    name: str
+    conclusion: str
+    number: int
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+
+
+@dataclass
+class JobResult:
+    """Summary of a single job within a workflow run."""
+
+    job_id: int
+    name: str
+    conclusion: str
+    status: str
+    html_url: str
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    runner_name: Optional[str] = None
+    failed_steps: list = field(default_factory=list)
+
+
+@dataclass
+class RunResult:
+    """Summary of a single workflow run."""
+
+    run_id: int
+    workflow: str
+    run_number: int
+    status: str
+    conclusion: str
+    branch: str
+    commit_sha: str
+    commit_message: str
+    event: str
+    html_url: str
+    created_at: str
+    updated_at: str
+    run_attempt: int
+    jobs: list = field(default_factory=list)
+
+
+class GitHubAPIError(Exception):
+    """Raised when a GitHub API request fails after retries."""
+
+
+class RateLimitError(GitHubAPIError):
+    """Raised when the GitHub API rate limit is exceeded."""
+
+
+def _build_headers(token: Optional[str] = None) -> dict:
+    """Build HTTP headers for GitHub API requests."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def api_request(url: str, token: Optional[str] = None) -> dict:
+    """
+    Make an authenticated GET request to the GitHub API with retry logic.
+
+    Handles transient errors (5xx, network) and rate limiting with
+    exponential backoff. Raises GitHubAPIError after exhausting retries.
+    """
+    headers = _build_headers(token)
+    last_error = None
+
+    for attempt, delay in enumerate(RETRY_DELAYS + [0]):
+        try:
+            req = urllib.request.Request(url, headers=headers, method="GET")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            last_error = e
+            if e.code == 403:
+                # Check for rate limit.
+                reset_time = e.headers.get("X-RateLimit-Reset")
+                remaining = e.headers.get("X-RateLimit-Remaining")
+                if remaining == "0" and reset_time:
+                    wait = max(0, int(reset_time) - int(time.time())) + 1
+                    raise RateLimitError(
+                        f"GitHub API rate limit exceeded. "
+                        f"Resets in {wait}s. "
+                        f"Set GITHUB_TOKEN for higher limits."
+                    ) from e
+            if e.code == 404:
+                raise GitHubAPIError(f"Resource not found: {url}") from e
+            if e.code < 500 and e.code != 429:
+                raise GitHubAPIError(
+                    f"GitHub API error {e.code}: {e.reason}"
+                ) from e
+            # Retry on 5xx and 429.
+            if delay:
+                time.sleep(delay)
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_error = e
+            if delay:
+                time.sleep(delay)
+
+    raise GitHubAPIError(
+        f"GitHub API request failed after {len(RETRY_DELAYS)} retries: "
+        f"{last_error}"
+    )
+
+
+def fetch_workflow_runs(
+    repo: str,
+    branch: Optional[str] = None,
+    status: Optional[str] = None,
+    workflow: str = DEFAULT_WORKFLOW,
+    limit: int = DEFAULT_LIMIT,
+    token: Optional[str] = None,
+) -> list:
+    """
+    Fetch workflow runs from the GitHub Actions API.
+
+    Returns a list of raw run dicts, paginated up to `limit` results.
+    """
+    per_page = min(limit, MAX_PER_PAGE)
+    params = [f"per_page={per_page}"]
+    if branch:
+        params.append(f"branch={branch}")
+    if status:
+        params.append(f"status={status}")
+
+    url = (
+        f"{API_BASE}/repos/{repo}/actions/workflows/{workflow}/runs"
+        f"?{'&'.join(params)}"
+    )
+
+    all_runs = []
+    pages_fetched = 0
+    max_pages = (limit + per_page - 1) // per_page
+
+    while url and pages_fetched < max_pages:
+        data = api_request(url, token)
+        runs = data.get("workflow_runs", [])
+        all_runs.extend(runs)
+        pages_fetched += 1
+
+        if len(all_runs) >= limit:
+            break
+
+        # Follow pagination via Link header logic.
+        # The API returns a 'next' link, but since we're using json
+        # response, we manually construct the next page URL.
+        if len(runs) < per_page:
+            break
+        page = pages_fetched + 1
+        url = (
+            f"{API_BASE}/repos/{repo}/actions/workflows/{workflow}/runs"
+            f"?{'&'.join(params)}&page={page}"
+        )
+
+    return all_runs[:limit]
+
+
+def fetch_jobs_for_run(
+    repo: str, run_id: int, token: Optional[str] = None
+) -> list:
+    """
+    Fetch all jobs for a given workflow run.
+
+    Returns a list of raw job dicts. Handles pagination for runs
+    with many jobs.
+    """
+    url = f"{API_BASE}/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"
+    all_jobs = []
+
+    while url:
+        data = api_request(url, token)
+        jobs = data.get("jobs", [])
+        all_jobs.extend(jobs)
+
+        if len(jobs) < 100:
+            break
+        # Simple page increment for additional jobs.
+        page = (len(all_jobs) // 100) + 1
+        url = (
+            f"{API_BASE}/repos/{repo}/actions/runs/{run_id}/jobs"
+            f"?per_page=100&page={page}"
+        )
+
+    return all_jobs
+
+
+def parse_run(raw_run: dict) -> RunResult:
+    """Parse a raw workflow run API response into a RunResult."""
+    commit = raw_run.get("head_commit", {}) or {}
+    return RunResult(
+        run_id=raw_run["id"],
+        workflow=raw_run.get("name", ""),
+        run_number=raw_run.get("run_number", 0),
+        status=raw_run.get("status", ""),
+        conclusion=raw_run.get("conclusion", ""),
+        branch=raw_run.get("head_branch", ""),
+        commit_sha=raw_run.get("head_sha", ""),
+        commit_message=commit.get("message", ""),
+        event=raw_run.get("event", ""),
+        html_url=raw_run.get("html_url", ""),
+        created_at=raw_run.get("created_at", ""),
+        updated_at=raw_run.get("updated_at", ""),
+        run_attempt=raw_run.get("run_attempt", 1),
+    )
+
+
+def parse_job(raw_job: dict) -> JobResult:
+    """Parse a raw job API response into a JobResult."""
+    failed_steps = []
+    for step in raw_job.get("steps", []):
+        if step.get("conclusion") == "failure":
+            failed_steps.append(
+                FailedStep(
+                    name=step.get("name", ""),
+                    conclusion=step.get("conclusion", ""),
+                    number=step.get("number", 0),
+                    started_at=step.get("started_at"),
+                    completed_at=step.get("completed_at"),
+                )
+            )
+
+    return JobResult(
+        job_id=raw_job["id"],
+        name=raw_job.get("name", ""),
+        conclusion=raw_job.get("conclusion", ""),
+        status=raw_job.get("status", ""),
+        html_url=raw_job.get("html_url", ""),
+        started_at=raw_job.get("started_at"),
+        completed_at=raw_job.get("completed_at"),
+        runner_name=raw_job.get("runner_name"),
+        failed_steps=[asdict(s) for s in failed_steps],
+    )
+
+
+def collect_failed_runs(
+    repo: str = DEFAULT_REPO,
+    branch: Optional[str] = None,
+    status: str = "failure",
+    workflow: str = DEFAULT_WORKFLOW,
+    limit: int = DEFAULT_LIMIT,
+    include_jobs: bool = True,
+    token: Optional[str] = None,
+) -> list:
+    """
+    Collect CI run data with optional job details.
+
+    This is the main entry point for programmatic use. Returns a list
+    of RunResult dicts.
+    """
+    raw_runs = fetch_workflow_runs(
+        repo=repo,
+        branch=branch,
+        status=status,
+        workflow=workflow,
+        limit=limit,
+        token=token,
+    )
+
+    results = []
+    for raw_run in raw_runs:
+        run = parse_run(raw_run)
+        if include_jobs:
+            raw_jobs = fetch_jobs_for_run(repo, run.run_id, token)
+            run.jobs = [asdict(parse_job(j)) for j in raw_jobs]
+        results.append(asdict(run))
+
+    return results
+
+
+def collect_single_run(
+    repo: str, run_id: int, token: Optional[str] = None
+) -> dict:
+    """Collect detailed data for a single workflow run."""
+    url = f"{API_BASE}/repos/{repo}/actions/runs/{run_id}"
+    raw_run = api_request(url, token)
+    run = parse_run(raw_run)
+
+    raw_jobs = fetch_jobs_for_run(repo, run_id, token)
+    run.jobs = [asdict(parse_job(j)) for j in raw_jobs]
+
+    return asdict(run)
+
+
+def format_summary(runs: list) -> str:
+    """Format run data as a human-readable summary."""
+    lines = []
+    for run in runs:
+        failed_jobs = [j for j in run.get("jobs", []) if j["conclusion"] == "failure"]
+        lines.append(
+            f"Run #{run['run_number']} ({run['run_id']}) "
+            f"[{run['conclusion']}] "
+            f"branch={run['branch']} "
+            f"commit={run['commit_sha'][:12]}"
+        )
+        # Truncate long commit messages to first line.
+        msg = run["commit_message"].split("\n")[0]
+        lines.append(f"  {msg}")
+        if failed_jobs:
+            lines.append(f"  Failed jobs ({len(failed_jobs)}):")
+            for job in failed_jobs:
+                steps = job.get("failed_steps", [])
+                step_names = ", ".join(s["name"] for s in steps) if steps else "unknown"
+                lines.append(f"    - {job['name']}: {step_names}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect GitHub Actions CI run data for failure analysis.",
+        epilog="Set GITHUB_TOKEN env var for authenticated API access.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--branch",
+        default=None,
+        help="Filter by branch name (e.g., 'main')",
+    )
+    parser.add_argument(
+        "--status",
+        default="failure",
+        choices=["failure", "success", "completed", "cancelled"],
+        help="Filter by run conclusion (default: failure)",
+    )
+    parser.add_argument(
+        "--workflow",
+        default=DEFAULT_WORKFLOW,
+        help=f"Workflow filename (default: {DEFAULT_WORKFLOW})",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"Maximum number of runs to retrieve (default: {DEFAULT_LIMIT}, max: {MAX_LIMIT})",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=int,
+        default=None,
+        help="Retrieve detailed data for a specific run ID",
+    )
+    parser.add_argument(
+        "--no-jobs",
+        action="store_true",
+        help="Skip fetching job details (faster, less data)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON instead of human-readable summary",
+    )
+    args = parser.parse_args()
+
+    if args.limit > MAX_LIMIT:
+        print(
+            f"Error: --limit must be <= {MAX_LIMIT} to avoid excessive API usage.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        if args.run_id:
+            results = [collect_single_run(args.repo, args.run_id, token)]
+        else:
+            results = collect_failed_runs(
+                repo=args.repo,
+                branch=args.branch,
+                status=args.status,
+                workflow=args.workflow,
+                limit=args.limit,
+                include_jobs=not args.no_jobs,
+                token=token,
+            )
+    except RateLimitError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+    except GitHubAPIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json_output:
+        json.dump(results, sys.stdout, indent=2)
+        print()  # Trailing newline.
+    else:
+        if not results:
+            print("No matching workflow runs found.")
+        else:
+            print(format_summary(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/ci/ci_run_collector_test.py
+++ b/hack/ci/ci_run_collector_test.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+Unit tests for ci_run_collector.py
+
+Run with:
+    python3 -m pytest hack/ci/ci_run_collector_test.py -v
+    python3 hack/ci/ci_run_collector_test.py
+"""
+
+import json
+import os
+import sys
+import unittest
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+# Ensure hack/ci is importable.
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import ci_run_collector
+
+
+# --- Test fixtures ---
+
+SAMPLE_RUN = {
+    "id": 31813098642,
+    "name": "ci",
+    "run_number": 1503,
+    "status": "completed",
+    "conclusion": "failure",
+    "head_branch": "main",
+    "head_sha": "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8",
+    "event": "push",
+    "html_url": "https://github.com/podman-container-tools/podman/actions/runs/31813098642",
+    "created_at": "2026-08-14T15:09:38Z",
+    "updated_at": "2026-08-14T16:12:06Z",
+    "run_attempt": 1,
+    "head_commit": {
+        "id": "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8",
+        "message": "Merge pull request #29279 from vtushar06/fix-prune-build-race\n\nlibpod: do not fail prune when build container is already gone",
+        "timestamp": "2026-08-14T15:09:35Z",
+        "author": {"name": "Matt Heon", "email": "mheon@redhat.com"},
+        "committer": {"name": "GitHub", "email": "noreply@github.com"},
+    },
+}
+
+SAMPLE_JOB_PASSED = {
+    "id": 90001,
+    "name": "validate-source",
+    "conclusion": "success",
+    "status": "completed",
+    "html_url": "https://github.com/podman-container-tools/podman/actions/runs/31813098642/job/90001",
+    "started_at": "2026-08-14T15:10:00Z",
+    "completed_at": "2026-08-14T15:15:00Z",
+    "runner_name": "cncf-ubuntu-8-32-x86-1",
+    "steps": [
+        {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2026-08-14T15:10:00Z",
+            "completed_at": "2026-08-14T15:10:05Z",
+        },
+    ],
+}
+
+SAMPLE_JOB_FAILED = {
+    "id": 90002,
+    "name": "sys local root fedora-current / lima",
+    "conclusion": "failure",
+    "status": "completed",
+    "html_url": "https://github.com/podman-container-tools/podman/actions/runs/31813098642/job/90002",
+    "started_at": "2026-08-14T15:10:00Z",
+    "completed_at": "2026-08-14T15:45:00Z",
+    "runner_name": "cncf-ubuntu-8-32-x86-3",
+    "steps": [
+        {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2026-08-14T15:10:00Z",
+            "completed_at": "2026-08-14T15:10:05Z",
+        },
+        {
+            "name": "Run test on lima",
+            "status": "completed",
+            "conclusion": "failure",
+            "number": 4,
+            "started_at": "2026-08-14T15:12:00Z",
+            "completed_at": "2026-08-14T15:45:00Z",
+        },
+        {
+            "name": "Output failure log as GITHUB_STEP_SUMMARY",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 5,
+            "started_at": "2026-08-14T15:45:01Z",
+            "completed_at": "2026-08-14T15:45:02Z",
+        },
+    ],
+}
+
+
+def _mock_api_response(data: dict) -> MagicMock:
+    """Create a mock urllib response with JSON data."""
+    body = json.dumps(data).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestBuildHeaders(unittest.TestCase):
+    """Tests for _build_headers."""
+
+    def test_without_token(self):
+        headers = ci_run_collector._build_headers()
+        self.assertIn("Accept", headers)
+        self.assertNotIn("Authorization", headers)
+
+    def test_with_token(self):
+        headers = ci_run_collector._build_headers("ghp_test123")
+        self.assertEqual(headers["Authorization"], "Bearer ghp_test123")
+        self.assertEqual(headers["Accept"], "application/vnd.github+json")
+
+
+class TestApiRequest(unittest.TestCase):
+    """Tests for api_request."""
+
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_successful_request(self, mock_urlopen):
+        expected = {"total_count": 1, "workflow_runs": []}
+        mock_urlopen.return_value = _mock_api_response(expected)
+
+        result = ci_run_collector.api_request("https://api.github.com/test")
+        self.assertEqual(result, expected)
+
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_404_raises_immediately(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError(
+            "https://api.github.com/test", 404, "Not Found", {}, BytesIO(b"")
+        )
+        with self.assertRaises(ci_run_collector.GitHubAPIError) as ctx:
+            ci_run_collector.api_request("https://api.github.com/test")
+        self.assertIn("not found", str(ctx.exception).lower())
+
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_rate_limit_raises_rate_limit_error(self, mock_urlopen):
+        headers = MagicMock()
+        headers.get = lambda key, default=None: {
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": str(int(ci_run_collector.time.time()) + 60),
+        }.get(key, default)
+        err = HTTPError(
+            "https://api.github.com/test", 403, "Forbidden", headers, BytesIO(b"")
+        )
+        mock_urlopen.side_effect = err
+        with self.assertRaises(ci_run_collector.RateLimitError):
+            ci_run_collector.api_request("https://api.github.com/test")
+
+    @patch("ci_run_collector.time.sleep")
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_retry_on_server_error(self, mock_urlopen, mock_sleep):
+        # First two calls fail with 502, third succeeds.
+        expected = {"ok": True}
+        mock_urlopen.side_effect = [
+            HTTPError(
+                "https://api.github.com/test", 502, "Bad Gateway", {}, BytesIO(b"")
+            ),
+            HTTPError(
+                "https://api.github.com/test", 502, "Bad Gateway", {}, BytesIO(b"")
+            ),
+            _mock_api_response(expected),
+        ]
+        result = ci_run_collector.api_request("https://api.github.com/test")
+        self.assertEqual(result, expected)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch("ci_run_collector.time.sleep")
+    @patch("ci_run_collector.urllib.request.urlopen")
+    def test_retry_exhaustion_raises(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = URLError("Connection refused")
+        with self.assertRaises(ci_run_collector.GitHubAPIError):
+            ci_run_collector.api_request("https://api.github.com/test")
+
+
+class TestParseRun(unittest.TestCase):
+    """Tests for parse_run."""
+
+    def test_parse_complete_run(self):
+        result = ci_run_collector.parse_run(SAMPLE_RUN)
+        self.assertEqual(result.run_id, 31813098642)
+        self.assertEqual(result.workflow, "ci")
+        self.assertEqual(result.run_number, 1503)
+        self.assertEqual(result.conclusion, "failure")
+        self.assertEqual(result.branch, "main")
+        self.assertEqual(result.commit_sha, "3a18c5e98f5ccdc5384ac998e6d9cb00648d3ff8")
+        self.assertIn("fix-prune-build-race", result.commit_message)
+        self.assertEqual(result.event, "push")
+        self.assertEqual(result.run_attempt, 1)
+
+    def test_parse_run_missing_commit(self):
+        """Handles missing head_commit gracefully."""
+        run_data = {**SAMPLE_RUN, "head_commit": None}
+        result = ci_run_collector.parse_run(run_data)
+        self.assertEqual(result.commit_message, "")
+
+    def test_parse_run_minimal(self):
+        """Handles minimal data without crashing."""
+        minimal = {"id": 1, "head_commit": {}}
+        result = ci_run_collector.parse_run(minimal)
+        self.assertEqual(result.run_id, 1)
+        self.assertEqual(result.workflow, "")
+
+
+class TestParseJob(unittest.TestCase):
+    """Tests for parse_job."""
+
+    def test_parse_passed_job(self):
+        result = ci_run_collector.parse_job(SAMPLE_JOB_PASSED)
+        self.assertEqual(result.job_id, 90001)
+        self.assertEqual(result.name, "validate-source")
+        self.assertEqual(result.conclusion, "success")
+        self.assertEqual(len(result.failed_steps), 0)
+
+    def test_parse_failed_job(self):
+        result = ci_run_collector.parse_job(SAMPLE_JOB_FAILED)
+        self.assertEqual(result.job_id, 90002)
+        self.assertEqual(result.name, "sys local root fedora-current / lima")
+        self.assertEqual(result.conclusion, "failure")
+        self.assertEqual(len(result.failed_steps), 1)
+        self.assertEqual(result.failed_steps[0]["name"], "Run test on lima")
+        self.assertEqual(result.failed_steps[0]["number"], 4)
+
+    def test_parse_job_no_steps(self):
+        """Handles job with no steps (e.g., cancelled)."""
+        job = {**SAMPLE_JOB_FAILED, "steps": []}
+        result = ci_run_collector.parse_job(job)
+        self.assertEqual(len(result.failed_steps), 0)
+
+
+class TestFetchWorkflowRuns(unittest.TestCase):
+    """Tests for fetch_workflow_runs."""
+
+    @patch("ci_run_collector.api_request")
+    def test_basic_fetch(self, mock_api):
+        mock_api.return_value = {
+            "total_count": 1,
+            "workflow_runs": [SAMPLE_RUN],
+        }
+        result = ci_run_collector.fetch_workflow_runs(
+            "podman-container-tools/podman", branch="main", limit=5
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], 31813098642)
+
+    @patch("ci_run_collector.api_request")
+    def test_limit_respected(self, mock_api):
+        """Results are capped at the requested limit."""
+        runs = [
+            {**SAMPLE_RUN, "id": i} for i in range(10)
+        ]
+        mock_api.return_value = {
+            "total_count": 10,
+            "workflow_runs": runs,
+        }
+        result = ci_run_collector.fetch_workflow_runs(
+            "podman-container-tools/podman", limit=3
+        )
+        self.assertEqual(len(result), 3)
+
+    @patch("ci_run_collector.api_request")
+    def test_pagination(self, mock_api):
+        """Multiple pages are fetched when needed."""
+        page1 = [
+            {**SAMPLE_RUN, "id": i} for i in range(100)
+        ]
+        page2 = [
+            {**SAMPLE_RUN, "id": i} for i in range(100, 150)
+        ]
+        mock_api.side_effect = [
+            {"total_count": 150, "workflow_runs": page1},
+            {"total_count": 150, "workflow_runs": page2},
+        ]
+        result = ci_run_collector.fetch_workflow_runs(
+            "podman-container-tools/podman", limit=150
+        )
+        self.assertEqual(len(result), 150)
+        self.assertEqual(mock_api.call_count, 2)
+
+    @patch("ci_run_collector.api_request")
+    def test_url_includes_filters(self, mock_api):
+        mock_api.return_value = {"total_count": 0, "workflow_runs": []}
+        ci_run_collector.fetch_workflow_runs(
+            "podman-container-tools/podman",
+            branch="main",
+            status="failure",
+            workflow="ci.yml",
+            limit=5,
+        )
+        call_url = mock_api.call_args[0][0]
+        self.assertIn("branch=main", call_url)
+        self.assertIn("status=failure", call_url)
+        self.assertIn("ci.yml", call_url)
+
+
+class TestCollectFailedRuns(unittest.TestCase):
+    """Tests for collect_failed_runs (integration of fetch + parse)."""
+
+    @patch("ci_run_collector.fetch_jobs_for_run")
+    @patch("ci_run_collector.fetch_workflow_runs")
+    def test_collect_with_jobs(self, mock_fetch_runs, mock_fetch_jobs):
+        mock_fetch_runs.return_value = [SAMPLE_RUN]
+        mock_fetch_jobs.return_value = [SAMPLE_JOB_PASSED, SAMPLE_JOB_FAILED]
+
+        results = ci_run_collector.collect_failed_runs(limit=1)
+        self.assertEqual(len(results), 1)
+
+        run = results[0]
+        self.assertEqual(run["run_id"], 31813098642)
+        self.assertEqual(len(run["jobs"]), 2)
+
+        failed_jobs = [j for j in run["jobs"] if j["conclusion"] == "failure"]
+        self.assertEqual(len(failed_jobs), 1)
+        self.assertEqual(failed_jobs[0]["name"], "sys local root fedora-current / lima")
+
+    @patch("ci_run_collector.fetch_workflow_runs")
+    def test_collect_without_jobs(self, mock_fetch_runs):
+        mock_fetch_runs.return_value = [SAMPLE_RUN]
+
+        results = ci_run_collector.collect_failed_runs(
+            limit=1, include_jobs=False
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["jobs"], [])
+
+
+class TestFormatSummary(unittest.TestCase):
+    """Tests for format_summary."""
+
+    def test_format_with_failures(self):
+        from dataclasses import asdict
+
+        run = ci_run_collector.parse_run(SAMPLE_RUN)
+        job = ci_run_collector.parse_job(SAMPLE_JOB_FAILED)
+        run.jobs = [asdict(job)]
+        run_dict = asdict(run)
+
+        output = ci_run_collector.format_summary([run_dict])
+        self.assertIn("Run #1503", output)
+        self.assertIn("failure", output)
+        self.assertIn("sys local root fedora-current", output)
+        self.assertIn("Run test on lima", output)
+
+    def test_format_empty(self):
+        output = ci_run_collector.format_summary([])
+        self.assertEqual(output, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hack/ci/docs/CI_FLAKE_ANALYSIS.md
+++ b/hack/ci/docs/CI_FLAKE_ANALYSIS.md
@@ -1,0 +1,237 @@
+# Podman CI Failure Categorization, Flake Detection, & Agentic Analysis
+
+> Architecture, CLI reference, and operational guide for the automated CI failure triage and flake analysis suite in `hack/ci/`.
+
+---
+
+## 1. Overview & Architecture
+
+This suite provides an end-to-end data pipeline for analyzing Podman GitHub Actions CI workflow runs, classifying failures into structured categories, calculating multi-signal flake probabilities, providing LLM-assisted root cause analysis, and integrating directly with GitHub (Step Summaries, Issues, and PR triage comments).
+
+### Layered Pipeline Architecture
+
+```
+┌────────────────────────────────────────────────────────┐
+│  PR 1: Data Ingestion                                  │
+│  hack/ci/ci_run_collector.py                           │
+│  • GitHub Actions REST API                             │
+│  • Workflow runs, jobs, failed steps pagination        │
+└──────────────────────────┬─────────────────────────────┘
+                           │ RunResult / JobResult (JSON)
+┌──────────────────────────▼─────────────────────────────┐
+│  PR 2: Failure Log Retrieval & Normalization           │
+│  hack/ci/ci_log_retriever.py                           │
+│  • ANSI / GHA timestamp / markup stripping             │
+│  • Secret / token / credential redaction               │
+│  • Contextual Ginkgo / BATS / Panic section extraction │
+└──────────────────────────┬─────────────────────────────┘
+                           │ FailureRecord (Normalized JSON)
+┌──────────────────────────▼─────────────────────────────┐
+│  PR 3: Deterministic Failure Classification            │
+│  hack/ci/ci_failure_classifier.py                      │
+│  • 14 Extensible Regex Rules across 12 Categories      │
+│  • Priority resolution & confidence scoring            │
+└──────────────────────────┬─────────────────────────────┘
+                           │ Classified FailureRecord
+             ┌─────────────┴─────────────┐
+             ▼                           ▼
+┌─────────────────────────────┐ ┌─────────────────────────────┐
+│  PR 4: Flake Detection      │ │  PR 5: Agentic Analysis     │
+│  hack/ci/ci_flake_detector  │ │  hack/ci/ci_agentic_analyzer│
+│  • 5-Signal Weighted Model  │ │  • OpenAI/Local LLM API     │
+│  • Commit diversity/Retries │ │  • JSON Schema Validation   │
+│  • Flake score (0.0 to 1.0) │ │  • Safe fallback on no key  │
+└────────────┬────────────────┘ └─────────────┬───────────────┘
+             │ FlakeReport                    │ AgenticAnalysis
+             └─────────────┬──────────────────┘
+                           │
+┌──────────────────────────▼─────────────────────────────┐
+│  PR 6: Reporting & GitHub Integration                  │
+│  hack/ci/ci_reporter.py                                │
+│  • GitHub Step Summary ($GITHUB_STEP_SUMMARY)          │
+│  • Deduplicated GitHub Issues with SHA-256 fingerprint │
+│  • Factual PR triage comments (LLM policy compliant)   │
+└────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. CLI Tooling Reference
+
+All scripts are standalone, use only Python standard library (`urllib`, `json`, `dataclasses`, `re`, `argparse`, `hashlib`), and compose seamlessly via Unix pipes (`|`).
+
+### 1. `ci_run_collector.py`
+Retrieves CI workflow runs and jobs from the GitHub Actions API.
+
+```bash
+# List recent failed CI runs on main branch
+./hack/ci/ci_run_collector.py --branch main --status failure --limit 10
+
+# Inspect a specific workflow run ID
+./hack/ci/ci_run_collector.py --run-id 31813098642
+
+# Output raw structured JSON for downstream piping
+./hack/ci/ci_run_collector.py --branch main --status failure --limit 20 --json
+```
+
+### 2. `ci_log_retriever.py`
+Downloads raw job logs, normalizes them, redacts secrets, and extracts failure sections.
+
+```bash
+# Retrieve and normalize logs for a single run
+./hack/ci/ci_log_retriever.py --run-id 31813098642
+
+# Process runs piped from ci_run_collector
+./hack/ci/ci_run_collector.py --branch main --status failure --limit 5 --json | \
+    ./hack/ci/ci_log_retriever.py --stdin
+```
+
+### 3. `ci_failure_classifier.py`
+Classifies failures into deterministic categories using priority-ordered pattern rules.
+
+```bash
+# Classify failure records from stdin
+./hack/ci/ci_log_retriever.py --run-id 31813098642 | \
+    ./hack/ci/ci_failure_classifier.py --stdin
+
+# Generate human-readable classification summary
+./hack/ci/ci_failure_classifier.py --run-id 31813098642 --summary
+```
+
+### 4. `ci_flake_detector.py`
+Performs multi-signal cross-run analysis to identify intermittent flakes.
+
+```bash
+# Analyze recent failures for flakiness (metadata mode)
+./hack/ci/ci_flake_detector.py --branch main --limit 50 --no-download
+
+# Full analysis pipeline with custom flake threshold
+./hack/ci/ci_flake_detector.py --branch main --limit 30 --threshold 0.50
+```
+
+### 5. `ci_agentic_analyzer.py`
+Optional LLM-assisted root cause analysis with strict JSON schema validation.
+
+```bash
+# Dry run (generate structured prompt without calling LLM)
+./hack/ci/ci_agentic_analyzer.py --run-id 31813098642 --dry-run
+
+# Run with LLM API key
+export CI_LLM_API_KEY="your-api-key"
+export CI_LLM_MODEL="gpt-4o-mini"
+./hack/ci/ci_agentic_analyzer.py --run-id 31813098642
+```
+
+### 6. `ci_reporter.py`
+Formats dashboards, creates deduplicated issues, and posts PR comments.
+
+```bash
+# Generate GitHub Actions Step Summary markdown
+./hack/ci/ci_flake_detector.py --branch main --limit 20 --json | \
+    ./hack/ci/ci_reporter.py --stdin --format step-summary
+
+# Write directly to GitHub Actions Step Summary environment
+./hack/ci/ci_reporter.py --stdin --format step-summary --write-step-summary < records.json
+
+# Post PR triage comment (dry-run mode)
+./hack/ci/ci_reporter.py --stdin --format pr-comment --pr 29279 --dry-run < records.json
+```
+
+---
+
+## 3. End-to-End Pipeline Example
+
+```bash
+# Complete automated pipeline: ingest -> normalize -> classify -> detect flakes -> format step summary
+./hack/ci/ci_run_collector.py --branch main --status failure --limit 30 --json | \
+    ./hack/ci/ci_log_retriever.py --stdin | \
+    ./hack/ci/ci_failure_classifier.py --stdin --json | \
+    ./hack/ci/ci_flake_detector.py --stdin --json | \
+    ./hack/ci/ci_reporter.py --stdin --format step-summary
+```
+
+---
+
+## 4. Failure Categories & Classification Rules
+
+The deterministic classifier uses 14 priority-ordered regex rules mapped across 12 distinct categories:
+
+| Priority | Category | Description | Sample Triggers |
+|---|---|---|---|
+| 100 | `panic` | Go panics, SIGSEGV, SIGABRT crashes | `panic:`, `signal SIGSEGV`, `goroutine N [running]` |
+| 90 | `timeout` | Test or job execution timeout | `exceeded the maximum execution time`, `context deadline exceeded` |
+| 85 | `resource_exhaustion` | OOM, disk space, file descriptors | `Out of Memory`, `No space left on device`, `EMFILE` |
+| 80 | `infrastructure_failure` | Lima VM, runner disconnect | `limactl: failed to start VM`, `runner lost communication` |
+| 70 | `network_error` | DNS, connection refused, TLS handshake | `Temporary failure in name resolution`, `TLS handshake timeout` |
+| 65 | `image_pull_failure` | Registry download, manifest error | `manifest unknown`, `failed to pull image`, `401 Unauthorized` |
+| 60 | `container_runtime_error` | crun/runc namespace/cgroup error | `crun: error creating container`, `OCI runtime error` |
+| 55 | `build_failure` | Go compilation or linker error | `undefined: symbol`, `build failed`, `could not import` |
+| 50 | `dependency_failure` | Package or module download | `dnf: No matching packages`, `go: module not found` |
+| 45 | `permission_error` | Permission or rootless capability | `Permission denied`, `EACCES`, `operation not permitted` |
+| 40 | `test_assertion_failure` | Ginkgo or BATS expectation | `[FAIL]`, `Expected ... to equal`, `not ok N` |
+| 0 | `unknown` | Unmatched pattern | Fallback for unclassified logs |
+
+---
+
+## 5. Multi-Signal Flake Scoring Model
+
+The flake detector computes an overall probability score between `0.0` (deterministic bug) and `1.0` (certain flake):
+
+$$\text{Flake Score} = 0.30 \cdot S_{\text{commits}} + 0.25 \cdot S_{\text{category}} + 0.20 \cdot S_{\text{dates}} + 0.15 \cdot S_{\text{rate}} + 0.10 \cdot S_{\text{retry}}$$
+
+- **Commit Diversity ($S_{\text{commits}}$)**: Same failure appearing across $\ge 5$ distinct commits indicates environmental flakiness.
+- **Category Correlation ($S_{\text{category}}$)**: Network, infra, and timeout failures push score up; pure test assertions push score down.
+- **Temporal Spread ($S_{\text{dates}}$)**: Failures spanning multiple days indicate recurring background flakiness.
+- **Retry Signal ($S_{\text{retry}}$)**: Failures occurring on `run_attempt > 1` where previous attempts were retried by CI.
+- **Default Threshold**: Jobs with score $\ge 0.45$ are flagged as flaky.
+
+---
+
+## 6. Testing & CI Integration
+
+### Running Unit Tests
+
+To run the complete test suite (176 unit tests):
+
+```bash
+# Run unified test suite
+python3 hack/ci/ci_flake_suite_test.py -v
+
+# Or run individual component test suites
+python3 hack/ci/ci_run_collector_test.py -v
+python3 hack/ci/ci_log_retriever_test.py -v
+python3 hack/ci/ci_failure_classifier_test.py -v
+python3 hack/ci/ci_flake_detector_test.py -v
+python3 hack/ci/ci_agentic_analyzer_test.py -v
+python3 hack/ci/ci_reporter_test.py -v
+```
+
+### GitHub Actions Workflow Integration Example
+
+An automated scheduled workflow (`.github/workflows/ci-flake-analyzer.yml`) can run periodically on `main`:
+
+```yaml
+name: CI Flake Analyzer
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  analyze-flakes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Run Flake Analysis & Update Step Summary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./hack/ci/ci_run_collector.py --branch main --status failure --limit 50 --json | \
+            ./hack/ci/ci_log_retriever.py --stdin | \
+            ./hack/ci/ci_failure_classifier.py --stdin --json | \
+            ./hack/ci/ci_flake_detector.py --stdin --json | \
+            ./hack/ci/ci_reporter.py --stdin --format step-summary --write-step-summary
+```


### PR DESCRIPTION
### What does this PR do?
Adds comprehensive documentation in `hack/ci/docs/CI_FLAKE_ANALYSIS.md` and a unified self-test runner `hack/ci/ci_flake_suite_test.py` consolidating all 176 unit tests across the CI flake categorization and analysis suite.

### Why?
Fulfills **Phase 4: Documentation** of **Issue #29265**.

### How?
- **Architecture & Operational Guide**: Documents the complete 6-stage pipeline, Unix piping workflows, CLI options for each tool, failure category definitions, and flake scoring parameters.
- **Workflow Integration**: Includes reference examples for scheduling periodic flake analysis workflows in `.github/workflows/`.
- **Unified Test Runner**: `hack/ci/ci_flake_suite_test.py` runs all unit tests across all modules in 0.008s, registered as a single clean entry in `Makefile` `.check-self-tests`.
