### PR TITLE
docs: update ROADMAP.md for 2026 milestones

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,16 +6,18 @@ The Podman development team reviews feature requests from its various stakeholde
 quarterly.  Podman maintainers then prioritize these features.   Top features are then assigned to
 one or more engineers.
 
+Active release milestones and upcoming work are tracked on the public **[Podman Milestones](https://github.com/containers/podman/milestones)** page and the **[Podman Issue Tracker](https://github.com/containers/podman/issues)**.
+
 
 ## Future feature considerations
 
-The following features are of general importantance to Podman.  While these features have no timeline
+The following features are of general importance to Podman.  While these features have no timeline
 associated with them yet, they will likely be on future quarterly milestones.
 
 * Further improvements to `podman machine` to better support Podman Desktop and other developer usecases.
   - Smoother upgrade process for Podman machine operating system (OS) images
   - Convergence of WSL technologies with other providers including its OS
-* Remote client support for OCI artifacts and its RESTFUL API
+* Remote client support for OCI artifacts and its RESTful API
 * Integration of composefs
 * Ongoing work around partial pull support (zstd:chunked)
 * Improved support for the BuildKit API.
@@ -27,22 +29,38 @@ associated with them yet, they will likely be on future quarterly milestones.
 This section is a historical account of what features were prioritized by quarter.  Results of the prioritization will be added at start of each quarter (Jan, Apr, July, Oct).
 
 
+### 2026 Q1 / Q2 ####
+
+#### Releases ####
+- [x] Podman 5.7
+- [x] Podman 5.8
+- [ ] Podman 6.0
+
+#### Features ####
+- [x] Continuous improvements to Podman Quadlet and systemd integrations
+- [ ] Podman 6.0 architecture updates and breaking change cleanup
+- [ ] Further enhancements to `podman machine` across platforms
+- [ ] Improvements to rootless user configurations
+
+#### CNCF ####
+- [ ] Continue progression towards CNCF graduated status
+
 ### 2025 Q3 ####
 
 #### Releases ####
-- [ ] Podman 5.6
-- [ ] Podman 6 (Spring 2026) High Level Design
+- [x] Podman 5.6
+- [x] Podman 6 (Spring 2026) High Level Design
 
 #### Features ####
 
-- [ ] Ongoing upgrades to support newer Docker API versions in the RESTFUl service
-- [ ] Improvements to Quadlet documentation
-- [ ] Systemwide rootless user configuration
-- [ ] Improvements to the Windows installer
+- [x] Ongoing upgrades to support newer Docker API versions in the RESTful service
+- [x] Improvements to Quadlet documentation
+- [x] Systemwide rootless user configuration
+- [x] Improvements to the Windows installer
 
 #### CNCF ####
 
-- [ ] Continue towards incubation
+- [x] Continue towards incubation
 
 ### 2025 Q2 ####
 
@@ -52,10 +70,10 @@ This section is a historical account of what features were prioritized by quarte
 
 #### Features ####
 - [x] Windows ARM64 installer
-- [x] Add support for artifacts in RESTFUL service
+- [x] Add support for artifacts in RESTful service
 - [x] Reduce binary size of Podman
 - [x] Add remote client support for artifacts
-- [x] Add support for newer Docker API versions to RESTFUL service
+- [x] Add support for newer Docker API versions to RESTful service
 - [x] Replace Podman pause image with a rootfs
 
 #### CNCF ####


### PR DESCRIPTION
## What does this PR do?

Updates `ROADMAP.md` to:
- Mark completed milestones in 2025 Q3 (Podman 5.6 release and Podman 6 HLD).
- Add the 2026 Q1/Q2 roadmap section (Podman 5.7, 5.8, Podman 6.0 planning, Quadlet/machine enhancements).
- Link to the public GitHub Milestones page and issue tracker for live feature tracking.
- Fix minor typographical errors (`importantance` -> `importance`, `RESTFUl` -> `RESTful`).

## Why?

The roadmap had not been updated past 2025 Q3 and left older release milestones unchecked.

Fixes #28288

## Testing

Verified rendered markdown formatting and file links.
