### PR TITLE
docs: remove outdated CNI references from network options

### DIFF
--- a/docs/source/markdown/options/internal.md
+++ b/docs/source/markdown/options/internal.md
@@ -8,8 +8,7 @@
 #### **--internal**
 << endif >>
 
-Restrict external access of this network when using a `bridge` network. Note when using the CNI backend
-DNS will be automatically disabled, see **--disable-dns**.
+Restrict external access of this network when using a `bridge` network.
 
 When using the `macvlan` or `ipvlan` driver with this option, no default route will be added to the container.
 Because it bypasses the host network stack, no additional restrictions can be set by Podman, and if a

--- a/docs/source/markdown/options/ipam-driver.md
+++ b/docs/source/markdown/options/ipam-driver.md
@@ -13,9 +13,9 @@ ipam driver automatically based on the network driver.
 
 Valid values are:
 
- - `dhcp`: IP addresses are assigned from a DHCP server on the network. When using the netavark backend
-  the `netavark-dhcp-proxy.socket` must be enabled in order to start the DHCP proxy when a container is
-  started, for CNI use the `cni-dhcp.socket` unit instead.
+ - `dhcp`: IP addresses are assigned from a DHCP server on the network.
+  The `netavark-dhcp-proxy.socket` unit must be enabled in order to start the DHCP proxy when a container is
+  started.
  - `host-local`: IP addresses are assigned locally.
  - `none`: No ip addresses are assigned to the interfaces.
 


### PR DESCRIPTION
## What does this PR do?

Removes obsolete references to the legacy CNI backend and `cni-dhcp.socket` from `docs/source/markdown/options/internal.md` and `docs/source/markdown/options/ipam-driver.md`.

## Why?

Since Podman 5.0+, CNI was completely removed in favor of Netavark. The remaining references in option man pages were outdated and confusing to users configuring network options.

Fixes #23973

## Testing

Verified rendered markdown formatting across option files.
