### PR TITLE
docs(stats): clarify --no-stream CPU percentage behavior

### DIFF
--- a/docs/source/markdown/options/no-stream.md
+++ b/docs/source/markdown/options/no-stream.md
@@ -4,4 +4,6 @@
 ####> are applicable to all of those.
 #### **--no-stream**
 
-Disable streaming <<|pod >>stats and only pull the first result, default setting is false
+Disable streaming <<|pod >>stats and only pull the first result, default setting is false.
+
+Note: When `--no-stream` is enabled, because only a single sample is captured without a preceding delta interval, the reported `CPU %` reflects the cumulative average CPU utilization over the container's lifetime since it started (or `--` when not available).

--- a/docs/source/markdown/podman-stats.1.md.in
+++ b/docs/source/markdown/podman-stats.1.md.in
@@ -9,7 +9,9 @@ podman\-stats - Display a live stream of one or more container's resource usage 
 **podman container stats** [*options*] [*container*]
 
 ## DESCRIPTION
-Display a live stream of one or more containers' resource usage statistics
+Display a live stream of one or more containers' resource usage statistics.
+
+In streaming mode, `CPU %` reports resource utilization calculated over the latest sampling interval. When streaming is disabled (via `--no-stream`), `CPU %` reflects cumulative average CPU utilization over the container's lifetime since startup.
 
 Note: Rootless environments are not able to report statistics
 about their networking usage.


### PR DESCRIPTION
## What does this PR do?

Clarifies in `docs/source/markdown/podman-stats.1.md.in` and `docs/source/markdown/options/no-stream.md` that when streaming mode is disabled (`--no-stream`), `CPU %` calculates the cumulative average CPU utilization over the container's lifetime since startup (or `--`) due to the absence of a preceding sampling interval.

## Why?

Users were confused when seeing average CPU metrics rather than interval deltas when running single-sample stats queries.

Fixes #25709

## Testing

Verified rendered markdown formatting across option files.
