### PR TITLE
docs(pull): clarify newer pull policy digest comparison behavior

### DIFF
--- a/docs/source/markdown/options/policy.md
+++ b/docs/source/markdown/options/policy.md
@@ -13,4 +13,4 @@ Pull image policy. The default is **always**.
 - `always`: Always pull the image and throw an error if the pull fails.
 - `missing`: Only pull the image if it could not be found in the local containers storage. Throw an error if no image could be found and the pull fails.
 - `never`: Never pull the image; only use the local version. Throw an error if the image is not present locally.
-- `newer`: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
+- `newer`: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the registry manifest digest differs from the local image. Comparing timestamps is prone to errors across registries and local builds. If the registry is unreachable and a local image exists, pull errors are suppressed.

--- a/docs/source/markdown/options/pull.image.md
+++ b/docs/source/markdown/options/pull.image.md
@@ -13,4 +13,4 @@ Pull image policy. The default is **missing**.
 - **always**: Always pull the image and throw an error if the pull fails.
 - **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.
 - **never**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the registry manifest digest differs from the local image.  Comparing timestamps is prone to errors across registries and local builds.  If the registry is unreachable and a local image exists, pull errors are suppressed.

--- a/docs/source/markdown/options/pull.md
+++ b/docs/source/markdown/options/pull.md
@@ -13,4 +13,4 @@ Pull image policy. The default is **missing**.
 - **always**: Always pull the image and throw an error if the pull fails.
 - **missing**: Pull the image only when the image is not in the local containers storage.  Throw an error if no image is found and the pull fails.
 - **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image is found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the registry manifest digest differs from the local image.  Comparing timestamps is prone to errors across registries and local builds.  If the registry is unreachable and a local image exists, pull errors are suppressed.


### PR DESCRIPTION
## What does this PR do?

Clarifies across option documentation (`options/pull.md`, `options/policy.md`, and `options/pull.image.md`) that the `newer` pull policy evaluates whether the registry manifest digest differs from the locally stored image (rather than comparing timestamps, which are prone to inaccuracies across registries and local builds) and suppresses remote pull errors if the local image is present.

## Why?

Users were confused regarding how `newer` handles image comparisons and network fallback.

Fixes #28997

## Testing

Verified rendered markdown formatting across option files.