### PR TITLE
docs(api): document OCI Mount destination field in SpecGenerator

### DIFF
--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -31,6 +31,8 @@ type specGeneratorWire struct {
 
 // CreateContainer takes a specgenerator and makes a container. It returns
 // the new container ID on success along with any warnings.
+// Note: Libpod container creation uses the OCI runtime specification for mounts,
+// which expects "destination" (instead of Docker's "target" parameter).
 func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	conf, err := runtime.GetConfigNoCopy()

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -181,6 +181,8 @@ type PodNetworkConfig struct {
 // PodStorageConfig contains all of the storage related options for the pod and its infra container.
 type PodStorageConfig struct {
 	// Mounts are mounts that will be added to the pod.
+	// These follow the OCI runtime specification (with fields destination, source, type, options).
+	// Note: Use "destination" (not "target") to specify the mount path inside the pod.
 	// These will supersede Image Volumes and VolumesFrom volumes where
 	// there are conflicts.
 	// Optional.

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -294,6 +294,8 @@ type ContainerStorageConfig struct {
 	// Optional.
 	InitPath string `json:"init_path,omitempty"`
 	// Mounts are mounts that will be added to the container.
+	// These follow the OCI runtime specification (with fields destination, source, type, options).
+	// Note: Use "destination" (not "target") to specify the mount path inside the container.
 	// These will supersede Image Volumes and VolumesFrom volumes where
 	// there are conflicts.
 	// Optional.


### PR DESCRIPTION
## What does this PR do?

Documents in `pkg/specgen/specgen.go`, `pkg/specgen/podspecgen.go`, and `pkg/api/handlers/libpod/containers_create.go` that `Mounts` in `SpecGenerator` follows the OCI Runtime Specification (`destination`, `source`, `type`, `options`). It explicitly notes that `destination` must be used instead of Docker's `target` field when interacting with native Libpod container/pod creation endpoints.

## Why?

Users and SDK authors creating containers via `/libpod/containers/create` were passing `target` (from the Docker API) and encountering issues because native Libpod endpoints parse OCI runtime mounts using `destination`.

Fixes #13092

## Testing

Verified Go struct comments and documentation consistency.
