### PR TITLE
Performance: Upgrade filepath.Walk to filepath.WalkDir

### DIFF
--- a/pkg/api/handlers/libpod/quadlets.go
+++ b/pkg/api/handlers/libpod/quadlets.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -100,11 +101,11 @@ func extractQuadletFiles(tempDir string, r io.ReadCloser) ([]string, error) {
 
 	// Collect all files from the extracted directory
 	var filePaths []string
-	err = filepath.Walk(quadletDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(quadletDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
+		if !d.IsDir() {
 			filePaths = append(filePaths, path)
 		}
 		return nil


### PR DESCRIPTION
`filepath.Walk` makes an expensive `os.Stat` system call on every file. `filepath.WalkDir` uses `os.ReadDir` under the hood to bypass this overhead, making directory scanning much faster.

This PR cleans up the last two lingering usages of `filepath.Walk` in the codebase.

Fixes #29562 

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #29562` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
