### PR TITLE
kube: share memory backed emptyDir between containers in a pod

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -608,12 +608,19 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 			}
 			s.Volumes = append(s.Volumes, &emptyDirVolume)
 		case KubeVolumeTypeEmptyDirTmpfs:
-			memVolume := spec.Mount{
-				Destination: volume.MountPath,
-				Type:        define.TypeTmpfs,
-				Source:      define.TypeTmpfs,
+			// A named volume, so the tmpfs is shared by every container in the pod.
+			tmpfsOptions := append(slices.Clone(options), "volume-opt=type="+define.TypeTmpfs)
+			if volumeSource.SizeLimit > 0 {
+				tmpfsOptions = append(tmpfsOptions, fmt.Sprintf("volume-opt=o=size=%d", volumeSource.SizeLimit))
 			}
-			s.Mounts = append(s.Mounts, memVolume)
+			memVolume := specgen.NamedVolume{
+				Dest:        volume.MountPath,
+				Name:        volumeSource.Source,
+				Options:     tmpfsOptions,
+				IsAnonymous: true,
+				SubPath:     volume.SubPath,
+			}
+			s.Volumes = append(s.Volumes, &memVolume)
 		case KubeVolumeTypeImage:
 			imageVolume := specgen.ImageVolume{
 				Destination: volume.MountPath,

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -58,6 +58,8 @@ type KubeVolume struct {
 	DefaultMode int32
 	// Used for volumes of type Image. Ignored for other volumes types.
 	ImagePullPolicy v1.PullPolicy
+	// Size limit in bytes, 0 when unset. Only used for EmptyDirTmpfs.
+	SizeLimit int64
 }
 
 // Create a KubeVolume from an HostPathVolumeSource
@@ -264,10 +266,14 @@ func VolumeFromConfigMap(configMapVolumeSource *v1.ConfigMapVolumeSource, config
 // Create a kubeVolume for an emptyDir volume
 func VolumeFromEmptyDir(emptyDirVolumeSource *v1.EmptyDirVolumeSource, name string) (*KubeVolume, error) {
 	if emptyDirVolumeSource.Medium == v1.StorageMediumMemory {
-		return &KubeVolume{
+		kv := &KubeVolume{
 			Type:   KubeVolumeTypeEmptyDirTmpfs,
 			Source: name,
-		}, nil
+		}
+		if emptyDirVolumeSource.SizeLimit != nil {
+			kv.SizeLimit = emptyDirVolumeSource.SizeLimit.Value()
+		}
+		return kv, nil
 	} else {
 		return &KubeVolume{
 			Type:   KubeVolumeTypeEmptyDir,

--- a/pkg/specgen/generate/kube/volume_test.go
+++ b/pkg/specgen/generate/kube/volume_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestVolumeFromEmptyDir(t *testing.T) {
@@ -21,4 +22,15 @@ func TestVolumeFromEmptyDir(t *testing.T) {
 	memEmptyDirVol, err := VolumeFromEmptyDir(&memEmptyDirSource, "emptydir")
 	assert.NoError(t, err)
 	assert.Equal(t, memEmptyDirVol.Type, KubeVolumeTypeEmptyDirTmpfs)
+	assert.Zero(t, memEmptyDirVol.SizeLimit)
+
+	sizeLimit := resource.MustParse("64Mi")
+	sizedEmptyDirSource := v1.EmptyDirVolumeSource{
+		Medium:    v1.StorageMediumMemory,
+		SizeLimit: &sizeLimit,
+	}
+	sizedEmptyDirVol, err := VolumeFromEmptyDir(&sizedEmptyDirSource, "emptydir")
+	assert.NoError(t, err)
+	assert.Equal(t, sizedEmptyDirVol.Type, KubeVolumeTypeEmptyDirTmpfs)
+	assert.Equal(t, int64(64*1024*1024), sizedEmptyDirVol.SizeLimit)
 }

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -789,7 +789,12 @@ spec:
   {{ range . }}
   - name: {{ .Name }}
     {{- if (eq .VolumeType "EmptyDir") }}
+    {{- if .EmptyDir.Medium }}
+    emptyDir:
+      medium: {{ .EmptyDir.Medium }}
+    {{- else }}
     emptyDir: {}
+    {{- end }}
     {{- end }}
     {{- if (eq .VolumeType "HostPath") }}
     hostPath:
@@ -2190,7 +2195,9 @@ type SecretVol struct {
 	DefaultMode int32
 }
 
-type EmptyDir struct{}
+type EmptyDir struct {
+	Medium string
+}
 
 type Volume struct {
 	VolumeType string
@@ -2268,6 +2275,14 @@ func getEmptyDirVolume() *Volume {
 		VolumeType: "EmptyDir",
 		Name:       defaultVolName,
 		EmptyDir:   EmptyDir{},
+	}
+}
+
+func getMemoryEmptyDirVolume() *Volume {
+	return &Volume{
+		VolumeType: "EmptyDir",
+		Name:       defaultVolName,
+		EmptyDir:   EmptyDir{Medium: "Memory"},
 	}
 }
 
@@ -4465,6 +4480,30 @@ spec:
 		podmanTest.PodmanExitCleanly("pod", "rm", "-f", podName)
 		volList2 := podmanTest.PodmanExitCleanly("volume", "ls", "-q")
 		Expect(volList2.OutputToString()).To(Equal(""))
+	})
+
+	It("with memory backed emptyDir volume shared between containers", func() {
+		podName := "test-pod"
+		ctrName1 := "vol-test-ctr"
+		ctrName2 := "vol-test-ctr-2"
+		ctr1 := getCtr(withVolumeMount("/test-emptydir", "", false), withImage(CITEST_IMAGE), withName(ctrName1))
+		ctr2 := getCtr(withVolumeMount("/test-emptydir", "", false), withImage(CITEST_IMAGE), withName(ctrName2))
+		pod := getPod(withPodName(podName), withVolume(getMemoryEmptyDirVolume()), withCtr(ctr1), withCtr(ctr2))
+		err = generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		podmanTest.PodmanExitCleanly("kube", "play", kubeYaml)
+
+		fsType := podmanTest.PodmanExitCleanly("exec", podName+"-"+ctrName1, "stat", "-f", "-c", "%T", "/test-emptydir")
+		Expect(fsType.OutputToString()).To(Equal("tmpfs"))
+
+		podmanTest.PodmanExitCleanly("exec", podName+"-"+ctrName1, "sh", "-c", "echo shared-data > /test-emptydir/file")
+		data := podmanTest.PodmanExitCleanly("exec", podName+"-"+ctrName2, "cat", "/test-emptydir/file")
+		Expect(data.OutputToString()).To(Equal("shared-data"))
+
+		podmanTest.PodmanExitCleanly("pod", "rm", "-f", podName)
+		volList := podmanTest.PodmanExitCleanly("volume", "ls", "-q")
+		Expect(volList.OutputToString()).To(Equal(""))
 	})
 
 	It("applies labels to pods", func() {


### PR DESCRIPTION
An emptyDir with `medium: Memory` was turned into a per-container tmpfs mount, so every container in the pod got its own empty filesystem. Anything an init container wrote was gone by the time the regular container looked at it, even though the mount did show up as tmpfs. Kubernetes says an emptyDir is shared by all containers in the pod.

Plain emptyDirs already behave correctly because they become anonymous named volumes, which the whole pod shares. This makes the memory backed case take the same path, with `volume-opt=type=tmpfs` so it stays on tmpfs. The local volume driver already understands that option, and it fills in the device from the type. `sizeLimit` was being dropped on the floor, it now goes through as the tmpfs `size` option.

This is smaller than what the reporter suggested in the issue (a pod scoped volume kept mounted by the infra container). Reusing the existing named volume path looks like it is enough, but I would rather be told if I am missing a reason it is not.

Testing: added an e2e case where two containers share one memory emptyDir, one writes and the other reads it back, and it also checks the mount is still tmpfs. Extended the existing unit test for the sizeLimit plumbing. I could not run the e2e suite locally since I do not have a Linux podman runtime here, so that part is only compiled and vetted and CI will be the first real run. Unit tests, `go vet ./test/e2e/` and `golangci-lint` (2.12.2, the version pinned in the Makefile) are clean.

Fixes: #29555

#### Checklist

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a `podman kube play` emptyDir volume with `medium: Memory` was not shared between the containers in a pod, and its `sizeLimit` was ignored.
```
