### PR TITLE
fix(exec): honor empty detach-keys on remote exec create

### DIFF
--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -53,7 +53,7 @@ func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 	libpodConfig.AttachStdin = input.AttachStdin
 	libpodConfig.AttachStderr = input.AttachStderr
 	libpodConfig.AttachStdout = input.AttachStdout
-	if input.DetachKeys != "" {
+	if input.DetachKeysSet {
 		libpodConfig.DetachKeys = &input.DetachKeys
 	}
 	libpodConfig.Environment = make(map[string]string)

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"encoding/json"
+
 	build "github.com/moby/moby/api/types/build"
 	dockerContainer "github.com/moby/moby/api/types/container"
 	dockerImage "github.com/moby/moby/api/types/image"
@@ -237,6 +239,21 @@ type HistoryResponse struct {
 
 type ExecCreateConfig struct {
 	dockerContainer.ExecCreateRequest
+	DetachKeysSet bool `json:"-"`
+}
+
+func (e *ExecCreateConfig) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &e.ExecCreateRequest); err != nil {
+		return err
+	}
+	if _, ok := raw["DetachKeys"]; ok {
+		e.DetachKeysSet = true
+	}
+	return nil
 }
 
 type ExecStartConfig struct {

--- a/pkg/api/handlers/types_exec_test.go
+++ b/pkg/api/handlers/types_exec_test.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecCreateConfigUnmarshalDetachKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("omitted detach keys", func(t *testing.T) {
+		t.Parallel()
+
+		var cfg ExecCreateConfig
+		err := json.Unmarshal([]byte(`{"Cmd":["echo"]}`), &cfg)
+		require.NoError(t, err)
+		assert.False(t, cfg.DetachKeysSet)
+		assert.Empty(t, cfg.DetachKeys)
+	})
+
+	t.Run("empty detach keys disables detaching", func(t *testing.T) {
+		t.Parallel()
+
+		var cfg ExecCreateConfig
+		err := json.Unmarshal([]byte(`{"Cmd":["echo"],"DetachKeys":""}`), &cfg)
+		require.NoError(t, err)
+		assert.True(t, cfg.DetachKeysSet)
+		assert.Empty(t, cfg.DetachKeys)
+	})
+
+	t.Run("custom detach keys", func(t *testing.T) {
+		t.Parallel()
+
+		var cfg ExecCreateConfig
+		err := json.Unmarshal([]byte(`{"Cmd":["echo"],"DetachKeys":"ctrl-a"}`), &cfg)
+		require.NoError(t, err)
+		assert.True(t, cfg.DetachKeysSet)
+		assert.Equal(t, "ctrl-a", cfg.DetachKeys)
+	})
+}


### PR DESCRIPTION
Fixes #28193

`podman run` already handles `--detach-keys ""` correctly, but remote `podman exec` still fell back to the default detach sequence.

The exec create handler only forwarded DetachKeys when the value was non-empty, so an explicit empty string was ignored.

This tracks whether DetachKeys was present in the exec create JSON and forwards it either way. Includes a small unmarshaller test.

Signed-off-by: Pranjal Manhgaye <manhgayepranjal@gmail.com>