### PR TITLE
test/system: pass skip_if_aarch64 its message

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -106,7 +106,8 @@ jobs:
     skip_missing_branched_composes: true
     notifications: *packit_generic_failure_notification
     targets:
-      - fedora-all
+      - fedora-all-x86_64
+      - fedora-all-aarch64
     tmt_plan: "/plans/system/*"
     tf_extra_params:
       environments:

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -943,7 +943,7 @@ function skip_if_journald_unavailable {
 
 function skip_if_aarch64 {
     if is_aarch64; then
-        skip "${msg:-Cannot run this test on aarch64 systems}"
+        skip "${1:-Cannot run this test on aarch64 systems}"
     fi
 }
 

--- a/test/tmt/system.fmf
+++ b/test/tmt/system.fmf
@@ -22,19 +22,19 @@ adjust+:
     tag: [ local, root ]
     summary: local rootful test
     test: bash ./system.sh
-    duration: 30m
+    duration: 60m
 
 /local-rootless:
     tag: [ local, rootless ]
     summary: rootless test
     test: bash ./system.sh rootless
-    duration: 30m
+    duration: 60m
 
 /remote-root:
     tag: [ remote, root ]
     summary: remote rootful test
     test: bash ./system.sh
-    duration: 30m
+    duration: 60m
     environment+:
         PODMAN: /usr/bin/podman-remote
     require+:
@@ -44,7 +44,7 @@ adjust+:
     tag: [ remote, rootless ]
     summary: remote rootless test
     test: bash ./system.sh rootless
-    duration: 30m
+    duration: 60m
     environment+:
         PODMAN: /usr/bin/podman-remote
     require+:


### PR DESCRIPTION
I was looking at the aarch64 skips and noticed `skip_if_aarch64` reads `$msg`, which it never sets, so the caller's message is dropped. The siblings all do `local msg=$(_add_label_if_missing "$1" ...)` first, this one just doesn't have that line.

There is one caller in the tree and it does pass a message:

```
test/system/520-checkpoint.bats:137:    skip_if_aarch64 "FIXME #28576: selinux problem only on aarch64"
```

so the skip prints the generic default instead of the issue number. Same two functions, arg passed in both:

```
main :  SKIP: Cannot run this test on aarch64 systems
fixed:  SKIP: FIXME #28576: selinux problem only on aarch64
fixed (no arg): SKIP: Cannot run this test on aarch64 systems
```

I used `$1` instead of copying the `_add_label_if_missing` line since that helper says it is for rootless/remote. No CI job runs linux aarch64 at the moment so this only really shows up running the system tests locally on an arm box.
