### PR TITLE
compat/secrets: do not expose secret data on inspect endpoint

### DIFF
--- a/pkg/api/handlers/compat/secrets.go
+++ b/pkg/api/handlers/compat/secrets.go
@@ -68,7 +68,7 @@ func InspectSecret(w http.ResponseWriter, r *http.Request) {
 	}
 	ic := abi.ContainerEngine{Libpod: runtime}
 	opts := entities.SecretInspectOptions{}
-	opts.ShowSecret = query.ShowSecret
+	opts.ShowSecret = query.ShowSecret && utils.IsLibpodRequest(r)
 
 	reports, errs, err := ic.SecretInspect(r.Context(), names, opts)
 	if err != nil {

--- a/test/apiv2/50-secrets.at
+++ b/test/apiv2/50-secrets.at
@@ -84,3 +84,17 @@ t GET /secrets/foosecret 200 \
     .Spec.Name=foosecret
 
 t DELETE /secrets/foosecret 204
+
+# showsecret=true
+t POST /secrets/create Name=hiddensecret Data=c2VjcmV0 200
+t GET /secrets/hiddensecret?showsecret=true 200 \
+    .Spec.Name=hiddensecret \
+    .SecretData=null
+t DELETE /secrets/hiddensecret 204
+
+# libpod endpoint keeps the old behavior
+t POST secrets/create Name=libpodsecret Data=c2VjcmV0 200
+t GET libpod/secrets/libpodsecret/json?showsecret=true 200 \
+    .Spec.Name=libpodsecret \
+    .SecretData=secret
+t DELETE libpod/secrets/libpodsecret 204


### PR DESCRIPTION
The Docker-compat secret inspect endpoint was incorrectly honoring the
ShowSecret query parameter, which could expose plaintext secret data
to clients using the Docker-compatible API.

This fix restricts ShowSecret to libpod-only requests. Docker-compat
clients always receive redacted secret data, matching Docker's own behavior.

Fixes: #29570
