### PR TITLE
pkg/api/server: document missing manifest push and create params

### DIFF
--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -70,6 +70,14 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    items:
 	//      type: string
 	//  - in: query
+	//    name: compressionFormat
+	//    type: string
+	//    description: Compression format used to compress image layers.
+	//  - in: query
+	//    name: compressionLevel
+	//    type: integer
+	//    description: Compression level used to compress image layers.
+	//  - in: query
 	//    name: forceCompressionFormat
 	//    description: Enforce compressing the layers with the specified --compression and do not reuse differently compressed blobs on the registry.
 	//    type: boolean
@@ -84,6 +92,14 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    description: push all images
 	//    type: boolean
 	//    default: true
+	//  - in: query
+	//    name: format
+	//    type: string
+	//    description: Manifest type (oci, v2s1, or v2s2) to use when pushing an image. Default is manifest type of source, with fallbacks.
+	//  - in: query
+	//    name: removeSignatures
+	//    type: boolean
+	//    description: Discard any pre-existing signatures in the image.
 	//  - in: query
 	//    name: tlsVerify
 	//    type: boolean
@@ -142,6 +158,17 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   name: amend
 	//   type: boolean
 	//   description: modify an existing list if one with the desired name already exists
+	// - in: query
+	//   name: annotation
+	//   type: array
+	//   items:
+	//     type: string
+	//   description: |
+	//     Annotation to set on the manifest list, in key=value format. Repeat parameter as needed.
+	// - in: query
+	//   name: annotations
+	//   type: string
+	//   description: JSON encoded map[string]string of annotations to set on the manifest list
 	// - in: body
 	//   name: options
 	//   description: options for new manifest


### PR DESCRIPTION
The `ManifestPushLibpod` and `ManifestCreateLibpod` swagger operations omit six
query parameters that their handlers decode in
`pkg/api/handlers/libpod/manifests.go`.

`POST /libpod/manifests/{name}/registry/{destination}` documented 7 of the 11
query parameters it decodes, missing `compressionFormat`, `compressionLevel`,
`format` and `removeSignatures`. `POST /libpod/manifests/{name}` was missing
`annotation` and `annotations`.

This adds them so the generated API docs and clients match what the endpoints
actually accept. The four push descriptions mirror the identical parameters on
`ImagePushLibpod` in `register_images.go`. The deprecated v3 push and add
endpoints are left unchanged.

Comment-only change inside a `.go` file, so `pr-should-include-tests` will fail
and needs the `No New Tests` label.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
