### PR TITLE
test: synchronize SHM lock test

### DIFF
--- a/libpod/lock/shm/shm_lock_test.go
+++ b/libpod/lock/shm/shm_lock_test.go
@@ -245,11 +245,14 @@ func TestLockSemaphoreActuallyLocks(t *testing.T) {
 		// Get the current time
 		startTime := time.Now()
 
+		lockAcquired := make(chan struct{})
+
 		// Start a goroutine to take the lock and then release it after
 		// a second.
 		go func() {
 			err := locks.LockSemaphore(0)
 			assert.NoError(t, err)
+			close(lockAcquired)
 
 			time.Sleep(1 * time.Second)
 
@@ -257,9 +260,8 @@ func TestLockSemaphoreActuallyLocks(t *testing.T) {
 			assert.NoError(t, err)
 		}()
 
-		// Sleep for a quarter of a second to give the goroutine time
-		// to kick off and grab the lock
-		time.Sleep(250 * time.Millisecond)
+		// Wait until the goroutine has acquired the lock.
+		<-lockAcquired
 
 		// Take the lock
 		err := locks.LockSemaphore(0)


### PR DESCRIPTION
## Checklist

* [x] I have read and understood the contributing guidelines and will not have more than two open PRs as a new contributor.
* [x] PR description, commit message, and GitHub comments are human-written, per the LLM Policy.
* [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). The author email matches the sign-off email address.
* [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable).
* [x] Tests have been updated.
* [x] Documentation changes are not needed.
* [ ] All commits pass `make validatepr`.
* [x] Release note entered below as `None` because this change has no user-facing impact.

## What does this PR do?

Replaces the fixed 250ms sleep used to synchronize `TestLockSemaphoreActuallyLocks` with channel-based synchronization.

The test now waits until the goroutine has successfully acquired the semaphore before attempting to acquire the same semaphore from the main test goroutine.

## Why?

The previous test relied on a fixed time delay to assume that the goroutine had acquired the semaphore. This introduces a timing dependency that can be sensitive to scheduling conditions, particularly in slower or loaded CI environments.

The new synchronization waits for the actual semaphore acquisition instead of relying on an arbitrary delay.

The existing one-second lock-holding delay and elapsed-time assertion are unchanged.

## Testing

`git diff --check` passes.

Local Go tests and `make validatepr` have not been run because Go is not installed in the current development environment.

## Does this PR introduce a user-facing change?

None.

```release-note
None
```
