### PR TITLE
test/e2e: skip terminated build prune test for remote

### DIFF
--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -607,6 +607,9 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune --build clean up after terminated build", func() {
+		// In remote tests SIGKILL targets podman-remote, while the server-side build may continue.
+		SkipIfRemote("SIGKILL only terminates the podman-remote client, not the server-side build")
+
 		useCustomNetworkDir(podmanTest, tempdir)
 
 		podmanTest.BuildImage(pruneImage, "alpine_notleaker:latest", "false")


### PR DESCRIPTION
## Summary

Related to #28868.

The terminated-build prune test sends `SIGKILL` to the process running the build. In remote tests, that process is `podman-remote`, so killing it terminates the client while the server-side build may continue.

As a result, the remote version of this test does not exercise the same scenario as the local test, where `SIGKILL` terminates the actual build process.

## Changes

Skip `podman system prune --build clean up after terminated build` for remote runs using `SkipIfRemote()`.

The existing local coverage is unchanged.

This change is intentionally limited to the test behavior. It does not attempt to fix server-side build cancellation. The related prune race was handled separately in #29279, while remote build cancellation is being worked on in `containers/buildah#7007`.

## Validation

- `git diff --check`
- Successfully compiled the Linux ARM64 E2E test package with:

  ```console
  GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -c -tags containers_image_openpgp ./test/e2e -o /tmp/podman-e2e.test