### PR TITLE
libpod: flush HTTP attach buffer before closing connection

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -151,6 +151,14 @@ func hijackWriteError(toWrite error, cid string, terminal bool, httpBuf *bufio.R
 func hijackWriteErrorAndClose(toWrite error, cid string, terminal bool, httpCon io.Closer, httpBuf *bufio.ReadWriter) {
 	hijackWriteError(toWrite, cid, terminal, httpBuf)
 
+	// Flush any remaining buffered output before closing. Without this, a
+	// full Close() on the underlying connection can send a TCP RST which
+	// causes the remote client to discard data still in its receive buffer,
+	// resulting in truncated or missing output.
+	if err := httpBuf.Flush(); err != nil {
+		logrus.Errorf("Flushing HTTP attach buffer for container %s: %v", cid, err)
+	}
+
 	if err := httpCon.Close(); err != nil {
 		logrus.Errorf("Closing container %s HTTP attach connection: %v", cid, err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

## Description
This PR addresses a race condition in the server-side connection teardown for podman-remote exec.

For fast-executing commands, the server sometimes completes the httpCon.Close() before the bufio.ReadWriter finishes flushing to the network. This causes the kernel to send a TCP RST instead of a graceful FIN, which forces the remote client to drop data still sitting in its receive buffer.

Adding an explicit httpBuf.Flush() in hijackWriteErrorAndClose() ensures all output has left the Go buffer before the socket is torn down, preventing the truncated/missing output flake described in #25855.

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a race condition that could cause podman-remote exec to randomly drop terminal output for short-lived commands.
```
