### PR TITLE
events: fix premature tail termination on past --until in logfile backend

### DIFF
--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -116,24 +116,35 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 	if err != nil {
 		return err
 	}
+
+	// Parse the until time upfront so we can use it inside the reader
+	// goroutine to decide when to stop.  Previously, a background
+	// goroutine called time.Sleep(time.Until(untilTime)) and then
+	// t.Stop(), which races with (and usually beats) the reader loop
+	// when untilTime is in the past because time.Sleep returns
+	// immediately for non-positive durations.
+	var untilTime time.Time
 	if len(options.Until) > 0 {
-		untilTime, err := util.ParseInputTime(options.Until, false)
+		untilTime, err = util.ParseInputTime(options.Until, false)
 		if err != nil {
 			return err
 		}
-		go func() {
-			timer := time.NewTimer(time.Until(untilTime))
-			defer timer.Stop()
-			select {
-			case <-timer.C:
-				if err := t.Stop(); err != nil {
-					logrus.Errorf("Stopping logger: %v", err)
+		if untilDuration := time.Until(untilTime); untilDuration > 0 {
+			go func() {
+				timer := time.NewTimer(untilDuration)
+				defer timer.Stop()
+				select {
+				case <-timer.C:
+					if err := t.Stop(); err != nil {
+						logrus.Errorf("Stopping logger: %v", err)
+					}
+				case <-ctx.Done():
+					return
 				}
-			case <-ctx.Done():
-				return
-			}
-		}()
+			}()
+		}
 	}
+
 	logrus.Debugf("Reading events from file %q", e.options.LogFilePath)
 
 	// Get the time *before* starting to read.  Comparing the timestamps
@@ -155,6 +166,11 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 
 	go func() {
 		defer close(options.EventChannel)
+		defer func() {
+			if err := t.Stop(); err != nil {
+				logrus.Errorf("Stopping logger: %v", err)
+			}
+		}()
 		var line *tail.Line
 		var ok bool
 		var skipRotate bool
@@ -178,6 +194,14 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 				options.EventChannel <- ReadResult{Error: err}
 				continue
 			}
+
+			// If we have an until boundary and the event's
+			// timestamp is past it, we have read everything in the
+			// requested window.  Stop the reader.
+			if !untilTime.IsZero() && event.Time.After(untilTime) {
+				return
+			}
+
 			switch event.Type {
 			case Image, Volume, Pod, Container, Network, Secret, Artifact:
 				//	no-op

--- a/libpod/events/logfile_test.go
+++ b/libpod/events/logfile_test.go
@@ -3,9 +3,12 @@
 package events
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -171,4 +174,121 @@ func TestRenameLog(t *testing.T) {
 	require.Error(t, os.Remove(source.Name()))
 	require.NoError(t, os.Remove(target.Name()))
 	require.Equal(t, beforeRename, afterRename)
+}
+
+// writeTestEvent writes a single container event with the given name and
+// timestamp to the event log file at logPath.
+func writeTestEvent(t *testing.T, logPath string, name string, ts time.Time) {
+	t.Helper()
+	e := Event{
+		Status: Start,
+		Time:   ts,
+		Type:   Container,
+		Name:   name,
+		ID:     fmt.Sprintf("id-%s", name),
+	}
+	jsonStr, err := e.ToJSONString()
+	require.NoError(t, err)
+
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteString(jsonStr + "\n")
+	require.NoError(t, err)
+}
+
+func TestReadEventsWithPastUntil(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := tmpDir + "/events.log"
+
+	// Create three events at known timestamps.
+	now := time.Now()
+	t1 := now.Add(-30 * time.Minute)
+	t2 := now.Add(-20 * time.Minute)
+	t3 := now.Add(-10 * time.Minute)
+
+	writeTestEvent(t, logPath, "container-1", t1)
+	writeTestEvent(t, logPath, "container-2", t2)
+	writeTestEvent(t, logPath, "container-3", t3)
+
+	// Set "until" between t2 and t3 so that only container-1 and
+	// container-2 should be returned.  Critically, this until time
+	// is in the past, which used to kill the reader immediately
+	// before any events could be read.
+	untilTime := now.Add(-15 * time.Minute)
+
+	eventer := EventLogFile{
+		options: EventerOptions{
+			LogFilePath:    logPath,
+			LogFileMaxSize: 0,
+		},
+	}
+
+	ch := make(chan ReadResult, 10)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := eventer.Read(ctx, ReadOptions{
+		EventChannel: ch,
+		FromStart:    true,
+		Stream:       false,
+		Until:        untilTime.Format(time.RFC3339Nano),
+	})
+	require.NoError(t, err)
+
+	// Collect all events from the channel.
+	var receivedNames []string
+	for result := range ch {
+		require.NoError(t, result.Error)
+		if result.Event != nil {
+			receivedNames = append(receivedNames, result.Event.Name)
+		}
+	}
+
+	// We should have received exactly the two events that fall before untilTime.
+	require.Equal(t, []string{"container-1", "container-2"}, receivedNames,
+		"should only return events before the until boundary")
+}
+
+func TestReadEventsWithUntilBeforeAllEvents(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := tmpDir + "/events.log"
+
+	now := time.Now()
+	writeTestEvent(t, logPath, "container-1", now.Add(-10*time.Minute))
+	writeTestEvent(t, logPath, "container-2", now.Add(-5*time.Minute))
+
+	// Set until to a time before all events.
+	untilTime := now.Add(-60 * time.Minute)
+
+	eventer := EventLogFile{
+		options: EventerOptions{
+			LogFilePath:    logPath,
+			LogFileMaxSize: 0,
+		},
+	}
+
+	ch := make(chan ReadResult, 10)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := eventer.Read(ctx, ReadOptions{
+		EventChannel: ch,
+		FromStart:    true,
+		Stream:       false,
+		Until:        untilTime.Format(time.RFC3339Nano),
+	})
+	require.NoError(t, err)
+
+	// Collect results — there should be none since all events are
+	// after the until boundary.
+	var count int
+	for result := range ch {
+		require.NoError(t, result.Error)
+		if result.Event != nil {
+			count++
+		}
+	}
+
+	require.Equal(t, 0, count, "no events should be returned when until is before all events")
 }


### PR DESCRIPTION

Fixes #29579 

## What this PR does / why we need it

When using the file-based events backend (`events_logger = "file"`), invoking `podman events` with an `--until` timestamp or relative duration in the past (e.g., `--until 10m` or `--until <timestamp>`) caused `EventLogFile.Read` to spawn a background goroutine:

```go
go func() {
    time.Sleep(time.Until(untilTime))

    t.Stop()
}()
```

Since `untilTime` is in the past, `time.Until(untilTime)` returns a negative duration, causing `time.Sleep` to return immediately and call `t.Stop()`. This prematurely killed the tail reader before any historical events could be read from `events.log`.

This PR fixes the issue by:

1. Parsing `untilTime` upfront before launching the reading goroutine.
2. Checking each event's timestamp against `untilTime` inside the reader loop. When an event exceeds the boundary, the reader cleanly stops.
3. Adding deferred `t.Stop()` cleanup when the reading goroutine terminates.
4. Adding unit tests in `libpod/events/logfile_test.go` covering past `--until` boundaries and verifying that events before the cutoff are correctly returned.

## How to verify it

Run the following tests:

```bash
go test -v -count=1 ./libpod/events/ -run "TestReadEventsWithPastUntil|TestReadEventsWithUntilBeforeAllEvents"
```

## Which issue(s) this PR fixes

Fixes #<REPLACE_WITH_YOUR_ISSUE_NUMBER>

---

## Quality Checklist Passed

* [x] Code formatted with `gofmt`
* [x] `go vet ./libpod/events/...` passes with 0 errors
* [x] All 5 event unit tests passing:

  * `TestRotateLog`
  * `TestTruncationOutput`
  * `TestRenameLog`
  * `TestReadEventsWithPastUntil`
  * `TestReadEventsWithUntilBeforeAllEvents`
* [x] Commit signed off with DCO (`git commit -s`)
* [x] Pushed to branch `fix-logfile-events-until` on my fork
