### PR TITLE
pkg/bindings/generator: use TrimSuffix to strip the .go extension

### DIFF
--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -86,7 +86,7 @@ func main() {
 		imports = append(imports, imp.Path.Value)
 	}
 
-	out, err := os.Create(strings.TrimRight(srcFile, ".go") + "_" + strings.Replace(strings.ToLower(inputStructName), "options", "_options", 1) + ".go")
+	out, err := os.Create(strings.TrimSuffix(srcFile, ".go") + "_" + strings.Replace(strings.ToLower(inputStructName), "options", "_options", 1) + ".go")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->


The generated bindings filename was built with `strings.TrimRight(srcFile, ".go")`,
which treats `".go"` as a cutset and strips any trailing run of `.`, `g`, `o`
characters rather than the `.go` suffix. Every current `//go:generate` caller
passes `types.go` (trimmed to `types` either way) so today's output is correct,
but a directive in a file whose base name ends in `g`, `o` or `.` — e.g.
`config.go` → `confi`, `info.go` → `inf` — would silently generate a wrong
filename. Switches to `strings.TrimSuffix`, which removes exactly the suffix.


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
