### PR TITLE
contrib/packit-tmt: handle missing testing-farm repo

### DIFF
--- a/contrib/packit-tmt/update-deps.sh
+++ b/contrib/packit-tmt/update-deps.sh
@@ -2,6 +2,11 @@
 
 set -exo pipefail
 
+DISABLE_REPO=()
+if grep -s -r -q -F '[testing-farm-tag-repository]' /etc/yum.repos.d 2>/dev/null; then
+    DISABLE_REPO=(--disable-repo=testing-farm-tag-repository)
+fi
+
 # This should work even when podman-next isn't installed. It'll fetch the
 # highest versions available across all repos.
-dnf -y upgrade --allowerasing --disable-repo=testing-farm-tag-repository --exclude=podman*
+dnf -y upgrade --allowerasing "${DISABLE_REPO[@]}" --exclude=podman*


### PR DESCRIPTION
Fixes a failure in `contrib/packit-tmt/update-deps.sh` when `testing-farm-tag-repository` is not created by Testing Farm.

Testing Farm may skip creating the repository when its reachability check fails. In that case, passing `--disable-repo=testing-farm-tag-repository` to `dnf` causes the dependency upgrade to fail.

This change checks whether the repository definition exists before passing the `--disable-repo` option. The existing behavior is preserved when the repository is present.

Fixes: #28452

#### Checklist

- [x] I have read and understood our contributing guidelines and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per LLM Policy.
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits.
- [x] Referenced issues using `Fixes: #28452` in commit message.
- [x] Tests have been added/updated (or no tests are needed).
- [x] Documentation has been updated (or no documentation changes are needed).
- [ ] All commits pass `make validatepr` (format/lint checks).
- [x] Release note: None.

#### Does this PR introduce a user-facing change?

```release-note
None