### PR TITLE
pkg/machine/hyperv: detach 9p server from parent console

### DIFF
--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"syscall"
 
 	"github.com/Microsoft/go-winio"
 	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
@@ -25,6 +26,7 @@ import (
 	"go.podman.io/podman/v6/pkg/machine/vmconfigs"
 	"go.podman.io/podman/v6/pkg/machine/windows"
 	"go.podman.io/podman/v6/pkg/systemd/parser"
+	syswindows "golang.org/x/sys/windows"
 )
 
 type HyperVStubber struct {
@@ -271,6 +273,12 @@ func (h HyperVStubber) MountVolumesToVM(mc *vmconfigs.MachineConfig, _ bool) err
 	logrus.Debugf("Going to start 9p server using command: %s %v", executable, p9ServerArgs)
 
 	fsCmd := exec.Command(executable, p9ServerArgs...)
+	// Set SysProcAttr CREATE_NO_WINDOW or
+	// the server9p process will be killed
+	// when the parent window is closed
+	fsCmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syswindows.CREATE_NO_WINDOW,
+	}
 
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		log, err := logCommandToFile(fsCmd, "podman-machine-server9.log")

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -22,6 +22,7 @@ import (
 	"go.podman.io/podman/v6/pkg/machine/env"
 	"go.podman.io/podman/v6/pkg/machine/sockets"
 	"go.podman.io/storage/pkg/fileutils"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -170,6 +171,9 @@ func launchWinProxy(opts WinProxyOpts) (bool, string, error) {
 	args = append(args, hostURL.String(), dest, opts.IdentityPath)
 
 	cmd := exec.Command(command, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS,
+	}
 	logrus.Debugf("winssh command: %s %v", command, args)
 	if err := cmd.Start(); err != nil {
 		return globalName, "", err

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -81,6 +81,7 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 	}
 
 	c := cmd.Cmd(binary)
+	setGvproxyProcessAttributes(c)
 
 	logrus.Debugf("gvproxy command-line: %s %s", binary, strings.Join(cmd.ToCmdline(), " "))
 	if err := c.Start(); err != nil {

--- a/pkg/machine/shim/networking_unix.go
+++ b/pkg/machine/shim/networking_unix.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,8 @@ import (
 	"go.podman.io/podman/v6/pkg/machine/define"
 	"go.podman.io/podman/v6/pkg/machine/vmconfigs"
 )
+
+func setGvproxyProcessAttributes(_ *exec.Cmd) {}
 
 func setupMachineSockets(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) ([]string, string, machine.APIForwardingState, error) {
 	hostSocket, err := mc.APISocket()

--- a/pkg/machine/shim/networking_windows.go
+++ b/pkg/machine/shim/networking_windows.go
@@ -2,13 +2,28 @@ package shim
 
 import (
 	"fmt"
+	"os/exec"
+	"syscall"
 
 	"go.podman.io/podman/v6/pkg/machine"
 	"go.podman.io/podman/v6/pkg/machine/define"
 	"go.podman.io/podman/v6/pkg/machine/env"
 	sc "go.podman.io/podman/v6/pkg/machine/sockets"
 	"go.podman.io/podman/v6/pkg/machine/vmconfigs"
+	"golang.org/x/sys/windows"
 )
+
+func setGvproxyProcessAttributes(c *exec.Cmd) {
+	// Set SysProcAttr DETACHED_PROCESS or the gvproxy process may be killed
+	// when the parent window is closed.
+	// This should not happen because gvproxy is built as a Windows GUI application
+	// and doesn't inherit the parent console. But a console version of gvproxy is
+	// also available, and using DETACHED_PROCESS makes sure that the behavior
+	// is the same nevertheless.
+	c.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS,
+	}
+}
 
 func setupMachineSockets(mc *vmconfigs.MachineConfig, _ *define.MachineDirs) ([]string, string, machine.APIForwardingState, error) {
 	machinePipe := env.WithPodmanPrefix(mc.Name)


### PR DESCRIPTION
<!--
Thank you for contributing to Podman!
-->

### Description

On Windows, when starting a Hyper-V machine in CMD.EXE or PowerShell, the background 9p server (`podman.exe machine server9p`) was started without detached process creation flags. Because `podman.exe` is a console subsystem application, Windows automatically attached it to the caller's console session. Closing the CMD.EXE/PowerShell window sent a console close event and terminated the 9p server process, causing 9p volume mounts (such as `/etc/containers`) in the VM to fail with input/output errors.

This change:
1. Configures `SysProcAttr` with `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS` on the 9p server command so it runs detached from the terminal session.
2. Decouples standard handles by redirecting `Stdin`, `Stdout`, and `Stderr` to `os.DevNull` (when debug file logging is not enabled) to prevent terminal sessions from hanging on exit due to open console handles.

Fixes: #29573

### Checklist

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue on Windows where closing the terminal session used to start a Hyper-V machine would terminate the 9p volume server.