### PR TITLE
pkg/api/server: drop duplicate generate/kube swagger operation

### DIFF
--- a/pkg/api/server/register_generate.go
+++ b/pkg/api/server/register_generate.go
@@ -119,38 +119,5 @@ func (s *APIServer) registerGenerateHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/internalError"
 	r.HandleFunc(VersionedPath("/libpod/generate/{name:.*}/systemd"), s.APIHandler(libpod.GenerateSystemd)).Methods(http.MethodGet)
-
-	// swagger:operation GET /libpod/generate/kube libpod GenerateKubeLibpod
-	// ---
-	// tags:
-	//  - containers
-	//  - pods
-	// summary: Generate a Kubernetes YAML file.
-	// description: Generate Kubernetes YAML based on a pod or container.
-	// parameters:
-	//  - in: query
-	//    name: names
-	//    type: array
-	//    items:
-	//       type: string
-	//    required: true
-	//    description: Name or ID of the container or pod.
-	//  - in: query
-	//    name: service
-	//    type: boolean
-	//    default: false
-	//    description: Generate YAML for a Kubernetes service object.
-	// produces:
-	// - text/vnd.yaml
-	// - application/json
-	// responses:
-	//   200:
-	//     description: Kubernetes YAML file describing pod
-	//     schema:
-	//      type: string
-	//      format: binary
-	//   500:
-	//     $ref: "#/responses/internalError"
-	r.HandleFunc(VersionedPath("/libpod/generate/kube"), s.APIHandler(libpod.GenerateKube)).Methods(http.MethodGet)
 	return nil
 }


### PR DESCRIPTION
GET /libpod/generate/kube is registered twice, in register_generate.go and
register_kube.go, both with the same GenerateKubeLibpod operation id. The
register_generate.go copy hasn't been updated since 2022 and documents only
2 of the 6 parameters the handler reads.

This removes the stale copy. The route stays registered in register_kube.go
with the same handler, so nothing changes at runtime.

No new tests since this only removes a duplicate, and the endpoint is already
covered by test/apiv2/80-kube.at. pr-should-include-tests will still fail as
it's a .go file, so it needs the No New Tests label.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
