### PR TITLE
pkg/util: add tests for ParseRestartPolicy

### DIFF
--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -13,6 +13,8 @@ import (
 	ruser "github.com/moby/sys/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/podman/v6/libpod/define"
 	"go.podman.io/storage/pkg/idtools"
 	stypes "go.podman.io/storage/types"
 )
@@ -891,6 +893,47 @@ func TestParseDockerignoreLeadingTrailingSlashes(t *testing.T) {
 			excludes, _, err := ParseDockerignore(nil, contextDir)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, excludes)
+		})
+	}
+}
+
+func TestParseRestartPolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		policy      string
+		wantPolicy  string
+		wantRetries uint
+		wantErr     string // substring to match; empty means no error expected
+	}{
+		{"empty policy", "", "", 0, ""},
+		{"no", "no", "no", 0, ""},
+		{"always", "always", "always", 0, ""},
+		{"unless-stopped", "unless-stopped", "unless-stopped", 0, ""},
+		{"on-failure without retries", "on-failure", "on-failure", 0, ""},
+		{"never is normalized to no", "never", define.RestartPolicyNo, 0, ""},
+		{"never is case-insensitive", "Never", define.RestartPolicyNo, 0, ""},
+		{"on-failure with retries", "on-failure:5", "on-failure", 5, ""},
+		{"on-failure with zero retries", "on-failure:0", "on-failure", 0, ""},
+		{"on-failure preserves original case", "ON-FAILURE:3", "ON-FAILURE", 3, ""},
+		{"retries with non on-failure policy", "always:5", "", 0, "can only be specified with on-failure"},
+		{"non-numeric retries", "on-failure:abc", "", 0, "parsing restart policy retry count"},
+		{"empty retries", "on-failure:", "", 0, "parsing restart policy retry count"},
+		{"negative retries", "on-failure:-1", "", 0, "greater than 0"},
+		{"too many fields", "on-failure:5:3", "", 0, "may specify retries at most once"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, retries, err := ParseRestartPolicy(tt.policy)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Empty(t, policy)
+				assert.Zero(t, retries)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPolicy, policy)
+			assert.Equal(t, tt.wantRetries, retries)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
`ParseRestartPolicy` (`pkg/util/utils.go`) parses the value of `--restart` and had no unit test. It has real branching worth covering: bare policy names, the `never` → `no` normalization (case-insensitive), `on-failure:N` retry parsing, and several error paths (retries on a non-`on-failure` policy, non-numeric/negative retry counts, too many colon-separated fields). This adds a table-driven test for the happy paths and each error branch.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
