### PR TITLE
hack/swagger-check: check routes registered on subrouters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,7 @@ help: ## Print this help message
 .PHONY: .check-self-tests
 .check-self-tests:
 	hack/markdown-preprocess.t
+	hack/swagger-check.t
 	hack/ci/pr-removes-fixed-skips.t
 	hack/ci/pr-should-include-tests.t
 	hack/ci/logformatter.t

--- a/hack/swagger-check
+++ b/hack/swagger-check
@@ -132,22 +132,79 @@ sub finder {
     open my $in, '<', $path
         or die "$ME: Cannot read $path: $!\n";
     my @comments;
+    my @handles;
+    my %prefix;
     while (my $line = <$in>) {
-        if ($line =~ m!^\s*//!) {
-            push @comments, $line;
+        # Routes may be registered on a subrouter, in which case the path passed to
+        # Handle() is relative to the subrouter's prefix:
+        #     v4 := r.PathPrefix("/v{version:...}/libpod/manifests").Subrouter()
+        #     v4.Handle("/{name}/registry/{destination}", ...)
+        # Remember the prefix so the full endpoint can be reassembled below. The
+        # version element is dropped, just as VersionedPath() is ignored.
+        if ($line =~ m!^\s*(\w+)\s*:=\s*\w+\.PathPrefix\("([^"]+)"\)\.Subrouter\(\)!) {
+            my ($var, $pfx) = ($1, $2);
+            $pfx =~ s!^/v\{version:[^\}]*\}!!;
+            $prefix{$var} = $pfx;
+            next;
         }
-        else {
-            # Not a comment line. If it's an r.Handle*() one, process it.
-            if ($line =~ m!^\s*r\.Handle(Func)?\(!) {
-                handle_handle($path, $line, @comments)
-                    or $exit_status = 1;
-            }
 
-            # Reset comments
-            @comments = ();
+        if ($line =~ m!^\s*//!) {
+            # A comment following a run of Handle()s begins a new block.
+            if (@handles) {
+                handle_handles($path, \@handles, \@comments)
+                    or $exit_status = 1;
+                @handles  = ();
+                @comments = ();
+            }
+            push @comments, $line;
+            next;
         }
+
+        # A single swagger comment may cover several consecutive Handle() lines,
+        # e.g. the v3 and v4 registrations of one logical endpoint. Collect the run.
+        if ($line =~ m!^\s*(\w+)\.Handle(Func)?\(!) {
+            push @handles, [ $line, $prefix{$1} // '' ];
+            next;
+        }
+
+        # Any other line ends the block.
+        if (@handles) {
+            handle_handles($path, \@handles, \@comments)
+                or $exit_status = 1;
+        }
+        @handles  = ();
+        @comments = ();
+    }
+    if (@handles) {
+        handle_handles($path, \@handles, \@comments)
+            or $exit_status = 1;
     }
     close $in;
+}
+
+
+####################
+#  handle_handles  #  Check one swagger comment against a run of route registrations
+####################
+#
+# A swagger comment may precede more than one consecutive route registration,
+# e.g. the v3 and v4 spellings of the same endpoint. The comment is correct if
+# it describes any one of them.
+#
+# Returns false only if none of the registrations match.
+#
+sub handle_handles {
+    my ($path, $handles, $comments) = @_;
+
+    return 1 if !@$handles;
+    return 1 if !grep { /swagger:operation/ } @$comments;
+
+    for my $h (@$handles) {
+        return 1 if handle_handle($path, $h->[0], $h->[1], 1, @$comments);
+    }
+
+    # Nothing matched; report the discrepancy against the first registration.
+    return handle_handle($path, $handles->[0][0], $handles->[0][1], 0, @$comments);
 }
 
 
@@ -161,13 +218,15 @@ sub finder {
 sub handle_handle {
     my $path     = shift;               # for error messages only
     my $line     = shift;               # in: the r.Handle* line
+    my $prefix   = shift;               # in: subrouter path prefix, or ''
+    my $quiet    = shift;               # in: if true, don't report a mismatch
     my @comments = @_;                  # in: preceding comment lines
 
     # Preserve the original line, so we can show it in comments
     my $line_orig = $line;
 
     # Strip off the 'r.Handle*(' and leading whitespace; preserve the latter
-    $line =~ s!^(\s*)r\.Handle(Func)?\(!!
+    $line =~ s!^(\s*)\w+\.Handle(Func)?\(!!
         or die "$ME: INTERNAL ERROR! Got '$line'!\n";
     my $indent = $1;
 
@@ -176,12 +235,12 @@ sub handle_handle {
     $line =~ s!^VersionedPath\(([^\)]+)\)!$1!;
     $line =~ m!^"(/[^"]+)",!
         or die "$ME: $path:$.: Cannot grok '$line'\n";
-    my $endpoint = $1;
+    my $endpoint = $prefix . $1;
 
     # Some function declarations require an argument of the form '{name:.*}'
     # but the swagger (which gets derived from the comments) should not
     # include them. Normalize all such args to just '{name}'.
-    $endpoint =~ s/\{name:\.\*\}/\{name\}/;
+    $endpoint =~ s/\{(\w+):[^\}]*\}/\{$1\}/g;
 
     # e.g. /auth, /containers/*/rename, /distribution, /monitor, /plugins
     return 1 if $line =~ /\.UnsupportedHandler/;
@@ -196,7 +255,7 @@ sub handle_handle {
     elsif ($line =~ m!\.Methods\((.*)\)!) {
         my $x = $1;
 
-        if ($x =~ /Method(Post|Get|Delete|Head)/) {
+        if ($x =~ /Method(Post|Get|Delete|Head|Put)/) {
             $method = uc $1;
         }
         elsif ($x =~ /\"(HEAD|GET|POST)"/) {
@@ -238,7 +297,8 @@ sub handle_handle {
     #
     # Compare actual swagger comment to what we expect based on Handle call.
     #
-    my $expect = " // swagger:operation $method $endpoint $tag $operation ";
+    my @expect = map { " // swagger:operation $method $endpoint $tag $_ " } @$operation;
+    my $expect = $expect[0];
     my @actual = grep { /swagger:operation/ } @comments;
 
     return 1 if !@actual;         # No swagger comment in file; oh well
@@ -248,7 +308,8 @@ sub handle_handle {
     # (Ignore whitespace discrepancies)
     (my $a_trimmed = $actual) =~ s/\s+/ /g;
 
-    return 1 if $a_trimmed eq $expect;
+    return 1 if grep { $a_trimmed eq $_ } @expect;
+    return 0 if $quiet;
 
     # Mismatch. Display it. Start with filename, if different from previous
     print "\n";
@@ -289,6 +350,23 @@ sub handle_handle {
 ####################
 sub operation_name {
     my ($method, $endpoint) = @_;
+
+    # A few operation names cannot be derived from method + path. The manifests
+    # handlers use v3 and v4 subrouters that register the same path, so one
+    # method+path pair can legitimately map to more than one operation, and some
+    # names (Push for .../registry/..., Create for POST on {name}) simply do not
+    # follow the usual pattern. List the acceptable names explicitly.
+    my %exception = (
+        'POST /libpod/manifests/{name}/push'                   => ['ManifestPushV3Libpod'],
+        'POST /libpod/manifests/{name}/registry/{destination}' => ['ManifestPushLibpod'],
+        'POST /libpod/manifests/{name}'                        => ['ManifestCreateLibpod'],
+        'PUT /libpod/manifests/{name}'                         => ['ManifestModifyLibpod'],
+        'DELETE /libpod/manifests/{name}'                      => ['ManifestDeleteV3Libpod',
+                                                                   'ManifestDeleteLibpod'],
+    );
+    if (my $names = $exception{"$method $endpoint"}) {
+        return $names;
+    }
 
     # /libpod/foo/bar -> (libpod, foo, bar)
     my @endpoints = grep { /\S/ } split '/', $endpoint;
@@ -353,7 +431,7 @@ sub operation_name {
         $action .= 's' if $action eq 'event';
     }
 
-    return "\u${main}\u${action}$Libpod";
+    return [ "\u${main}\u${action}$Libpod" ];
 }
 
 

--- a/hack/swagger-check.t
+++ b/hack/swagger-check.t
@@ -1,0 +1,127 @@
+#!/usr/bin/perl
+#
+# tests for swagger-check
+#
+# swagger-check takes a directory to scan, so each test writes a small
+# throwaway .go file and checks the exit status.
+#
+use v5.14;
+use strict;
+use warnings;
+
+use File::Temp qw(tempdir);
+use Test::More;
+
+my $script = $0;
+$script =~ s/\.t$//;
+die "$0: cannot find $script\n" if ! -e $script;
+
+# Run swagger-check over a directory containing just $content.
+# Returns the exit status: 0 = consistent, 1 = mismatch reported.
+sub check {
+    my $content = shift;
+
+    my $dir = tempdir(CLEANUP => 1);
+    open my $fh, '>', "$dir/register_test.go"
+        or die "cannot write $dir/register_test.go: $!\n";
+    print { $fh } $content;
+    close $fh;
+
+    my $out = qx{$script $dir 2>&1};
+    return $? >> 8;
+}
+
+#
+# Routes registered directly on the router. This has always worked; the
+# tests are here so a future refactor cannot quietly break it.
+#
+is(check(<<'END_GO'), 0, 'r.HandleFunc: matching comment passes');
+	// swagger:operation GET /libpod/things/json libpod ThingListLibpod
+	// ---
+	// summary: List things
+	r.HandleFunc(VersionedPath("/libpod/things/json"), s.APIHandler(libpod.ListThings)).Methods(http.MethodGet)
+END_GO
+
+is(check(<<'END_GO'), 1, 'r.HandleFunc: wrong tag is caught');
+	// swagger:operation GET /libpod/things/json compat ThingListLibpod
+	// ---
+	// summary: List things
+	r.HandleFunc(VersionedPath("/libpod/things/json"), s.APIHandler(libpod.ListThings)).Methods(http.MethodGet)
+END_GO
+
+#
+# Routes registered on a subrouter. The path passed to Handle() is relative
+# to the subrouter prefix, so the full endpoint has to be reassembled before
+# it can be compared. These were skipped entirely until 2026-08.
+#
+is(check(<<'END_GO'), 0, 'subrouter: matching comment passes');
+	v4 := r.PathPrefix("/v{version:[4-9][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	// swagger:operation GET /libpod/things/{name}/exists libpod ThingExistsLibpod
+	// ---
+	// summary: Check if a thing exists
+	v4.Handle("/{name:.*}/exists", s.APIHandler(libpod.ThingExists)).Methods(http.MethodGet)
+END_GO
+
+is(check(<<'END_GO'), 1, 'subrouter: wrong operation is caught');
+	v4 := r.PathPrefix("/v{version:[4-9][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	// swagger:operation GET /libpod/things/{name}/exists libpod ThingWrongNameLibpod
+	// ---
+	// summary: Check if a thing exists
+	v4.Handle("/{name:.*}/exists", s.APIHandler(libpod.ThingExists)).Methods(http.MethodGet)
+END_GO
+
+is(check(<<'END_GO'), 1, 'subrouter: wrong path is caught');
+	v4 := r.PathPrefix("/v{version:[4-9][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	// swagger:operation GET /libpod/somethingelse/{name}/exists libpod ThingExistsLibpod
+	// ---
+	// summary: Check if a thing exists
+	v4.Handle("/{name:.*}/exists", s.APIHandler(libpod.ThingExists)).Methods(http.MethodGet)
+END_GO
+
+#
+# PUT is a real method in this tree (ManifestModifyLibpod). It used to make
+# the script die with "Cannot grok http.MethodPut".
+#
+is(check(<<'END_GO'), 0, 'PUT is understood');
+	v4 := r.PathPrefix("/v{version:[4-9][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	// swagger:operation PUT /libpod/things/{name} libpod ThingInspectLibpod
+	// ---
+	// summary: Modify a thing
+	v4.Handle("/{name:.*}", s.APIHandler(libpod.ThingModify)).Methods(http.MethodPut)
+END_GO
+
+#
+# A single swagger comment may cover several consecutive registrations, e.g.
+# the v3 and v4 spellings of one endpoint. It is correct if it describes any
+# one of them.
+#
+is(check(<<'END_GO'), 0, 'one comment may cover consecutive routes');
+	v3 := r.PathPrefix("/v{version:[0-3][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	v4 := r.PathPrefix("/v{version:[4-9][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	// swagger:operation POST /libpod/things/{name} libpod ThingInspectLibpod
+	// ---
+	// summary: Create a thing
+	v3.Handle("/create", s.APIHandler(libpod.ThingCreate)).Methods(http.MethodPost)
+	v4.Handle("/{name:.*}", s.APIHandler(libpod.ThingCreate)).Methods(http.MethodPost)
+END_GO
+
+is(check(<<'END_GO'), 1, 'a run matching none of the routes is caught');
+	v3 := r.PathPrefix("/v{version:[0-3][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	v4 := r.PathPrefix("/v{version:[4-9][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	// swagger:operation POST /libpod/things/{name} libpod ThingCompletelyWrongLibpod
+	// ---
+	// summary: Create a thing
+	v3.Handle("/create", s.APIHandler(libpod.ThingCreate)).Methods(http.MethodPost)
+	v4.Handle("/{name:.*}", s.APIHandler(libpod.ThingCreate)).Methods(http.MethodPost)
+END_GO
+
+#
+# A route with no swagger comment is not an error. Longstanding behaviour;
+# pinned here so it is a deliberate decision rather than an accident.
+#
+is(check(<<'END_GO'), 0, 'a route with no swagger comment is allowed');
+	v4 := r.PathPrefix("/v{version:[4-9][0-9A-Za-z.-]*}/libpod/things").Subrouter()
+	v4.Handle("/{name:.*}/exists", s.APIHandler(libpod.ThingExists)).Methods(http.MethodGet)
+END_GO
+
+done_testing();


### PR DESCRIPTION
hack/swagger-check only matched routes registered on a router named r, so the
12 routes in register_manifest.go, which uses v3 and v4 subrouters, were never
checked. Corrupting a swagger comment in that file passes today, while the same
corruption in any other register_*.go file is caught.

This tracks subrouter prefixes so the full endpoint can be rebuilt, handles PUT,
and lets one swagger comment cover consecutive registrations. Five manifest
operation names cannot be derived from method and path, so they are listed as
explicit exceptions.

Adds hack/swagger-check.t with regression tests for the above, wired into
.check-self-tests alongside the other self-tests. There are no mismatches in the
tree today, so this changes no existing result: I ran the old and new script over
each register_*.go separately and the verdicts are identical.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
