### PR TITLE
test/e2e: keep containerfile out of the build context

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -73,6 +73,28 @@ var _ = Describe("Podman build", func() {
 		}
 	})
 
+	It("podman build helper keeps the containerfile out of the context", func() {
+		podmanTest.AddImageToRWStore(ALPINE)
+
+		// The helper used to write its generated Containerfile into
+		// podmanTest.TempDir, which is also the build context, so every build
+		// shipped the Containerfiles of the builds around it.
+		err := os.WriteFile(filepath.Join(podmanTest.TempDir, "marker"), []byte("hi"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		containerfile := fmt.Sprintf(`FROM %s
+COPY . /ctx`, ALPINE)
+		podmanTest.BuildImage(containerfile, "ctxtest", "false")
+
+		session := podmanTest.Podman([]string{"run", "--rm", "ctxtest", "ls", "/ctx"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		// the context is still TempDir, tests rely on that for COPY and ADD
+		Expect(session.OutputToString()).To(ContainSubstring("marker"))
+		Expect(session.OutputToString()).ToNot(ContainSubstring("Containerfile"))
+		Expect(session.OutputToString()).ToNot(ContainSubstring("Dockerfile"))
+	})
+
 	It("podman build and remove basic alpine with TMPDIR as relative", func() {
 		// preserve TMPDIR if it was originally set
 		if cacheDir, found := os.LookupEnv("TMPDIR"); found {

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1528,7 +1528,7 @@ func (p *PodmanTestIntegration) buildImage(dockerfile, imageName string, layers 
 	cmd = append(cmd, p.TempDir)
 	session := p.Podman(cmd)
 	session.Wait(240)
-	Expect(session).Should(Exit(0), fmt.Sprintf("BuildImage session output: %q", session.OutputToString()))
+	Expect(session).Should(Exit(0), fmt.Sprintf("BuildImage session output: %q stderr: %q", session.OutputToString(), session.ErrorToString()))
 	output := session.OutputToStringArray()
 	return output[len(output)-1]
 }

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1504,8 +1504,16 @@ func (s *PodmanSessionIntegration) jq(jqCommand string) (string, error) {
 }
 
 func (p *PodmanTestIntegration) buildImage(dockerfile, imageName string, layers string, label string, extraOptions []string) string {
-	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile-"+stringid.GenerateRandomID())
-	err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o755)
+	// p.TempDir is the build context and some tests drop files there for COPY
+	// and ADD to pick up, so it has to stay the context. Keep the generated
+	// Containerfile out of it: builds that run concurrently walk this
+	// directory to make the context, and a file appearing mid-walk is a race.
+	containerfileDir, err := os.MkdirTemp(filepath.Dir(p.TempDir), "containerfile")
+	Expect(err).ToNot(HaveOccurred())
+	defer os.RemoveAll(containerfileDir)
+
+	dockerfilePath := filepath.Join(containerfileDir, "Containerfile")
+	err = os.WriteFile(dockerfilePath, []byte(dockerfile), 0o755)
 	Expect(err).ToNot(HaveOccurred())
 	cmd := []string{"build", "--pull-never", "--layers=" + layers, "--file", dockerfilePath}
 	if label != "" {


### PR DESCRIPTION
I was going through the rerun history to work out why `podman image rm - concurrent with shared layers` keeps coming back, and got stuck because the log gives you nothing:

```
[FAILED] BuildImage session output: "STEP 1/2: FROM ... STEP 2/2: RUN touch rmtest:0 COMMIT rmtest:0"
Expected <int>: 1 to match exit code: <int>: 0
```

the build reached COMMIT and then exited 1, and the reason is nowhere in the job output. the assert only prints `OutputToString()`, which is stdout, so build errors on stderr get dropped. second commit adds stderr there.

first commit is what I noticed while reading that helper. it writes its generated Containerfile into `p.TempDir` and then passes `p.TempDir` as the build context, so concurrent builds walk a directory the others are still writing into. that test starts 10 builds in goroutines. running just the file layout:

```
entries each build saw in its own context: [10 10 5 10 10 10 7 10 6 6]
```

`--file` takes an absolute path so the Containerfile does not need to sit in the context. TempDir stays the context since some tests drop files there for COPY and ADD, and the new test checks both halves.

I cant claim this fixes the flake, with stderr dropped there is no record of what actually failed.
