### PR TITLE
test/system: fail loudly when _prefetch cannot fetch or load an image

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -132,7 +132,13 @@ function _prefetch() {
             if [[ $status -ne 0 ]]; then
                 echo "# 'pull $want' failed again, will retry one last time..." >&3
                 sleep 30
-                $cmd
+                run $cmd
+                echo "$output"
+                if [[ $status -ne 0 ]]; then
+                    # Remove any partial archive so the next run refetches
+                    rm -f "$cachepath"
+                    die "'pull $want' failed three times"
+                fi
             fi
         fi
     fi
@@ -166,7 +172,11 @@ function _prefetch() {
     # with skopeo, not podman, in order to preserve metadata
     cmd="skopeo copy --all oci-archive:$cachepath containers-storage:$want"
     echo "$_LOG_PROMPT $cmd"
-    $cmd
+    run $cmd
+    echo "$output"
+    if [[ $status -ne 0 ]]; then
+        die "failed to load cached image '$want' from $cachepath"
+    fi
 }
 
 # END   tools for fetching & caching test images


### PR DESCRIPTION
_prefetch runs two commands bare, so a failure in either is invisible at the
point it happens.

The third and final 'podman pull' retry runs $cmd directly rather than through
run, so its exit status is never checked. If all three attempts fail, _prefetch
returns as though it succeeded and leaves either no cache entry or a partial
one behind.

The skopeo copy that loads the cached archive into containers-storage has the
same problem. If it fails, the image is simply absent.

Either way the test that asked for the image carries on and fails later with an
unrelated-looking 'image not found', pointing at the test rather than at the
fetch that actually broke. That is expensive to debug because the symptom and
the cause are in different places.

Check the status of both, remove a partial archive so the next run refetches
rather than loading a truncated one, and die with the real reason.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```

