### PR TITLE
podman exec: align --detach-keys help text with run, start, and attach

### DIFF
--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -64,7 +64,7 @@ func execFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&execDetach, "detach", "d", false, "Run the exec session in detached mode (backgrounded)")
 
 	detachKeysFlagName := "detach-keys"
-	flags.StringVar(&execOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Select the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _")
+	flags.StringVar(&execOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Select the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
 
 	cidfileFlagName := "cidfile"


### PR DESCRIPTION
The `--detach-keys` help on `podman exec` still uses the old, slightly mangled wording ("... a-z, @, ^, [, , or _"), while `podman run`, `start` and `attach` already share the corrected string. This aligns `exec` with them so all four flags describe the detach-key format the same way.

No functional change - help text only.