### PR TITLE
Update podman-manifest-add.1.md.in to correct `manifest add` examples

### DIFF
--- a/docs/source/markdown/podman-manifest-add.1.md.in
+++ b/docs/source/markdown/podman-manifest-add.1.md.in
@@ -121,23 +121,23 @@ configuration information.
   An existing local directory _path_ storing the manifest, layer tarballs, and signatures as individual files. This
   is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
-    $ podman manifest add dir:/tmp/myimage
+    $ podman manifest add mylist:v1.11 dir:/tmp/myimage
 
   **docker-archive:**_path_[**:**_docker-reference_]
   An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a
   file, and it must not contain a digest.
 
-    $ podman manifest add docker-archive:/tmp/myimage
+    $ podman manifest add mylist:v1.11 docker-archive:/tmp/myimage
 
   **docker-daemon:**_docker-reference_
   An image in _docker-reference_ format stored in the docker daemon internal storage. The _docker-reference_ can also be an image ID (docker-daemon:algo:digest).
 
-    $ sudo podman manifest add docker-daemon:docker.io/library/myimage:33
+    $ podman manifest add mylist:v1.11 docker-daemon:docker.io/library/myimage:33
 
   **oci-archive:**_path_**:**_tag_
   An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
 
-    $ podman manifest add oci-archive:/tmp/myimage
+    $ podman manifest add mylist:v1.11 oci-archive:/tmp/myimage
 
 ## EXAMPLES
 


### PR DESCRIPTION
Several of the examples given for `podman manifest add` were missing the manifest name argument and one had a `sudo` prefix.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [X] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [X] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [X] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [X] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [X] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [X] All commits pass `make validatepr` (format/lint checks)
- [X] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
