### PR TITLE
Add support for --passwd to the create command

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -495,6 +495,9 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(chrootDirsFlagName, completion.AutocompleteDefault)
 
+		passwdFlagName := "passwd"
+		createFlags.BoolVar(&cf.Passwd, passwdFlagName, true, "add entries to /etc/passwd and /etc/group")
+
 		passwdEntryName := "passwd-entry"
 		createFlags.StringVar(&cf.PasswdEntry, passwdEntryName, "", "Entry to write to /etc/passwd")
 		_ = cmd.RegisterFlagCompletionFunc(passwdEntryName, completion.AutocompleteNone)

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -161,6 +161,8 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 	s.RawImageName = rawImageName
 
+	s.Passwd = &cliVals.Passwd
+
 	// Include the command used to create the container.
 	s.ContainerCreateCommand = os.Args
 

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -79,9 +79,6 @@ func runFlags(cmd *cobra.Command) {
 	flags.StringVar(&runOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-cf`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
 
-	passwdFlagName := "passwd"
-	flags.BoolVar(&runOpts.Passwd, passwdFlagName, true, "add entries to /etc/passwd and /etc/group")
-
 	if registry.IsRemote() {
 		_ = flags.MarkHidden(preserveFdsFlagName)
 		_ = flags.MarkHidden(preserveFdFlagName)
@@ -129,6 +126,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	runOpts.CIDFile = cliVals.CIDFile
 	runOpts.Rm = cliVals.Rm
+	runOpts.Passwd = cliVals.Passwd
 	cliVals, err := CreateInit(cmd, cliVals, false)
 	if err != nil {
 		return err

--- a/docs/source/markdown/options/passwd.md
+++ b/docs/source/markdown/options/passwd.md
@@ -1,0 +1,8 @@
+####> This option file is used in:
+####>   podman create, run
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--passwd**
+
+Allow Podman to add entries to /etc/passwd and /etc/group when used in conjunction with the --user option.
+This is used to override the Podman provided user setup in favor of entrypoint configurations such as libnss-extrausers.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -287,6 +287,8 @@ This option conflicts with **--add-host**.
 
 @@option os.pull
 
+@@option passwd
+
 @@option passwd-entry
 
 @@option personality

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -306,10 +306,7 @@ This option conflicts with **--add-host**.
 
 @@option os.pull
 
-#### **--passwd**
-
-Allow Podman to add entries to /etc/passwd and /etc/group when used in conjunction with the --user option.
-This is used to override the Podman provided user setup in favor of entrypoint configurations such as libnss-extrausers.
+@@option passwd
 
 @@option passwd-entry
 

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -274,6 +274,7 @@ type ContainerCreateOptions struct {
 
 	CgroupConf []string
 
+	Passwd      bool
 	GroupEntry  string
 	PasswdEntry string
 }

--- a/test/e2e/create_passwd_test.go
+++ b/test/e2e/create_passwd_test.go
@@ -1,0 +1,33 @@
+//go:build linux || freebsd
+
+package integration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman create passwd", func() {
+	It("podman create without --passwd flag (default true)", func() {
+		podmanTest.PodmanExitCleanly("create", "--name", "test_passwd", "--user", "1234:1234", ALPINE, "cat", "/etc/passwd")
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		run := podmanTest.PodmanExitCleanly("start", "-a", "test_passwd")
+		Expect(run.OutputToString()).To(ContainSubstring("1234"))
+	})
+
+	It("podman create with --passwd=false", func() {
+		podmanTest.PodmanExitCleanly("create", "--name", "test_no_passwd", "--passwd=false", "--user", "1234:1234", ALPINE, "cat", "/etc/passwd")
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		run := podmanTest.PodmanExitCleanly("start", "-a", "test_no_passwd")
+		Expect(run.OutputToString()).NotTo(ContainSubstring("1234"))
+	})
+
+	It("podman create with explicit --passwd=true (same as default)", func() {
+		podmanTest.PodmanExitCleanly("create", "--name", "test_passwd_explicit", "--passwd=true", "--user", "5678:5678", ALPINE, "cat", "/etc/passwd")
+
+		run := podmanTest.PodmanExitCleanly("start", "-a", "test_passwd_explicit")
+		Expect(run.OutputToString()).To(ContainSubstring("5678"))
+	})
+})


### PR DESCRIPTION
I was using `podman run` before with the `--passwd` flag. I wanted to move to a compose file and switch to `podman-compose`, but this uses `create` and `start` separately, meaning I could not set the `--passwd` option in any way. Maybe I am misunderstanding something, and there's a reason it was not available to `create`, but adding support for it looked trivial enough and now my use case works.

#### Checklist

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks) (there is a lint error on `pkg/api/handlers/compat/images_search.go:108` but that is "not my/this PR's department")
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Add the `--passwd` flag to the `create` command, same as `run` currently has.
```
