### PR TITLE
Security: Prevent API DoS via unbounded memory read in manifests handler

### DIFF
--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -107,7 +107,8 @@ func ManifestCreate(w http.ResponseWriter, r *http.Request) {
 		status = http.StatusCreated
 	}
 
-	buffer, err := io.ReadAll(r.Body)
+	// Limit manifest payload to 20MB to prevent DOS
+	buffer, err := io.ReadAll(io.LimitReader(r.Body, 20<<20))
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return


### PR DESCRIPTION
The manifests API endpoint previously read the incoming HTTP request payload directly into memory using `io.ReadAll(r.Body)` without an upper bound. This creates a Denial-of-Service vector where a malicious client could send an infinitely streaming payload and OOM crash the podman daemon.

This commit enforces a generous 20MB limit on the payload using `io.LimitReader` to mitigate this.

Fixes #29604 

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #29604` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
