### PR TITLE
hack/ci/logcollector: collect all network diagnostics even if one fails

### DIFF
--- a/hack/ci/logcollector.sh
+++ b/hack/ci/logcollector.sh
@@ -76,5 +76,10 @@ packages)
     # Any not-present packages will be listed as such
     $PKG_LST_CMD "${PKG_NAMES[@]}" | sort -u
     ;;
-ip) showrun sh -c "ip addr && ip route && ip -6 route" ;;
+ip)
+    # Run each independently so a failure in one still collects the rest.
+    showrun ip addr
+    showrun ip route
+    showrun ip -6 route
+    ;;
 esac


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
 the ip case chained ip addr && ip route && ip -6 route, so a partial failure silently dropped the remaining network state — the opposite of a log collector's job. Now each runs through showrun independently

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
