### PR TITLE
build: do not leak context tmpdir

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -195,6 +195,22 @@ func ParseBuildOpts(cmd *cobra.Command, args []string, buildOpts *BuildFlagsWrap
 		contextDir   string
 		apiBuildOpts entities.BuildOptions
 	)
+	// The caller only cleans up TmpDirToClose and LogFileToClose when we
+	// return successfully, so clean them up ourselves on every error path.
+	succeeded := false
+	defer func() {
+		if succeeded {
+			return
+		}
+		if apiBuildOpts.TmpDirToClose != "" {
+			if err := os.RemoveAll(apiBuildOpts.TmpDirToClose); err != nil {
+				logrus.Errorf("Removing temporary directory %q: %v", apiBuildOpts.TmpDirToClose, err)
+			}
+		}
+		if apiBuildOpts.LogFileToClose != nil {
+			apiBuildOpts.LogFileToClose.Close()
+		}
+	}()
 	if len(args) > 0 {
 		// The context directory could be a URL.  Try to handle that.
 		tempDir, subDir, err := buildahDefine.TempDirForURL("", "buildah", args[0])
@@ -283,6 +299,7 @@ func ParseBuildOpts(cmd *cobra.Command, args []string, buildOpts *BuildFlagsWrap
 	apiBuildOpts.ContainerFiles = containerFiles
 	apiBuildOpts.Authfile = buildOpts.Authfile
 
+	succeeded = true
 	return &apiBuildOpts, err
 }
 

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -34,6 +34,18 @@ EOF
     run_podman rmi -f $imgname
 }
 
+# 22642: a failed flag check used to leak the downloaded context directory
+@test "podman build - no tmpdir leak on early failure" {
+    tmpdir=$PODMAN_TMPDIR/build-tmp
+    mkdir -p $tmpdir
+
+    TMPDIR=$tmpdir run_podman 125 build --authfile=$PODMAN_TMPDIR/bogus-authfile - <<<"from scratch"
+    is "$output" ".*credential file is not accessible.*" "expected authfile error"
+
+    run ls -A $tmpdir
+    assert "$output" == "" "leftover files in TMPDIR after failed build"
+}
+
 @test "podman buildx - basic test" {
     rand_filename=$(random_string 20)
     rand_content=$(random_string 50)


### PR DESCRIPTION
I was looking at #22642 and traced it to ParseBuildOpts: it downloads a URL or stdin context into a temp dir and stores it in TmpDirToClose, but the caller only removes that when the whole parse succeeds, so every error return after the download leaks the directory. built the tree with and without the patch and ran the reproducer from the issue:

```
== main: build --authfile=/nonexistent - ==
Error: credential file is not accessible: faccessat /nonexistent/authfile.json: no such file or directory
leftover in TMPDIR: buildah408229798 (count 1)
== fix: same command ==
leftover in TMPDIR: (count 0)
```

same guard TempDirForURL itself uses, one level up so it covers both tmpdir call sites and the logfile next to them. added a system test that runs the same reproducer.

Fixes: #22642
