### PR TITLE
pkg/systemd/parser: add tests for escapeWords and escapeString

### DIFF
--- a/pkg/systemd/parser/split_test.go
+++ b/pkg/systemd/parser/split_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,5 +85,61 @@ func TestExtractFirstWordUnescapes(t *testing.T) {
 
 		next = remaining
 		assert.Equal(t, expected[i], word)
+	}
+}
+
+func TestEscapeWords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		words []string
+		want  string
+	}{
+		{"empty list", nil, ""},
+		{"single empty word", []string{""}, ""},
+		{"no escaping needed", []string{"foo"}, "foo"},
+		{"words are joined by a space", []string{"foo", "bar"}, "foo bar"},
+		{"a space forces quoting and is hex-escaped", []string{"foo bar"}, `"foo\x20bar"`},
+		{"tab", []string{"a\tb"}, `"a\tb"`},
+		{"newline", []string{"a\nb"}, `"a\nb"`},
+		{"backslash", []string{"a\\b"}, `"a\\b"`},
+		{"double quote", []string{"a\"b"}, `"a\"b"`},
+		{"single quote is kept as-is inside the quotes", []string{"a'b"}, `"a'b"`},
+		{"control character uses a hex escape", []string{"a\x01b"}, `"a\x01b"`},
+		{"non-ascii is left untouched", []string{"café"}, "café"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, escapeWords(test.words))
+		})
+	}
+}
+
+func TestEscapeString(t *testing.T) {
+	t.Parallel()
+
+	// The isPath variant treats '/' as a path separator: separators become
+	// '-', a leading '/' is dropped, and a literal '-' is hex-escaped so it is
+	// not mistaken for a separator.
+	tests := []struct {
+		name   string
+		in     string
+		isPath bool
+		want   string
+	}{
+		{"path separator becomes a dash", "a/b", true, "a-b"},
+		{"leading path separator is dropped", "/ab", true, "ab"},
+		{"literal dash in a path is hex-escaped", "a-b", true, `a\x2db`},
+		{"slash is untouched when not a path", "a/b", false, "a/b"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var b strings.Builder
+			escapeString(&b, test.in, test.isPath)
+			assert.Equal(t, test.want, b.String())
+		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

The systemd word-escaping helpers in `pkg/systemd/parser/split.go` — `escapeWords`
and `escapeString` (with `charNeedEscape` / `wordNeedEscape`) — had no unit tests.
They implement the C-style escaping used when serialising unit-file values:
control characters become `\xNN`, a space is hex-escaped (`\x20`) and forces the
word to be quoted, backslashes and quotes are escaped, and in path mode a `/`
separator becomes `-`, a leading `/` is dropped, and a literal `-` is hex-escaped
so it can't be mistaken for a separator. This adds table-driven tests covering the
escape branches and the path-mode handling.


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
