### PR TITLE
libpod: adjust permissions for imported volumes

### DIFF
--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -104,7 +105,7 @@ type VolumeState struct {
 	// a container, the container will chown the volume to the container process
 	// UID/GID.
 	NeedsChown bool `json:"notYetChowned,omitempty"`
-	// Indicates that a copy-up event occurred during the current mount of
+	// CopiedUp indicates that a copy-up event occurred during the current mount of
 	// the volume into a container.
 	// We use this to determine if a chown is appropriate.
 	CopiedUp bool `json:"copiedUp,omitempty"`
@@ -344,6 +345,23 @@ func (v *Volume) Import(r io.Reader) error {
 
 	if err := chrootarchive.Untar(r, mountPoint, nil); err != nil {
 		return fmt.Errorf("extracting into volume %s: %w", v.Name(), err)
+	}
+
+	contents, err := os.ReadDir(mountPoint)
+	if err != nil {
+		return fmt.Errorf("reading contents of imported volume %s: %w", v.Name(), err)
+	}
+	if len(contents) != 0 {
+		v.lock.Lock()
+		defer v.lock.Unlock()
+		if err := v.update(); err != nil {
+			return err
+		}
+		if v.state.NeedsCopyUp && v.state.NeedsChown {
+			v.state.NeedsCopyUp = false
+			v.state.CopiedUp = true
+			return v.save()
+		}
 	}
 
 	return nil

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -120,6 +120,34 @@ var _ = Describe("Podman volume create", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("hello"))
 	})
 
+	It("podman import volume preserves first mount permission adjustment", func() {
+		imageName := "volume-copyup-permissions:latest"
+		containerfile := fmt.Sprintf(`FROM %s
+RUN mkdir -p /vol-target && chown 70:71 /vol-target && chmod 750 /vol-target && echo hello > /vol-target/test
+`, ALPINE)
+		podmanTest.BuildImage(containerfile, imageName, "false")
+
+		volName := "my_vol_" + RandomString(10)
+		podmanTest.PodmanExitCleanly("volume", "create", volName)
+
+		session := podmanTest.PodmanExitCleanly("run", "--volume", volName+":/vol-target", imageName, "stat", "-c", "%u:%g %a", "/vol-target")
+		Expect(session.OutputToString()).To(Equal("70:71 750"))
+
+		helloTar := filepath.Join(podmanTest.TempDir, "hello.tar")
+		podmanTest.PodmanExitCleanly("volume", "export", volName, "--output", helloTar)
+
+		importedVolName := "my_vol_" + RandomString(10)
+		podmanTest.PodmanExitCleanly("volume", "create", importedVolName)
+
+		podmanTest.PodmanExitCleanly("volume", "import", importedVolName, helloTar)
+
+		session = podmanTest.PodmanExitCleanly("run", "--volume", importedVolName+":/vol-target", imageName, "stat", "-c", "%u:%g %a", "/vol-target")
+		Expect(session.OutputToString()).To(Equal("70:71 750"))
+
+		session = podmanTest.PodmanExitCleanly("run", "--volume", importedVolName+":/vol-target", imageName, "cat", "/vol-target/test")
+		Expect(session.OutputToString()).To(Equal("hello"))
+	})
+
 	It("podman import/export volume should fail", func() {
 		// try import on volume or source which does not exist
 		SkipIfRemote("Volume export check does not work with a remote client")


### PR DESCRIPTION
Imported volumes now get ownership and permissions matching the container's mount tareget.
Previously, permission adjustment was skipped for imported volumes as they were already non-empty when mounted.

Fixes: #25442

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Imported volumes now get ownership and permissions matching the container's mount tareget.
```
