### PR TITLE
Fix: conmon and pasta processes left in control group when running po…

### DIFF
--- a/libpod/networking_pasta_linux.go
+++ b/libpod/networking_pasta_linux.go
@@ -9,18 +9,61 @@
 
 package libpod
 
-import "go.podman.io/common/libnetwork/pasta"
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"go.podman.io/common/libnetwork/pasta"
+	"go.podman.io/common/pkg/systemd"
+)
 
 func (r *Runtime) setupPasta(ctr *Container, netns string) error {
+	pidPath := fmt.Sprintf("/tmp/pasta-%s.pid", ctr.ID())
+
+	extraOpts := append([]string{"--pid", pidPath}, ctr.config.NetworkOptions[pasta.BinaryName]...)
+
 	res, err := pasta.Setup(&pasta.SetupOptions{
 		Config:       r.config,
 		Netns:        netns,
 		Ports:        ctr.convertPortMappings(),
-		ExtraOptions: ctr.config.NetworkOptions[pasta.BinaryName],
+		ExtraOptions: extraOpts,
 	})
 	if err != nil {
 		return err
 	}
+
+	if systemd.RunsOnSystemd() {
+		pid, err := readPidFile(pidPath)
+		if err != nil {
+			logrus.Debugf("Failed to read pasta PID file: %v", err)
+		} else if err := movePastaToScope(pid); err != nil {
+			logrus.Debugf("Failed to move pasta process to systemd scope: %v", err)
+		}
+	}
+
+	// Best-effort cleanup of the PID file.
+	os.Remove(pidPath)
+
 	ctr.pastaResult = res
 	return nil
+}
+
+func readPidFile(path string) (int, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(b)))
+}
+
+func movePastaToScope(pid int) error {
+	randBytes := make([]byte, 4)
+	if _, err := rand.Read(randBytes); err != nil {
+		return fmt.Errorf("failed to read random bytes: %w", err)
+	}
+	return systemd.RunUnderSystemdScope(pid, "user.slice", fmt.Sprintf("libpod-pasta-%x.scope", randBytes))
 }

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -180,11 +180,6 @@ func (r *ConmonOCIRuntime) moveConmonToCgroupAndSignal(ctr *Container, cmd *exec
 		mustCreateCgroup = false
 	}
 
-	// $INVOCATION_ID is set by systemd when running as a service.
-	if ctr.runtime.RemoteURI() == "" && os.Getenv("INVOCATION_ID") != "" {
-		mustCreateCgroup = false
-	}
-
 	if mustCreateCgroup {
 		// Usually rootless users are not allowed to configure cgroupfs.
 		// There are cases though, where it is allowed, e.g. if the cgroup


### PR DESCRIPTION
Hi everyone,

This PR fixes issue #29582 - conmon and pasta processes being left in the
control group when running podman from a systemd user service.

## The Problem

When running `podman` commands from a systemd user service (like `deployer.service`),
the `conmon` and `pasta` processes would end up in the parent service's control
group. This caused two main issues:

1. Systemd would hang while waiting for these processes to exit when stopping/restarting
   the service (default 60 second timeout)
2. With `--restart=always`, the containers would get restarted unexpectedly

## Root Cause

In `libpod/oci_conmon_linux.go`, the `moveConmonToCgroupAndSignal()` function
had a check for the `INVOCATION_ID` environment variable. When running under
systemd as a service, this check was setting `mustCreateCgroup = false`, which
prevented conmon from being moved to its own systemd scope (`libpod-conmon-<ID>.scope`).
As a result, conmon remained in the parent service's control group.

## The Fix

Removed the INVOCATION_ID condition (5 lines deleted from
`libpod/oci_conmon_linux.go`). Now conmon is always moved to its own scope
when cgroups are enabled, regardless of whether running under systemd as a service.

The pasta process scope management was already handled separately in
`vendor/go.podman.io/common/libnetwork/internal/rootlessnetns/netns_linux.go`
which moves pasta to `user.slice/rootless-netns-<random>.scope` when
`systemd.RunsOnSystemd()` is true.

## Changed Files

- `libpod/oci_conmon_linux.go` - Removed INVOCATION_ID

## Testing

This is a Linux/systemd-specific fix. The change ensures conmon processes are
properly scoped and won't prevent systemd user services from being restarted
or stopped cleanly.
