### PR TITLE
[WIP] tmt: Disable podman-next on release branches

### DIFF
--- a/contrib/packit-tmt/update-deps.sh
+++ b/contrib/packit-tmt/update-deps.sh
@@ -7,6 +7,20 @@ if grep -s -r -q -F '[testing-farm-tag-repository]' /etc/yum.repos.d 2>/dev/null
     DISABLE_REPO=(--disable-repo=testing-farm-tag-repository)
 fi
 
+# Only use podman-next for PRs targeting main branch
+# PACKIT_TARGET_BRANCH is set by Packit for PR jobs (the base/target branch)
+TARGET_BRANCH="${PACKIT_TARGET_BRANCH:-unknown}"
+
+echo "DEBUG: PACKIT_TARGET_BRANCH='$PACKIT_TARGET_BRANCH'"
+echo "DEBUG: TARGET_BRANCH='$TARGET_BRANCH'"
+
+if [ "$TARGET_BRANCH" != "main" ]; then
+    echo "Target branch is '$TARGET_BRANCH' (not main), disabling podman-next repo"
+    DISABLE_REPO+=(--disable-repo='copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next')
+else
+    echo "Target branch is 'main', podman-next repo will be used"
+fi
+
 # This should work even when podman-next isn't installed. It'll fetch the
 # highest versions available across all repos.
 dnf -y upgrade --allowerasing --setopt=allow_vendor_change=1 "${DISABLE_REPO[@]}" --exclude=podman*


### PR DESCRIPTION
Only use podman-next COPR for PRs targeting main branch. PRs to release branches should test against stable repositories only.

Uses PACKIT_TARGET_BRANCH to detect the PR target branch.

<!-- Thanks for sending a pull request! -->

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
