### PR TITLE
Don't allocate 1 GB of memory to create a file

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -698,7 +698,7 @@ subdir**`
 		Expect(os.WriteFile(filepath.Join(subdirPath, "extra"), contents.Bytes(), 0o644)).
 			ToNot(HaveOccurred())
 		randomFile := filepath.Join(subdirPath, "randomFile")
-		dd := exec.Command("dd", "if=/dev/urandom", "of="+randomFile, "bs=1G", "count=1")
+		dd := exec.Command("dd", "if=/dev/urandom", "of="+randomFile, "bs=1M", "count=1024")
 		ddSession, err := Start(dd, GinkgoWriter, GinkgoWriter)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(ddSession, "30s", "1s").Should(Exit(0))


### PR DESCRIPTION
`bs=1G` means "read 1GB into memory at a time"; we really don't need that.

On a system with 6GB physical memory (while our test VM is configured to have 8 GB of virtual RAM), this seems to result in trashing and exceeding the 30s timeout, while with a smaller block size, the copy happens in <13 seconds. (`dd` itself reports 11 s vs. 27 s).
