### PR TITLE
pkg/machine/vmconfigs: add tests for SplitVolume

### DIFF
--- a/pkg/machine/vmconfigs/volumes_test.go
+++ b/pkg/machine/vmconfigs/volumes_test.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package vmconfigs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitVolume(t *testing.T) {
+	tests := []struct {
+		name         string
+		idx          int
+		volume       string
+		wantTag      string
+		wantSource   string
+		wantTarget   string
+		wantReadonly bool
+		wantSecModel string
+	}{
+		{"read-only option", 0, "/host:/guest:ro", "vol0", "/host", "/guest", true, "none"},
+		{"read-write option", 1, "/host:/guest:rw", "vol1", "/host", "/guest", false, "none"},
+		{"security model option", 2, "/host:/guest:security_model=mapped", "vol2", "/host", "/guest", false, "mapped"},
+		{"combined options", 0, "/host:/guest:ro,security_model=none", "vol0", "/host", "/guest", true, "none"},
+		{"no options uses defaults", 3, "/host:/guest", "vol3", "/host", "/guest", false, "none"},
+		{"source only targets itself", 0, "/host", "vol0", "/host", "/host", false, "none"},
+		{"unknown option is ignored", 0, "/host:/guest:bogus", "vol0", "/host", "/guest", false, "none"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tag, source, target, readonly, securityModel := SplitVolume(tt.idx, tt.volume)
+			assert.Equal(t, tt.wantTag, tag)
+			assert.Equal(t, tt.wantSource, source)
+			assert.Equal(t, tt.wantTarget, target)
+			assert.Equal(t, tt.wantReadonly, readonly)
+			assert.Equal(t, tt.wantSecModel, securityModel)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

`SplitVolume` (`pkg/machine/vmconfigs/volumes.go`) parses a `podman machine` volume spec (`source:target:options`) into its tag, source, target, read-only flag and security model, but the whole parsing chain (`SplitVolume` / `extractMountOptions` / `pathsFromVolume` / `extractSourcePath` / `extractTargetPath`) had no unit test. This adds a table-driven test covering the `ro`/`rw` and `security_model=` options, combined options, the no-options defaults, a source-only spec (which targets itself), and an unknown option being ignored.


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
