### PR TITLE
specgen: ensure keep-id overrides image USER

### DIFF
--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -2,6 +2,7 @@ package artifact
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -36,6 +37,7 @@ type listFlagType struct {
 	format    string
 	noHeading bool
 	noTrunc   bool
+	quiet     bool
 }
 
 type artifactListOutput struct {
@@ -78,9 +80,14 @@ func init() {
 	_ = listCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&artifactListOutput{}))
 	flags.BoolVarP(&listFlag.noHeading, "noheading", "n", false, "Do not print column headings")
 	flags.BoolVar(&listFlag.noTrunc, "no-trunc", false, "Do not truncate output")
+	flags.BoolVarP(&listFlag.quiet, "quiet", "q", false, "Display only artifact digests")
 }
 
 func list(cmd *cobra.Command, _ []string) error {
+	if listFlag.quiet && cmd.Flags().Changed("format") {
+		return errors.New("quiet and format flags cannot be used together")
+	}
+
 	reports, err := registry.ImageEngine().ArtifactList(registry.Context(), entities.ArtifactListOptions{})
 	if err != nil {
 		return err
@@ -135,11 +142,22 @@ func list(cmd *cobra.Command, _ []string) error {
 		})
 	}
 
+	if listFlag.quiet {
+		quietOut(artifacts)
+		return nil
+	}
+
 	switch {
 	case report.IsJSON(listFlag.format):
 		return writeJSON(artifacts)
 	default:
 		return writeTemplate(cmd, artifacts)
+	}
+}
+
+func quietOut(listed []artifactListOutput) {
+	for _, a := range listed {
+		fmt.Println(a.Digest)
 	}
 }
 

--- a/docs/source/markdown/podman-artifact-ls.1.md.in
+++ b/docs/source/markdown/podman-artifact-ls.1.md.in
@@ -30,6 +30,10 @@ Print results with a Go template.
 
 @@option noheading
 
+#### **--quiet**, **-q**
+
+Lists only the artifact digests.
+
 ## EXAMPLES
 
 List artifacts in the local store
@@ -74,6 +78,13 @@ $ podman artifact ls --format json"
         "Digest": "cd734b558ceb"
     }
 ]
+```
+
+List only artifact digests
+```
+$ podman artifact ls --quiet
+ab609fad386d
+cd734b558ceb
 ```
 
 

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -244,14 +244,21 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 			toReturn = append(toReturn, libpod.WithAddCurrentUserPasswdEntry())
 		}
 
+		imageUser := ""
+		if imageData != nil && imageData.Config != nil {
+			imageUser = imageData.Config.User
+		}
+
 		// If user is not overridden, set user in the container
 		// to user running Podman.
-		if s.User == "" {
+		if s.User == "" || (imageUser != "" && s.User == imageUser) {
 			_, uid, gid, err := util.GetKeepIDMapping(opts)
 			if err != nil {
 				return nil, err
 			}
-			toReturn = append(toReturn, libpod.WithUser(fmt.Sprintf("%d:%d", uid, gid)))
+			keepIDUser := fmt.Sprintf("%d:%d", uid, gid)
+			toReturn = append(toReturn, libpod.WithUser(keepIDUser))
+			s.User = keepIDUser
 		}
 	case specgen.FromPod:
 		if pod == nil || infraCtr == nil {

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -87,6 +87,30 @@ var _ = Describe("Podman artifact", func() {
 		Expect(noHeaderOutput).To(HaveLen(2))
 		Expect(noHeaderOutput).ToNot(ContainElement("REPOSITORY"))
 
+		// check with --quiet and verify only the (truncated) digests are printed
+		quietSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--quiet")
+		quietOutput := quietSession.OutputToStringArray()
+		Expect(quietOutput).To(HaveLen(2))
+		Expect(quietOutput).ToNot(ContainElement("REPOSITORY"))
+		Expect(quietOutput).To(ContainElement(defaultOutput))
+		for _, digest := range quietOutput {
+			Expect(digest).To(HaveLen(12))
+		}
+
+		// check with --quiet and --no-trunc combined and verify full (non-truncated) digests are printed
+		quietNoTruncSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--quiet", "--no-trunc")
+		quietNoTruncOutput := quietNoTruncSession.OutputToStringArray()
+		Expect(quietNoTruncOutput).To(HaveLen(2))
+		Expect(quietNoTruncOutput).ToNot(ContainElement("REPOSITORY"))
+		for _, digest := range quietNoTruncOutput {
+			Expect(digest).To(HaveLen(len(add1.OutputToString())))
+		}
+
+		// check --quiet and --format together are rejected
+		quietFormatSession := podmanTest.Podman([]string{"artifact", "ls", "--quiet", "--format", "{{.Repository}}"})
+		quietFormatSession.WaitWithDefaultTimeout()
+		Expect(quietFormatSession).To(ExitWithError(125, "quiet and format flags cannot be used together"))
+
 		// Check if .VirtualSize is reported correctly
 		virtualSizeFormatSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.VirtualSize}}")
 		virtualSizes := virtualSizeFormatSession.OutputToStringArray()

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -198,6 +198,17 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(exec2).Should(ExitCleanly())
 	})
 
+	It("podman --userns=keep-id overrides image user", func() {
+		// Run container with --userns=keep-id against an image with a predefined USER
+		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "quay.io/libpod/testimage:20241011", "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		// Verify the UID inside the container matches the host user's EUID
+		uid := strconv.Itoa(os.Geteuid())
+		Expect(session.OutputToString()).To(Equal(uid))
+	})
+
 	It("podman --userns=auto", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fixes #29600

#### What this PR does / why we need it
When running a container with `--userns=keep-id`, `s.User` retained the image's default `USER` directive if no explicit `--user` flag was passed. This caused downstream spec generation to retain the image user instead of mapping to the host user running Podman.

In `namespaces.go` file where `s.User == ""` (it is already populated before when running the `container.go` file) therefore we need another check to see if it matches `s.User == imageUser`.
