### PR TITLE
fix(api): nil check Memory.Limit before dereference in stats handler

### DIFF
--- a/pkg/api/handlers/compat/containers_stats_linux.go
+++ b/pkg/api/handlers/compat/containers_stats_linux.go
@@ -72,7 +72,7 @@ func statsContainerJSON(ctnr *libpod.Container, stats *define.ContainerStats, pr
 
 	resources := ctnr.LinuxResources()
 	memoryLimit := cgroupStat.MemoryStats.Usage.Limit
-	if resources != nil && resources.Memory != nil && *resources.Memory.Limit > 0 {
+	if resources != nil && resources.Memory != nil && resources.Memory.Limit != nil && *resources.Memory.Limit > 0 {
 		memoryLimit = uint64(*resources.Memory.Limit)
 	}
 

--- a/test/apiv2/19-stats.at
+++ b/test/apiv2/19-stats.at
@@ -27,3 +27,9 @@ podman rm -f testctr2
 
 podman network rm testnet1
 podman network rm testnet2
+
+# regression for https://github.com/containers/podman/issues/29627
+# stats should not panic when memory-reservation is set without memory-limit
+podman run -dt --name testctr3 --memory-reservation=10m $IMAGE top &>/dev/null
+t GET libpod/containers/testctr3/stats?stream=false 200
+podman rm -f testctr3


### PR DESCRIPTION
Fixes #29627

When a container is created with `--memory-reservation` but without `--memory-limit`, the OCI spec has a non-nil `Memory` object with a nil `Limit` pointer. The compat stats handler dereferences `*resources.Memory.Limit` without checking for nil first, causing a panic that returns a 500 error to the client.

Add a nil check for `resources.Memory.Limit` before dereferencing it.

### How to reproduce

```
podman run -d --name t --memory-reservation 10m --entrypoint sleep alpine 60
curl -s --unix-socket /run/podman/podman.sock 'http://d/v1.41/containers/t/stats?stream=false'
```

### Test plan

Added a regression test in `test/apiv2/19-stats.at` that creates a container with `--memory-reservation` only and verifies the stats endpoint returns 200 without panic.

### Test result

N/A — will be verified by CI once authorized.
