### PR TITLE
test/apiv2: build healthcheck image as docker

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -645,7 +645,8 @@ cat >$HEALTHCHECK_INHERIT_TMPD/Dockerfile <<EOF
 FROM $IMAGE
 HEALTHCHECK --interval=99s --timeout=98s --start-period=97s --start-interval=96s --retries=95 CMD true
 EOF
-podman build -t healthcheck_inherit $HEALTHCHECK_INHERIT_TMPD &>/dev/null
+# HEALTHCHECK is only recorded in the docker image format, the oci default drops it
+podman build --format docker -t healthcheck_inherit $HEALTHCHECK_INHERIT_TMPD &>/dev/null
 
 # empty Test inherits the image healthcheck unchanged (all fields preserved)
 t POST containers/create Image=healthcheck_inherit Cmd='["top"]' Healthcheck='{"Test":[]}' 201 \


### PR DESCRIPTION
building test/apiv2/20-containers.at's healthcheck_inherit image without `--format docker`. `HEALTHCHECK` is only recorded in the docker image format, so the oci default drops it silently and inherit has nothing to inherit from.

```
$ podman build -t healthcheck_inherit /t
STEP 2/2: HEALTHCHECK --interval=99s ... CMD true
level=warning msg="HEALTHCHECK is not supported for OCI image format and will be ignored. Must use `docker` format"
$ podman image inspect healthcheck_inherit --format '{{json .HealthCheck}}'
null
```

`--format docker` on the same image gives exactly what the test asserts:

```
{"Test":["CMD-SHELL","true"],"StartPeriod":97000000000,"StartInterval":96000000000,"Interval":99000000000,"Timeout":98000000000,"Retries":95}
```
