### PR TITLE
specgen: ensure keep-id overrides image USER

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -320,7 +320,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		s.SeccompProfilePath = p
 	}
 
-	if len(s.User) == 0 && inspectData != nil {
+	if len(s.User) == 0 && inspectData != nil && !s.UserNS.IsKeepID() {
 		s.User = inspectData.Config.User
 	}
 	// Unless already set via the CLI, check if we need to disable process

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -198,6 +198,26 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(exec2).Should(ExitCleanly())
 	})
 
+	It("podman --userns=keep-id overrides image default user", func() {
+		// 1. Create a temporary Containerfile that sets a custom image user
+		dockerfile := fmt.Sprintf("FROM %s\nUSER 1001\n", CITEST_IMAGE)
+		imageName := "test-keepid-user-image"
+
+		podmanTest.BuildImage(dockerfile, imageName, "false")
+
+		// 2. Case 1: --userns=keep-id without --user flag -> should run as host user UID
+		session := podmanTest.Podman([]string{"run", "--userns=keep-id", imageName, "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(Equal(strconv.Itoa(os.Geteuid())))
+
+		// 3. Case 2: --userns=keep-id with explicit --user 1001 -> should run as UID 1001
+		session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--user", "1001", imageName, "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(Equal("1001"))
+	})
+
 	It("podman --userns=auto", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fixes #29600

#### What this PR does / why we need it
When running a container with `--userns=keep-id`, `s.User` retained the image's default `USER` directive if no explicit `--user` flag was passed. This caused downstream spec generation to retain the image user instead of mapping to the host user running Podman.

In `namespaces.go` file where `s.User == ""` (it is already populated before when running the `container.go` file) therefore we need another check to see if it matches `s.User == imageUser`.

Added tests too in `test/e2e/run_userns_test.go` file