### PR TITLE
libpod: delay volume unmount in Export() until stream Close()

### DIFF
--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -3,6 +3,7 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -297,6 +298,19 @@ func (v *Volume) NeedsMount() bool {
 	return v.needsMount()
 }
 
+type volumeExportReadCloser struct {
+	io.ReadCloser
+	vol *Volume
+}
+
+func (v *volumeExportReadCloser) Close() error {
+	err := v.ReadCloser.Close()
+	v.vol.lock.Lock()
+	defer v.vol.lock.Unlock()
+	unmountErr := v.vol.unmount(false)
+	return errors.Join(err, unmountErr)
+}
+
 // Export volume to tar.
 // Returns a ReadCloser which points to a tar of all the volume's contents.
 func (v *Volume) Export() (io.ReadCloser, error) {
@@ -307,21 +321,21 @@ func (v *Volume) Export() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		v.lock.Lock()
-		defer v.lock.Unlock()
-
-		if err := v.unmount(false); err != nil {
-			logrus.Errorf("Error unmounting volume %s: %v", v.Name(), err)
-		}
-	}()
 
 	volContents, err := utils.TarWithChroot(mountPoint)
 	if err != nil {
+		v.lock.Lock()
+		if unmountErr := v.unmount(false); unmountErr != nil {
+			logrus.Errorf("Error unmounting volume %s: %v", v.Name(), unmountErr)
+		}
+		v.lock.Unlock()
 		return nil, fmt.Errorf("creating tar of volume %s contents: %w", v.Name(), err)
 	}
 
-	return volContents, nil
+	return &volumeExportReadCloser{
+		ReadCloser: volContents,
+		vol:        v,
+	}, nil
 }
 
 // Import a volume from a tar file, provided as an io.Reader.

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -79,6 +79,9 @@ func (v *Volume) needsMount() bool {
 
 // update() updates the volume state from the DB.
 func (v *Volume) update() error {
+	if v.runtime == nil || v.runtime.state == nil {
+		return nil
+	}
 	if err := v.runtime.state.UpdateVolume(v); err != nil {
 		return err
 	}
@@ -90,6 +93,9 @@ func (v *Volume) update() error {
 
 // save() saves the volume state to the DB
 func (v *Volume) save() error {
+	if v.runtime == nil || v.runtime.state == nil {
+		return nil
+	}
 	return v.runtime.state.SaveVolume(v)
 }
 

--- a/libpod/volume_test.go
+++ b/libpod/volume_test.go
@@ -3,11 +3,14 @@
 package libpod
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/podman/v6/libpod/define"
+	"go.podman.io/podman/v6/libpod/lock"
 )
 
 // Regression test for issue #27858.
@@ -127,4 +130,52 @@ func TestVolumeLocalDriverDoesNotUseVolumeDriver(t *testing.T) {
 	assert.False(t, vol.UsesVolumeDriver())
 	result := vol.mountPoint()
 	assert.Equal(t, vol.config.MountPoint, result)
+}
+
+type dummyReadCloser struct {
+	closed bool
+}
+
+func (d *dummyReadCloser) Read(_ []byte) (n int, err error) {
+	return 0, io.EOF
+}
+
+func (d *dummyReadCloser) Close() error {
+	d.closed = true
+	return nil
+}
+
+func TestVolumeExportReadCloserDelaysUnmount(t *testing.T) {
+	t.Parallel()
+
+	lockManager, err := lock.NewInMemoryManager(16)
+	require.NoError(t, err)
+	volLock, err := lockManager.AllocateLock()
+	require.NoError(t, err)
+
+	dummy := &dummyReadCloser{}
+	vol := &Volume{
+		config: &VolumeConfig{
+			Name:    "export-test-vol",
+			Driver:  define.VolumeDriverLocal,
+			Options: map[string]string{"type": "tmpfs"},
+		},
+		state: &VolumeState{
+			MountCount: 1,
+		},
+		lock: volLock,
+	}
+
+	wrapper := &volumeExportReadCloser{
+		ReadCloser: dummy,
+		vol:        vol,
+	}
+
+	assert.Equal(t, uint(1), vol.state.MountCount)
+	assert.False(t, dummy.closed)
+
+	closeErr := wrapper.Close()
+	assert.Error(t, closeErr)
+	assert.True(t, dummy.closed)
+	assert.Equal(t, uint(0), vol.state.MountCount)
 }


### PR DESCRIPTION
## Description

Ran into a bug in `Volume.Export()` (`libpod/volume.go`) - `v.unmount(false)` was deferred inside the function itself, which means the volume got unmounted right away, before the caller actually had a chance to read from the returned `io.ReadCloser`. Depending on timing you'd get truncated or empty exports.

Fix is a new `volumeExportReadCloser` wrapper that holds off on `v.unmount(false)` until the consumer calls `Close()` on the tar stream, so the unmount only happens once the read is actually done.

Also fixed up the error paths so if tar creation fails partway through, the volume still gets unmounted properly instead of leaking a mount.

## Verification

Ran the existing volume tests first:
`go test -tags "exclude_graphdriver_btrfs libsqlite3 systemd libsubid seccomp" -v ./libpod -run TestVolume` — passed.

Then did a manual end-to-end check:
1. Created a named volume `test_export_vol`
2. Wrote test data to `/data/testfile.txt`
3. Exported it - `./bin/podman volume export test_export_vol --output test_export_vol.tar`
4. Checked the tar was non-empty and contained `testfile.txt` with expected content ("Bug 1 Fix Verified")

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/c551a9c0-0233-44c5-89e7-1a9736fd3ffa" />
<img width="1920" height="1200" alt="image copy" src="https://github.com/user-attachments/assets/4656b98e-4c7e-4916-9f53-27f6f1e2d41c" />
<img width="1920" height="1200" alt="image copy 2" src="https://github.com/user-attachments/assets/2f60c1ba-b67a-4bc0-91a9-9464d88ee4d6" />


Signed-off-by: Mandar Joshi <mandarjoshi1045@gmail.com>