### PR TITLE
podman ps: allow sorting by pod (finishes #13033's --sort half)

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1688,9 +1688,9 @@ func AutocompletePodPsSort(_ *cobra.Command, _ []string, _ string) ([]string, co
 }
 
 // AutocompletePsSort - Autocomplete images sort options.
-// -> "command", "created", "id", "image", "names", "runningfor", "size", "status"
+// -> "command", "created", "id", "image", "names", "pod", "runningfor", "size", "status"
 func AutocompletePsSort(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	sortBy := []string{"command", "created", "id", "image", "names", "runningfor", "size", "status"}
+	sortBy := []string{"command", "created", "id", "image", "names", "pod", "runningfor", "size", "status"}
 	return sortBy, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -101,7 +101,7 @@ func listFlagSet(cmd *cobra.Command) {
 	flags.UintVarP(&listOpts.Watch, watchFlagName, "w", 0, "Watch the ps output on an interval in seconds")
 	_ = cmd.RegisterFlagCompletionFunc(watchFlagName, completion.AutocompleteNone)
 
-	sort := validate.Value(&listOpts.Sort, "command", "created", "id", "image", "names", "runningfor", "size", "status")
+	sort := validate.Value(&listOpts.Sort, "command", "created", "id", "image", "names", "pod", "runningfor", "size", "status")
 	sortFlagName := "sort"
 	flags.Var(sort, sortFlagName, "Sort output by: "+sort.Choices())
 	_ = cmd.RegisterFlagCompletionFunc(sortFlagName, common.AutocompletePsSort)

--- a/docs/source/markdown/podman-ps.1.md.in
+++ b/docs/source/markdown/podman-ps.1.md.in
@@ -116,7 +116,7 @@ Display the total file size
 
 #### **--sort**=*created*
 
-Sort by command, created, id, image, names, runningfor, size, or status",
+Sort by command, created, id, image, names, pod, runningfor, size, or status",
 Note: Choosing size sorts by size of rootFs, not alphabetically like the rest of the options
 
 #### **--sync**

--- a/pkg/domain/entities/container_ps.go
+++ b/pkg/domain/entities/container_ps.go
@@ -51,7 +51,7 @@ func (a psSortedNames) Less(i, j int) bool {
 type psSortedPod struct{ SortListContainers }
 
 func (a psSortedPod) Less(i, j int) bool {
-	return a.SortListContainers[i].Pod < a.SortListContainers[j].Pod
+	return a.SortListContainers[i].PodName < a.SortListContainers[j].PodName
 }
 
 type psSortedRunningFor struct{ SortListContainers }
@@ -102,7 +102,7 @@ func SortPsOutput(sortBy string, psOutput SortListContainers) (SortListContainer
 	case "pod":
 		sort.Sort(psSortedPod{psOutput})
 	default:
-		return nil, errors.New("invalid option for --sort, options are: command, created, id, image, names, runningfor, size, or status")
+		return nil, errors.New("invalid option for --sort, options are: command, created, id, image, names, pod, runningfor, size, or status")
 	}
 	return psOutput, nil
 }

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -519,6 +519,26 @@ var _ = Describe("Podman ps", func() {
 		})).To(BeTrue(), "slice is sorted")
 	})
 
+	It("podman --sort by pod", func() {
+		// Create the pods in reverse-alphabetical order so a broken sort
+		// (falling back to creation order) would fail this test.
+		for _, name := range []string{"bpod", "apod"} {
+			pod := podmanTest.Podman([]string{"pod", "create", "--name", name})
+			pod.WaitWithDefaultTimeout()
+			Expect(pod).Should(ExitCleanly())
+
+			ctr := podmanTest.Podman([]string{"create", "--pod", name, ALPINE, "top"})
+			ctr.WaitWithDefaultTimeout()
+			Expect(ctr).Should(ExitCleanly())
+		}
+
+		session := podmanTest.Podman([]string{"ps", "-a", "--pod", "--sort=pod", "--format", "{{.PodName}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		Expect(sort.StringsAreSorted(session.OutputToStringArray())).To(BeTrue(), "containers are sorted by pod name")
+	})
+
 	It("podman --sort by command", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

`SortPsOutput` already had a `case "pod"` backed by the `psSortedPod` sorter, but `pod`
was not among the `--sort` flag's accepted values (`validate.Value`), so it was rejected
before ever reaching the sorter — the sort option was unreachable. This wires it up by
adding `pod` to the four surfaces that excluded it: the `--sort` accepted values, shell
completion, the invalid-option error message, and the man page. Completes the `--sort`
part of the RFE in #13033 (the `--format` part already works).


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
