### PR TITLE
pkg/bindings: keep auth fields out of the query string

### DIFF
--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -136,7 +136,7 @@ type PushOptions struct {
 	All *bool
 	// Authfile is the path to the authentication file. Ignored for remote
 	// calls.
-	Authfile *string
+	Authfile *string `schema:"-"`
 	// Compress tarball image layers when pushing to a directory using the 'dir' transport.
 	Compress *bool
 	// CompressionFormat is the format to use for the compression of the blobs
@@ -180,7 +180,7 @@ type PushOptions struct {
 type SearchOptions struct {
 	// Authfile is the path to the authentication file. Ignored for remote
 	// calls.
-	Authfile *string
+	Authfile *string `schema:"-"`
 	// Filters for the search results.
 	Filters map[string][]string
 	// Limit the number of results.
@@ -206,7 +206,7 @@ type PullOptions struct {
 	Arch *string
 	// Authfile is the path to the authentication file. Ignored for remote
 	// calls.
-	Authfile *string
+	Authfile *string `schema:"-"`
 	// OS will overwrite the local operating system (OS) for image
 	// pulls.
 	OS *string

--- a/pkg/bindings/kube/types.go
+++ b/pkg/bindings/kube/types.go
@@ -11,13 +11,13 @@ type PlayOptions struct {
 	// Annotations - Annotations to add to Pods
 	Annotations map[string]string
 	// Authfile - path to an authentication file.
-	Authfile *string
+	Authfile *string `schema:"-"`
 	// CertDir - to a directory containing TLS certifications and keys.
 	CertDir *string
 	// Username for authenticating against the registry.
-	Username *string
+	Username *string `schema:"-"`
 	// Password for authenticating against the registry.
-	Password *string
+	Password *string `schema:"-"`
 	// Network - name of the networks to connect to.
 	Network *[]string
 	// NoHostname - do not generate /etc/hostname file in pod's containers

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -90,10 +90,9 @@ func Inspect(ctx context.Context, name string, options *InspectOptions) (*manife
 	if err != nil {
 		return nil, err
 	}
-	// SkipTLSVerify is special.  We need to delete the param added by
-	// ToParams() and change the key and flip the bool
+	// SkipTLSVerify is not serialized by ToParams(); the server expects
+	// tlsVerify with the opposite meaning.
 	if options.SkipTLSVerify != nil {
-		params.Del("SkipTLSVerify")
 		params.Set("tlsVerify", strconv.FormatBool(!options.GetSkipTLSVerify()))
 	}
 
@@ -128,10 +127,9 @@ func InspectListData(ctx context.Context, name string, options *InspectOptions) 
 	if err != nil {
 		return nil, err
 	}
-	// SkipTLSVerify is special.  We need to delete the param added by
-	// ToParams() and change the key and flip the bool
+	// SkipTLSVerify is not serialized by ToParams(); the server expects
+	// tlsVerify with the opposite meaning.
 	if options.SkipTLSVerify != nil {
-		params.Del("SkipTLSVerify")
 		params.Set("tlsVerify", strconv.FormatBool(!options.GetSkipTLSVerify()))
 	}
 

--- a/pkg/bindings/manifests/types.go
+++ b/pkg/bindings/manifests/types.go
@@ -7,10 +7,10 @@ import "io"
 //go:generate go run ../generator/generator.go InspectOptions
 type InspectOptions struct {
 	// Authfile - path to an authentication file.
-	Authfile *string
+	Authfile *string `schema:"-"`
 	// SkipTLSVerify - skip https and certificate validation when
 	// contacting container registries.
-	SkipTLSVerify *bool
+	SkipTLSVerify *bool `schema:"-"`
 }
 
 // CreateOptions are optional options for creating manifests
@@ -43,10 +43,10 @@ type AddOptions struct {
 	Variant    *string
 
 	Images        []string
-	Authfile      *string
-	Password      *string
-	Username      *string
-	SkipTLSVerify *bool `schema:"-"`
+	Authfile      *string `schema:"-"`
+	Password      *string `schema:"-"`
+	Username      *string `schema:"-"`
+	SkipTLSVerify *bool   `schema:"-"`
 }
 
 // AddArtifactOptions are optional options for adding artifact manifests
@@ -95,10 +95,10 @@ type ModifyOptions struct {
 	Variant          *string           // Variant overrides the architecture variant for the image
 
 	Images        []string // Images is an optional list of images to add/remove to/from manifest list depending on operation
-	Authfile      *string
-	Password      *string
-	Username      *string
-	SkipTLSVerify *bool `schema:"-"`
+	Authfile      *string  `schema:"-"`
+	Password      *string  `schema:"-"`
+	Username      *string  `schema:"-"`
+	SkipTLSVerify *bool    `schema:"-"`
 
 	ArtifactType          **string          `json:"artifact_type"`           // the ArtifactType in an artifact manifest being created
 	ArtifactConfigType    *string           `json:"artifact_config_type"`    // the config.MediaType in an artifact manifest being created

--- a/pkg/bindings/test/types_test.go
+++ b/pkg/bindings/test/types_test.go
@@ -13,54 +13,85 @@ import (
 var _ = Describe("Binding types", func() {
 	It("serialize image pull options", func() {
 		var writer bytes.Buffer
-		opts := new(images.PullOptions).WithOS("foo").WithProgressWriter(&writer).WithSkipTLSVerify(true)
+		opts := new(images.PullOptions).WithOS("foo").WithProgressWriter(&writer).WithSkipTLSVerify(true).
+			WithAuthfile("/tmp/auth.json").WithUsername("user").WithPassword("pass")
 		params, err := opts.ToParams()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(params.Get("os")).To(Equal("foo"))
 		Expect(params.Has("progresswriter")).To(BeFalse())
 		Expect(params.Has("skiptlsverify")).To(BeFalse())
+		Expect(params.Has("authfile")).To(BeFalse())
+		Expect(params.Has("username")).To(BeFalse())
+		Expect(params.Has("password")).To(BeFalse())
 	})
 
 	It("serialize image push options", func() {
 		var writer bytes.Buffer
-		opts := new(images.PushOptions).WithAll(true).WithProgressWriter(&writer).WithSkipTLSVerify(true)
+		opts := new(images.PushOptions).WithAll(true).WithProgressWriter(&writer).WithSkipTLSVerify(true).
+			WithAuthfile("/tmp/auth.json").WithUsername("user").WithPassword("pass")
 		params, err := opts.ToParams()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(params.Get("all")).To(Equal("true"))
 		Expect(params.Has("progresswriter")).To(BeFalse())
 		Expect(params.Has("skiptlsverify")).To(BeFalse())
+		Expect(params.Has("authfile")).To(BeFalse())
+		Expect(params.Has("username")).To(BeFalse())
+		Expect(params.Has("password")).To(BeFalse())
 	})
 
 	It("serialize image search options", func() {
-		opts := new(images.SearchOptions).WithLimit(123).WithSkipTLSVerify(true)
+		opts := new(images.SearchOptions).WithLimit(123).WithSkipTLSVerify(true).
+			WithAuthfile("/tmp/auth.json").WithUsername("user").WithPassword("pass")
 		params, err := opts.ToParams()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(params.Get("limit")).To(Equal("123"))
 		Expect(params.Has("skiptlsverify")).To(BeFalse())
+		Expect(params.Has("authfile")).To(BeFalse())
+		Expect(params.Has("username")).To(BeFalse())
+		Expect(params.Has("password")).To(BeFalse())
 	})
 
 	It("serialize manifest modify options", func() {
-		opts := new(manifests.ModifyOptions).WithOS("foo").WithSkipTLSVerify(true)
+		opts := new(manifests.ModifyOptions).WithOS("foo").WithSkipTLSVerify(true).
+			WithAuthfile("/tmp/auth.json").WithUsername("user").WithPassword("pass")
 		params, err := opts.ToParams()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(params.Get("os")).To(Equal("foo"))
 		Expect(params.Has("skiptlsverify")).To(BeFalse())
+		Expect(params.Has("authfile")).To(BeFalse())
+		Expect(params.Has("username")).To(BeFalse())
+		Expect(params.Has("password")).To(BeFalse())
 	})
 
 	It("serialize manifest add options", func() {
-		opts := new(manifests.AddOptions).WithAll(true).WithOS("foo").WithSkipTLSVerify(true)
+		opts := new(manifests.AddOptions).WithAll(true).WithOS("foo").WithSkipTLSVerify(true).
+			WithAuthfile("/tmp/auth.json").WithUsername("user").WithPassword("pass")
 		params, err := opts.ToParams()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(params.Get("all")).To(Equal("true"))
 		Expect(params.Get("os")).To(Equal("foo"))
 		Expect(params.Has("skiptlsverify")).To(BeFalse())
+		Expect(params.Has("authfile")).To(BeFalse())
+		Expect(params.Has("username")).To(BeFalse())
+		Expect(params.Has("password")).To(BeFalse())
 	})
 
 	It("serialize kube play options", func() {
-		opts := new(kube.PlayOptions).WithQuiet(true).WithSkipTLSVerify(true)
+		opts := new(kube.PlayOptions).WithQuiet(true).WithSkipTLSVerify(true).
+			WithAuthfile("/tmp/auth.json").WithUsername("user").WithPassword("pass")
 		params, err := opts.ToParams()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(params.Get("quiet")).To(Equal("true"))
+		Expect(params.Has("skiptlsverify")).To(BeFalse())
+		Expect(params.Has("authfile")).To(BeFalse())
+		Expect(params.Has("username")).To(BeFalse())
+		Expect(params.Has("password")).To(BeFalse())
+	})
+	It("serialize manifest inspect options", func() {
+		opts := new(manifests.InspectOptions).WithAuthfile("/tmp/auth.json").WithSkipTLSVerify(true)
+		params, err := opts.ToParams()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(params.Has("authfile")).To(BeFalse())
 		Expect(params.Has("skiptlsverify")).To(BeFalse())
 	})
 })


### PR DESCRIPTION
When podman remote runs kube play, manifest add/modify/inspect or image
pull/push/search, it copies Authfile, Username and Password into the query
string of the request URL. The server does not read them there, it takes the
credentials from the X-Registry-Auth header instead, so the copies in the URL
serve no purpose.
Commit cfdca82938 added schema:"-" to these fields for image pull and push so
that ToParams leaves them out. The same tag was never added to the other
options, so this adds it.
InspectOptions.SkipTLSVerify had the same problem. Tagging it also lets me
drop the two params.Del("SkipTLSVerify") calls, which never removed anything
because ToParams stores keys in lower case and Del is case sensitive.
The tests in pkg/bindings/test/types_test.go now check that these fields do
not appear in the query string.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
