### PR TITLE
bindings: use a per-test network config dir, allow parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -727,7 +727,8 @@ ginkgo-remote:
 # bindings tests need access to podman-registry
 testbindings: PATH := $(PATH):$(CURDIR)/hack
 testbindings: .install.ginkgo
-	$(GINKGO) -v $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --trace --no-color --timeout 30m  -v -r ./pkg/bindings/test
+	$(GINKGO) -v $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --trace --no-color --timeout 30m \
+		$(if $(findstring y,$(GINKGO_PARALLEL)),-p,) -r ./pkg/bindings/test
 
 .PHONY: localintegration
 localintegration: test-binaries ginkgo ## Run integration tests locally (test/e2e/)

--- a/pkg/bindings/test/exec_test.go
+++ b/pkg/bindings/test/exec_test.go
@@ -52,10 +52,15 @@ var _ = Describe("Podman containers exec", func() {
 		err = containers.ExecStart(bt.conn, sessionID, nil)
 		Expect(err).ToNot(HaveOccurred())
 
-		inspectOut, err = containers.ExecInspect(bt.conn, sessionID, nil)
-		Expect(err).ToNot(HaveOccurred())
+		// ExecStart returning only means the session was started, the process
+		// can still be running when we inspect it.
+		Eventually(func() bool {
+			inspectOut, err = containers.ExecInspect(bt.conn, sessionID, nil)
+			Expect(err).ToNot(HaveOccurred())
+			return inspectOut.Running
+		}, "20s", "250ms").Should(BeFalse(), "session should not be running")
+
 		Expect(inspectOut.ContainerID).To(Equal(cid))
-		Expect(inspectOut.Running).To(BeFalse(), "session should not be running")
 		Expect(inspectOut.ExitCode).To(Equal(0), "exit code from echo")
 	})
 

--- a/pkg/bindings/test/networks_test.go
+++ b/pkg/bindings/test/networks_test.go
@@ -16,7 +16,10 @@ import (
 	"go.podman.io/podman/v6/pkg/bindings/network"
 )
 
-var _ = Describe("Podman networks", func() {
+// Serial because the network config dir is shared between all the services
+// these tests start, so the prune in BeforeEach and the list assertions below
+// would see networks belonging to another test.
+var _ = Describe("Podman networks", Serial, func() {
 	var (
 		bt       *bindingTest
 		s        *gexec.Session

--- a/pkg/bindings/test/system_test.go
+++ b/pkg/bindings/test/system_test.go
@@ -15,7 +15,9 @@ import (
 	"go.podman.io/podman/v6/pkg/domain/entities/reports"
 )
 
-var _ = Describe("Podman system", func() {
+// Serial because system.Prune also prunes networks, and the network config dir
+// is shared between all the services these tests start.
+var _ = Describe("Podman system", Serial, func() {
 	var (
 		bt     *bindingTest
 		s      *gexec.Session


### PR DESCRIPTION
the epic at #18540 has an item for running the bindings tests in parallel, so I had a look at what was blocking it.

almost everything is already per test. runPodman passes --root, --runroot and --tmpdir from a fresh temp dir, so containers, pods, volumes and images are isolated per service. networks are not, and they should not be, the config dir is shared so podman can keep subnet allocation consistent across services.

what that leaves is two describes that do global network operations. the BeforeEach in networks_test.go prunes unfiltered, and system.Prune prunes networks too:

```go
// Remove all unused networks.
networkPruneOptions := entities.NetworkPruneOptions{}
```

both would take out networks belonging to another test under -p, so they are marked serial the way test/e2e already marks its own network prune test. nothing else in the suite touches networks, and only one It ever creates one.

then -p is gated on GINKGO_PARALLEL the same way ginkgo-run does, so GINKGO_PARALLEL=n puts it back to serial like pkg/machine/e2e.

I could not run the suite locally, I am on macos, so this needs CI.
