### PR TITLE
test/e2e: do not use os.Exit for error handling

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -195,19 +195,15 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		podman.createArtifact(image)
 	}
 
-	if err := os.MkdirAll(filepath.Join(ImageCacheDir, podman.ImageCacheFS+"-images"), 0o777); err != nil {
-		GinkgoWriter.Printf("%q\n", err)
-		os.Exit(1)
-	}
+	err = os.MkdirAll(filepath.Join(ImageCacheDir, podman.ImageCacheFS+"-images"), 0o777)
+	Expect(err).ToNot(HaveOccurred())
 	podman.Root = ImageCacheDir
 	// If running localized tests, the cache dir is created and populated. if the
 	// tests are remote, this is a no-op
 	populateCache(podman)
 
-	if err := os.MkdirAll(filepath.Join(globalTmpDir, lockdir), 0o700); err != nil {
-		GinkgoWriter.Printf("%q\n", err)
-		os.Exit(1)
-	}
+	err = os.MkdirAll(filepath.Join(globalTmpDir, lockdir), 0o700)
+	Expect(err).ToNot(HaveOccurred())
 
 	// If running remote, we need to stop the associated podman system service
 	if podman.RemoteTest {
@@ -741,10 +737,7 @@ func processTestResult(r SpecReport) {
 func GetPortLock(port string) *lockfile.LockFile {
 	lockFile := filepath.Join(LockTmpDir, port)
 	lock, err := lockfile.GetLockFile(lockFile)
-	if err != nil {
-		GinkgoWriter.Println(err)
-		os.Exit(1)
-	}
+	Expect(err).ToNot(HaveOccurred())
 	lock.Lock()
 	return lock
 }

--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"os"
 	"os/user"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -81,9 +80,7 @@ var _ = Describe("Podman top", func() {
 		Expect(result.OutputToStringArray()[1]).To(Equal("0"))
 
 		user, err := user.Current()
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).ToNot(HaveOccurred())
 
 		result = podmanTest.Podman([]string{"container", "top", session.OutputToString(), "huid"})
 		result.WaitWithDefaultTimeout()

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -39,13 +39,9 @@ var _ = Describe("Podman trust", Ordered, func() {
 		Expect(session).Should(ExitCleanly())
 		var teststruct map[string][]map[string]string
 		policyContent, err := os.ReadFile(policyJSON)
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).ToNot(HaveOccurred())
 		err = json.Unmarshal(policyContent, &teststruct)
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).ToNot(HaveOccurred())
 		Expect(teststruct["default"][0]).To(HaveKeyWithValue("type", "insecureAcceptAnything"))
 	})
 


### PR DESCRIPTION
another item off #18540, "do not use os.Exit() as error handling, let ginkgo handle errors so it can provide useful output".

there were six of them. os.Exit(1) takes the process down before ginkgo can report anything, so what you get in CI is a suite that stops with no failure and no location. three are inside It blocks in top_test.go and trust_test.go, the other three are in the SynchronizedBeforeSuite and in GetPortLock, which also run under ginkgo, so Expect works in all six:

```go
-		user, err := user.Current()
-		if err != nil {
-			os.Exit(1)
-		}
+		user, err := user.Current()
+		Expect(err).ToNot(HaveOccurred())
```

the two in the SynchronizedBeforeSuite were already printing to GinkgoWriter before exiting, so those lose nothing, Expect prints the same error plus the line.

the os.Exit(m.Run()) in TestMain is left alone, that one is how a Go test binary is supposed to exit.
