### PR TITLE
fix: specgen: do not inherit image USER with --userns=keep-id

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -321,7 +321,11 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	}
 
 	if len(s.User) == 0 && inspectData != nil {
-		s.User = inspectData.Config.User
+		// Only inherit the image user if we aren't using keep-id.
+		// keep-id overrides the image user to the current host user.
+		if s.UserNS.NSMode != specgen.KeepID {
+			s.User = inspectData.Config.User
+		}
 	}
 	// Unless already set via the CLI, check if we need to disable process
 	// labels or set the defaults.

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -177,6 +177,27 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(session.OutputToString()).To(Equal("0"))
 	})
 
+	It("podman --userns=keep-id overrides image USER", func() {
+		image := "user-override-keep-id"
+		podmanTest.BuildImage(podmanTest.TempDir, image, `FROM `+ALPINE+`
+RUN adduser -D -u 1001 appuser
+USER 1001`, ALPINE)
+
+		session := podmanTest.Podman([]string{"run", "--rm", "--userns=keep-id", image, "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		uid := os.Getuid()
+		// If running as root, keep-id means uid=0. If rootless, uid=caller's uid.
+		Expect(session.OutputToString()).To(Equal(fmt.Sprintf("%d", uid)))
+
+		// But if explicitly overridden, it must use the explicit user.
+		session = podmanTest.Podman([]string{"run", "--rm", "--userns=keep-id", "--user", "1001", image, "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(Equal("1001"))
+	})
+
 	It("podman run --userns=keep-id can add users", func() {
 		userName := os.Getenv("USER")
 		if userName == "" {


### PR DESCRIPTION
## Problem
When running an image that defines a `USER`, `podman run --userns=keep-id` incorrectly keeps using the image-defined user instead of running the container process as the invoking host user.

## Solution
Modified `pkg/specgen/generate/container.go` to skip populating `s.User` from the image configuration when `s.UserNS.NSMode == specgen.KeepID`. This preserves the fact that no explicit `--user` was passed, allowing `namespaceOptions()` to accurately apply the `keep-id` UID mapping.

Fixes: #29600

## Testing
- Added an e2e test `podman --userns=keep-id overrides image USER` in `test/e2e/run_userns_test.go`.
- All tests passed cleanly.