### PR TITLE
libpod(refactor): optimize directory empty check

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1942,21 +1942,21 @@ func (c *Container) mountNamedVolume(v *ContainerNamedVolume, mountpoint string)
 		// a bizarre issue where something copier.Get will ENOENT on
 		// empty directories and sometimes it will not.
 		// RHBZ#1928643
-		srcContents, err := os.ReadDir(srcDir)
+		srcEmpty, err := isDirEmpty(srcDir)
 		if err != nil {
 			return nil, fmt.Errorf("reading contents of source directory for copy up into volume %s: %w", vol.Name(), err)
 		}
-		if len(srcContents) == 0 {
+		if srcEmpty {
 			return vol, nil
 		}
 
 		// If the volume is not empty, we should not copy up.
 		volMount := vol.mountPoint()
-		contents, err := os.ReadDir(volMount)
+		volEmpty, err := isDirEmpty(volMount)
 		if err != nil {
 			return nil, fmt.Errorf("listing contents of volume %s mountpoint when copying up from container %s: %w", vol.Name(), c.ID(), err)
 		}
-		if len(contents) > 0 {
+		if !volEmpty {
 			// The volume is not empty. It was likely modified
 			// outside of Podman. For safety, let's not copy up into
 			// it. Fixes CVE-2020-1726.

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -3035,12 +3035,12 @@ func (c *Container) fixVolumePermissionsUnlocked(v *ContainerNamedVolume, vol *V
 	// If the volume is not empty, and it is not the first copy-up event -
 	// we should not do a chown.
 	if vol.state.NeedsChown && !vol.state.CopiedUp {
-		contents, err := os.ReadDir(vol.mountPoint())
+		empty, err := isDirEmpty(vol.mountPoint())
 		if err != nil {
 			return fmt.Errorf("reading contents of volume %q: %w", vol.Name(), err)
 		}
 		// Not empty, do nothing and unset NeedsChown.
-		if len(contents) > 0 {
+		if !empty {
 			vol.state.NeedsChown = false
 			if err := vol.save(); err != nil {
 				return fmt.Errorf("saving volume %q state: %w", vol.Name(), err)

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"os"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -347,11 +346,11 @@ func (v *Volume) Import(r io.Reader) error {
 		return fmt.Errorf("extracting into volume %s: %w", v.Name(), err)
 	}
 
-	contents, err := os.ReadDir(mountPoint)
+	empty, err := isDirEmpty(mountPoint)
 	if err != nil {
 		return fmt.Errorf("reading contents of imported volume %s: %w", v.Name(), err)
 	}
-	if len(contents) != 0 {
+	if !empty {
 		v.lock.Lock()
 		defer v.lock.Unlock()
 		if err := v.update(); err != nil {

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -3,7 +3,9 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"go.podman.io/podman/v6/libpod/define"
@@ -75,6 +77,23 @@ func (v *Volume) needsMount() bool {
 	}
 	// Local driver with options other than uid,gid needs mount
 	return len(v.config.Options) > index
+}
+
+func isDirEmpty(path string) (bool, error) {
+	dir, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer dir.Close()
+
+	_, err = dir.Readdirnames(1)
+	if err == nil {
+		return false, nil
+	}
+	if errors.Is(err, io.EOF) {
+		return true, nil
+	}
+	return false, err
 }
 
 // update() updates the volume state from the DB.


### PR DESCRIPTION
I noticed that the volume empty check is used in several places, thought it would be better to make a helper for that.
Ref: https://github.com/podman-container-tools/podman/pull/29614#discussion_r3828759095

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
