### PR TITLE
test/utils: fix BeValidJSON and remove IsJSONOutputValid

### DIFF
--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -42,7 +42,11 @@ var _ = Describe("Podman Info", func() {
 
 			desc := fmt.Sprintf("JSON test(%q)", tt.input)
 			Expect(session).Should(Exit(tt.exitCode), desc)
-			Expect(session.IsJSONOutputValid()).To(Equal(tt.success), desc)
+			if tt.success {
+				Expect(session.OutputToString()).To(BeValidJSON(), desc)
+			} else {
+				Expect(session.OutputToString()).ToNot(BeValidJSON(), desc)
+			}
 		}
 	})
 

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -68,7 +68,11 @@ var _ = Describe("Podman version", func() {
 
 			desc := fmt.Sprintf("JSON test(%q)", tt.input)
 			Expect(session).Should(Exit(tt.exitCode), desc)
-			Expect(session.IsJSONOutputValid()).To(Equal(tt.success), desc)
+			if tt.success {
+				Expect(session.OutputToString()).To(BeValidJSON(), desc)
+			} else {
+				Expect(session.OutputToString()).ToNot(BeValidJSON(), desc)
+			}
 		}
 	})
 

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -145,6 +145,8 @@ func (matcher *exitCleanlyMatcher) NegatedFailureMessage(_ any) (message string)
 
 type ValidJSONMatcher struct {
 	types.GomegaMatcher
+	// err is why the input was not valid JSON, reported in FailureMessage.
+	err error
 }
 
 func BeValidJSON() *ValidJSONMatcher {
@@ -159,13 +161,17 @@ func (matcher *ValidJSONMatcher) Match(actual any) (success bool, err error) {
 
 	var i any
 	if err := json.Unmarshal([]byte(s), &i); err != nil {
-		return false, err
+		// Not valid JSON is a mismatch, not a failure to evaluate. Returning
+		// the error here makes ToNot(BeValidJSON()) fail on exactly the input
+		// it is meant to accept, so keep it for FailureMessage instead.
+		matcher.err = err
+		return false, nil //nolint:nilerr // reported by FailureMessage
 	}
 	return true, nil
 }
 
 func (matcher *ValidJSONMatcher) FailureMessage(actual any) (message string) {
-	return format.Message(actual, "to be valid JSON")
+	return format.Message(actual, fmt.Sprintf("to be valid JSON: %v", matcher.err))
 }
 
 func (matcher *ValidJSONMatcher) NegatedFailureMessage(actual any) (message string) {

--- a/test/utils/podmansession_test.go
+++ b/test/utils/podmansession_test.go
@@ -36,14 +36,14 @@ var _ = Describe("PodmanSession test", func() {
 		Expect(session.ErrorToStringArray()).To(BeEmpty())
 	})
 
-	It("Test IsJSONOutputValid", func() {
+	It("Test BeValidJSON", func() {
 		session = StartFakeCmdSession([]string{`{"page":1,"fruits":["apple","peach","pear"]}`})
 		session.WaitWithDefaultTimeout()
-		Expect(session.IsJSONOutputValid()).To(BeTrue())
+		Expect(session.OutputToString()).To(BeValidJSON())
 
 		session = StartFakeCmdSession([]string{"I am not JSON"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.IsJSONOutputValid()).To(Not(BeTrue()))
+		Expect(session.OutputToString()).ToNot(BeValidJSON())
 	})
 
 	It("Test WaitWithDefaultTimeout", func() {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -279,17 +279,6 @@ func (s *PodmanSession) ErrorToStringArray() []string {
 	return results
 }
 
-// IsJSONOutputValid attempts to unmarshal the session buffer
-// and if successful, returns true, else false
-func (s *PodmanSession) IsJSONOutputValid() bool {
-	var i any
-	if err := json.Unmarshal(s.Out.Contents(), &i); err != nil {
-		GinkgoWriter.Println(err)
-		return false
-	}
-	return true
-}
-
 // WaitWithDefaultTimeout waits for process finished with DefaultWaitTimeout
 func (s *PodmanSession) WaitWithDefaultTimeout() {
 	s.WaitWithTimeout(DefaultWaitTimeout)


### PR DESCRIPTION
IsJSONOutputValid is the last of the bool returning helpers on the #18540 list. I left it out of #29640 because swapping it for BeValidJSON() broke the negative rows of the info and version table tests, and it turned out the matcher is the reason.

Match() returned the unmarshal error for input that is simply not json. gomega treats a non nil error as a failure to evaluate, so the assertion fails whichever way you write it:

```
Expect("{not json").ToNot(BeValidJSON())
--> invalid character 'n' looking for beginning of object key string
```

a non match is (false, nil). the error return is there for input the matcher cannot evaluate, which is the wrong type case just above it.

first commit fixes that, second removes the helper and moves its five call sites over. the self test in podmansession_test.go now covers both directions, and with the matcher fix reverted it fails at that line, so it does catch the regression.

ran the test/utils suite, 23 of 23.
