### PR TITLE
fix(libpod): keep '=' in a volume subpath

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -384,8 +384,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		m := &g.Config.Mounts[i]
 		var options []string
 		for _, o := range m.Options {
-			if strings.HasPrefix(o, "subpath=") {
-				subpath := strings.Split(o, "=")[1]
+			if subpath, ok := strings.CutPrefix(o, "subpath="); ok {
 				safeMount, err := c.safeMountSubPath(m.Source, subpath)
 				if err != nil {
 					return nil, nil, err

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -1113,7 +1113,7 @@ RUN chmod 755 /test1 /test2 /test3`, ALPINE)
 		mkvol.WaitWithDefaultTimeout()
 		Expect(mkvol).Should(ExitCleanly())
 
-		subvol := "/test/test2/"
+		subvol := "/test/a=b/"
 		pathInCtr := "/mnt"
 		pathToCreate := filepath.Join(pathInCtr, subvol)
 		popvol := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/mnt", volName), ALPINE, "sh", "-c", fmt.Sprintf("mkdir -p %s; touch %s; touch %s", pathToCreate, filepath.Join(pathToCreate, "foo"), filepath.Join(pathToCreate, "bar"))})


### PR DESCRIPTION
The subpath mount option is parsed with `strings.Split(o, "=")[1]`, so it keeps only the text between the first and second `=`. A subpath that contains `=` gets cut short and the container mounts a different directory than the one that was asked for.

```
--mount type=volume,src=v,dst=/mnt,subpath=/opt/a=b/c   mounts /opt/a
```

The existing subpath e2e test now uses a path with an `=` in it.
