### PR TITLE
rootless: clear environment before spawning pause process

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -656,7 +656,7 @@ is_pause_process (long pid)
   if (asprintf (&environ_path, "/proc/%ld/environ", pid) < 0)
     return 0;
 
-  buf = malloc (buf_size);
+  buf = malloc (buf_size + 1);
   if (buf == NULL)
     return 0;
 
@@ -668,6 +668,7 @@ is_pause_process (long pid)
   n = TEMP_FAILURE_RETRY (read (fd, buf, buf_size));
   if (n <= 0)
     return 0;
+  buf[n] = '\0';
 
   /* environ entries are separated by '\0'.  Search for "_PODMAN_PAUSE=1".  */
   for (char *p = buf; p < buf + n; )
@@ -1099,6 +1100,7 @@ create_pause_process (const char *state_dir, char **argv)
           for (fd = 3; fd < open_files_max_fd + 16; fd++)
             close (fd);
 
+          clearenv ();
           setenv ("_PODMAN_PAUSE", "1", 1);
           execlp (argv[0], argv[0], NULL);
 


### PR DESCRIPTION
<!-- Please include a concise description of your changes -->
### Description
When spawning the pause process in `pkg/rootless/rootless_linux.c`, the process inherited environment variables from the parent process before setting `_PODMAN_PAUSE=1`. If the parent environment exceeded 4096 bytes (the chunk size read by `is_pause_process`), `_PODMAN_PAUSE=1` was placed beyond the first 4KB chunk, causing `is_pause_process` to treat a healthy pause process as stale and unlink its `pause.pid` file.

This PR calls `clearenv()` before setting `_PODMAN_PAUSE=1` so the pause process only carries the necessary marker at index 0. Additionally, `is_pause_process()` safely null-terminates its read buffer.

Fixes: #29650
Signed-off-by: sundeep8967 <sundeep8967@gmail.com>