### PR TITLE
compat: Document and test GET /images/json until filter

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -106,6 +106,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//        - `label=key` or `label="key=value"` of an image label
 	//        - `reference`=(`<image-name>[:<tag>]`)
 	//        - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+	//        - `until=<timestamp>` List images created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the machine’s time.
 	//     type: string
 	//   - name: digests
 	//     in: query
@@ -960,6 +961,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//        - `reference`=(`<image-name>[:<tag>]`)
 	//        - `id`=(`<image-id>`)
 	//        - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+	//        - `until=<timestamp>` List images created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the machine’s time.
 	//     type: string
 	// produces:
 	// - application/json

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -240,6 +240,18 @@ t GET images/json?filters='{"reference":["test1"]}' 200 length=1
 t POST images/prune?filters='{"until":["500000"]}' 200
 t GET images/json?filters='{"reference":["test1"]}' 200 length=1
 
+# Get number of images for verification.
+t GET images/json 200
+img_count=$(jq -r 'length' <<<"$output")
+
+# Test compat: GET images/json - until filter (distant future x past).
+t GET images/json?filters='{"until":["99999999999"]}' 200 length=$img_count
+t GET images/json?filters='{"until":["500000"]}' 200 length=0
+
+# Test libpod: GET images/json - until filter (distant future x past).
+t GET libpod/images/json?filters='{"until":["99999999999"]}' 200 length=$img_count
+t GET libpod/images/json?filters='{"until":["500000"]}' 200 length=0
+
 t DELETE libpod/images/test1:latest 200
 
 # to be used in prune until filter tests


### PR DESCRIPTION
The `until` filter was missing from the documentation for GET `/images/json`. 
- Document it for both `GET /libpod/images/json` and the compat `GET /images/json`.
- Add tests for the until filter exercising both endpoints.

Fixes: https://redhat.atlassian.net/browse/RUN-3316

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
None (only missing docs and tests added).
