### PR TITLE
rootless: read all of /proc/<pid>/environ when checking for a pause process

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -647,16 +647,17 @@ can_use_shortcut (char **argv)
 static int
 is_pause_process (long pid)
 {
+  const char marker[] = "_PODMAN_PAUSE=1";
   cleanup_free char *environ_path = NULL;
   cleanup_free char *buf = NULL;
   cleanup_close int fd = -1;
-  const size_t buf_size = 4096;
-  ssize_t n;
+  size_t allocated = 4096;
+  size_t size = 0;
 
   if (asprintf (&environ_path, "/proc/%ld/environ", pid) < 0)
     return 0;
 
-  buf = malloc (buf_size);
+  buf = malloc (allocated);
   if (buf == NULL)
     return 0;
 
@@ -664,17 +665,46 @@ is_pause_process (long pid)
   if (fd < 0)
     return 0;
 
-  /* Read in chunks and search for the null-delimited key=value entry.  */
-  n = TEMP_FAILURE_RETRY (read (fd, buf, buf_size));
-  if (n <= 0)
-    return 0;
-
-  /* environ entries are separated by '\0'.  Search for "_PODMAN_PAUSE=1".  */
-  for (char *p = buf; p < buf + n; )
+  /* setenv() appends, so the marker is at the end of the block.  procfs
+     reports st_size 0 here, so keep reading until EOF instead of assuming
+     the environment fits in one chunk.  */
+  for (;;)
     {
-      if (strcmp (p, "_PODMAN_PAUSE=1") == 0)
+      ssize_t n;
+
+      if (size == allocated)
+        {
+          char *tmp;
+
+          /* An environment block cannot legitimately get this big; give up
+             rather than grow without bound if procfs misbehaves.  */
+          if (allocated >= 16 * 1024 * 1024)
+            return 0;
+          allocated *= 2;
+          tmp = realloc (buf, allocated);
+          if (tmp == NULL)
+            return 0;
+          buf = tmp;
+        }
+
+      n = TEMP_FAILURE_RETRY (read (fd, buf + size, allocated - size));
+      if (n < 0)
+        return 0;
+      if (n == 0)
+        break;
+      size += (size_t) n;
+    }
+
+  /* environ entries are separated by '\0'.  The final one can be missing its
+     terminator if the process was changing its environment while we read, so
+     bound every comparison by what was actually read.  */
+  for (size_t i = 0; i < size; )
+    {
+      size_t len = strnlen (buf + i, size - i);
+
+      if (len == sizeof (marker) - 1 && memcmp (buf + i, marker, len) == 0)
         return 1;
-      p += strlen (p) + 1;
+      i += len + 1;
     }
   return 0;
 }


### PR DESCRIPTION
Fixes #29650.

#29657 is already open against the same issue and comes at it from the other end:
it calls `clearenv()` before `setenv("_PODMAN_PAUSE", "1", 1)`, so the pause
process carries almost nothing and the marker lands inside the first chunk. That
does stop the bug I hit, and its second hunk — null-terminating the buffer — is
the out-of-bounds walk I flagged in the issue. I'm not putting this up instead of
that one; it fixes a different half, and I'm happy with whichever shape you prefer,
including folding the two together.

What made me write this is that `clearenv()` changes what goes *into* the pause
process rather than what `is_pause_process()` is willing to *read*, and two things
live through that:

**Pause processes that already exist.** Upgrading podman doesn't restart the pause
process. Anyone who updates while holding one created by an older build still has a
large environment on the other end, so the first command after the upgrade can
still unlink a valid `pause.pid` and leave every running container unreachable.
That is a bad moment for it to happen, because it reads as the upgrade having
broken the containers.

**The asymmetry with the Go side.** `isPauseProcess()` in `rootless_linux.go` uses
`os.ReadFile` and reads the whole file. The C twin reading a single chunk is the
odd one out, and it stays odd: a later change that puts anything else in the pause
process's environment brings this back silently, with the same consequence.

So this reads to EOF, which is what the Go implementation already does. The buffer
grows with an explicit 16 MB ceiling so a misbehaving procfs can't make it grow
without bound, and each comparison is bounded by the number of bytes actually read,
since `read()` can stop mid-entry and `strcmp`/`strlen` would then run past the end
of the buffer.

### Testing

I lifted `is_pause_process()` into a standalone harness, once from `main` and once
from this branch, and ran both against two processes that differ only in how much
padding they carry:

```
$ env -i PAD=short _PODMAN_PAUSE=1 sleep 60 & SMALL=$!
$ env -i PAD=$(printf 'x%.0s' $(seq 1 4200)) _PODMAN_PAUSE=1 sleep 60 & BIG=$!

proces                       old          new
environ=26     B (SMALL)     1            1
environ=4221   B (BIG)       0            1
```

The 26-byte row is there to show the case that already worked still works.

Both files compile clean under `gcc -Wall -Wextra`.
