### PR TITLE
machine: ensure OCI pull cache directory exists

### DIFF
--- a/pkg/machine/ocipull/ociartifact_test.go
+++ b/pkg/machine/ocipull/ociartifact_test.go
@@ -1,6 +1,15 @@
 package ocipull
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.podman.io/image/v5/oci/layout"
+	"go.podman.io/podman/v6/pkg/machine/define"
+)
 
 func Test_extractKindAndCompression(t *testing.T) {
 	type args struct {
@@ -54,4 +63,30 @@ func Test_extractKindAndCompression(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPullCreatesParentDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	parentCacheDir := filepath.Join(tmpDir, "containers", "podman", "machine", "wsl", "cache")
+	destPath := filepath.Join(parentCacheDir, "24672f841cbf90346f87c9e4f33b2c99f9c54d090a65a46f8f4e6e1be5e469a3")
+	destVMFile, err := define.NewMachineFile(destPath, nil)
+	require.NoError(t, err)
+
+	_, err = os.Stat(parentCacheDir)
+	require.True(t, os.IsNotExist(err), "parent directory must not exist before pull()")
+
+	dummySrcRef, err := layout.ParseReference(filepath.Join(tmpDir, "dummy_source"))
+	require.NoError(t, err)
+
+	pullErr := pull(context.Background(), dummySrcRef, destVMFile, &pullOptions{quiet: true})
+
+	parentInfo, statErr := os.Stat(parentCacheDir)
+	require.NoError(t, statErr, "pull() must create the missing parent directory")
+	require.True(t, parentInfo.IsDir())
+
+	// copy.Image will fail reading dummySrcRef, but execution must reach it rather than failing early in destination layout.ParseReference
+	require.Error(t, pullErr)
+	require.Contains(t, pullErr.Error(), "pulling source image:")
+	require.NotContains(t, pullErr.Error(), destPath)
 }

--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"go.podman.io/buildah/pkg/parse"
@@ -48,6 +49,10 @@ var noSignaturePolicy string = `{"default":[{"type":"insecureAcceptAnything"}]}`
 
 // pull `imageInput` from a container registry to `sourcePath`.
 func pull(ctx context.Context, imageInput types.ImageReference, localDestPath *define.VMFile, options *pullOptions) error {
+	if err := os.MkdirAll(filepath.Dir(localDestPath.GetPath()), 0o755); err != nil {
+		return err
+	}
+
 	destRef, err := layout.ParseReference(localDestPath.GetPath())
 	if err != nil {
 		return err


### PR DESCRIPTION
## What does this PR do?

Fixes `podman machine init` failing on Windows with:

```text
The system cannot find the path specified.
```

when the OCI machine image cache parent directory does not exist.

## Why?

`pkg/machine/ocipull/pull.go` passes the destination path to `layout.ParseReference()`. On Windows, the path resolution performed by `containers/image` requires the parent directory to exist.

When the cache parent directory is missing, this results in `ERROR_PATH_NOT_FOUND`.

This change creates the destination's parent directory with `os.MkdirAll()` before calling `layout.ParseReference()`.

The final OCI layout directory is not created beforehand. It is still created by `containers/image` during the pull.

## Testing

Added a regression test covering the missing parent directory case.

The following targeted test passes:

```text
go test -tags containers_image_openpgp ./pkg/machine/ocipull -run TestPullCreatesParentDirectory -v
```

The complete `pkg/machine/ocipull` package test suite also passes.

Fixes #29639

---

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

* [x] I have read and understood our [contributing guidelines](https://github.com/containers/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
* [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/containers/community/blob/main/LLM_POLICY.md)
* [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
* [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
* [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
* [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
* [ ] All commits pass `make validatepr` (format/lint checks)
* [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fix `podman machine init` failing on Windows when the OCI machine image cache parent directory does not exist.
```