### PR TITLE
fix: report pod states in lowercase for consistency

### DIFF
--- a/libpod/define/podstate.go
+++ b/libpod/define/podstate.go
@@ -2,21 +2,21 @@ package define
 
 const (
 	// PodStateCreated indicates the pod is created but has not been started
-	PodStateCreated = "Created"
+	PodStateCreated = "created"
 	// PodStateErrored indicates the pod is in an errored state where
 	// information about it can no longer be retrieved
-	PodStateErrored = "Error"
+	PodStateErrored = "error"
 	// PodStateExited indicates the pod ran but has been stopped
-	PodStateExited = "Exited"
+	PodStateExited = "exited"
 	// PodStatePaused indicates the pod has been paused
-	PodStatePaused = "Paused"
+	PodStatePaused = "paused"
 	// PodStateRunning indicates that all of the containers in the pod are
 	// running.
-	PodStateRunning = "Running"
+	PodStateRunning = "running"
 	// PodStateDegraded indicates that at least one, but not all, of the
 	// containers in the pod are running.
-	PodStateDegraded = "Degraded"
+	PodStateDegraded = "degraded"
 	// PodStateStopped indicates all of the containers belonging to the pod
 	// are stopped.
-	PodStateStopped = "Stopped"
+	PodStateStopped = "stopped"
 )

--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -90,7 +90,7 @@ t POST  libpod/pods/bar/restart 200 \
   .Id=$pod_bar_id
 
 t GET  libpod/pods/bar/json     200 \
-  .State=Running
+  .State=running
 
 t POST  libpod/pods/bar/restart 200 \
   .Errs=null \

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2462,7 +2462,7 @@ var _ = Describe("Podman kube play", func() {
 			output := inspect.OutputToString()
 			id, state, found := strings.Cut(output, "@")
 			Expect(found).To(BeTrue())
-			Expect(state).To(Equal(name + ":Running"))
+			Expect(state).To(Equal(name + ":running"))
 			ids = append(ids, id)
 
 		}
@@ -4836,7 +4836,7 @@ spec:
 		Expect(inspectVolume.OutputToString()).To(ContainSubstring(volName))
 
 		inspectPod := podmanTest.PodmanExitCleanly("inspect", podName+"-pod", "--format", "'{{ .State }}'")
-		Expect(inspectPod.OutputToString()).To(ContainSubstring(`Running`))
+		Expect(inspectPod.OutputToString()).To(ContainSubstring(`running`))
 
 		inspectMounts := podmanTest.PodmanExitCleanly("inspect", podName+"-pod-"+ctrName, "--format", "{{ (index .Mounts 0).Type }}:{{ (index .Mounts 0).Name }}")
 
@@ -4898,7 +4898,7 @@ spec:
 		podmanTest.PodmanExitCleanly("kube", "play", kubeYaml)
 		for _, n := range podNames {
 			inspect := podmanTest.PodmanExitCleanly("inspect", n, "--format", "'{{ .State }}'")
-			Expect(inspect.OutputToString()).To(ContainSubstring(`Running`))
+			Expect(inspect.OutputToString()).To(ContainSubstring(`running`))
 		}
 	})
 

--- a/test/e2e/pod_clone_test.go
+++ b/test/e2e/pod_clone_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Podman pod clone", func() {
 		podInspect.WaitWithDefaultTimeout()
 		Expect(podInspect).To(ExitCleanly())
 		data := podInspect.InspectPodToJSON()
-		Expect(data.State).To(ContainSubstring("Running"))
+		Expect(data.State).To(ContainSubstring("running"))
 	})
 
 	It("podman pod clone destroy test", func() {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -566,7 +566,7 @@ entrypoint ["/fromimage"]
 		status1 := podmanTest.Podman([]string{"pod", "inspect", "--format", "{{ .State }}", podName})
 		status1.WaitWithDefaultTimeout()
 		Expect(status1).Should(ExitCleanly())
-		Expect(status1.OutputToString()).To(ContainSubstring("Created"))
+		Expect(status1.OutputToString()).To(ContainSubstring("created"))
 
 		ctr1 := podmanTest.Podman([]string{"run", "--pod", podName, "-d", ALPINE, "top"})
 		ctr1.WaitWithDefaultTimeout()
@@ -575,7 +575,7 @@ entrypoint ["/fromimage"]
 		status2 := podmanTest.Podman([]string{"pod", "inspect", "--format", "{{ .State }}", podName})
 		status2.WaitWithDefaultTimeout()
 		Expect(status2).Should(ExitCleanly())
-		Expect(status2.OutputToString()).To(ContainSubstring("Running"))
+		Expect(status2.OutputToString()).To(ContainSubstring("running"))
 
 		ctr2 := podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
 		ctr2.WaitWithDefaultTimeout()
@@ -584,7 +584,7 @@ entrypoint ["/fromimage"]
 		status3 := podmanTest.Podman([]string{"pod", "inspect", "--format", "{{ .State }}", podName})
 		status3.WaitWithDefaultTimeout()
 		Expect(status3).Should(ExitCleanly())
-		Expect(status3.OutputToString()).To(ContainSubstring("Degraded"))
+		Expect(status3.OutputToString()).To(ContainSubstring("degraded"))
 	})
 
 	It("podman create with unsupported network options", func() {

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -309,7 +309,7 @@ EOF
 
     # pod ps
     run_podman pod ps --format '{{.ID}} {{.Name}} {{.Status}} {{.Labels}}'
-    assert "$output" =~ "${pod_id:0:12} $podname Running ${labelname}=${labelvalue}"  "pod ps"
+    assert "$output" =~ "${pod_id:0:12} $podname running ${labelname}=${labelvalue}"  "pod ps"
 
     run_podman pod ps --no-trunc --filter "label=${labelname}=${labelvalue}" --format '{{.ID}}'
     is "$output" "$pod_id" "pod ps --filter label=..."
@@ -495,14 +495,14 @@ EOF
     podID="$output"
     run_podman run --pod $podID $IMAGE true
     run_podman pod inspect $podID --format "{{.State}}"
-    _ensure_pod_state $podID Degraded
+    _ensure_pod_state $podID degraded
     run_podman pod rm $podID
 
     run_podman pod create --exit-policy stop
     podID="$output"
     run_podman run --pod $podID $IMAGE true
     run_podman pod inspect $podID --format "{{.State}}"
-    _ensure_pod_state $podID Exited
+    _ensure_pod_state $podID exited
     run_podman pod rm -t -1 -f $podID
 }
 
@@ -527,7 +527,7 @@ spec:
     run_podman play kube $PODMAN_TMPDIR/test.yaml
     run_podman pod inspect $name --format "{{.ExitPolicy}}"
     is "$output" "stop" "custom exit policy"
-    _ensure_pod_state $name Exited
+    _ensure_pod_state $name exited
     run_podman pod rm $name
 }
 

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1375,7 +1375,7 @@ EOF
     service_setup $QUADLET_SERVICE_NAME
 
     run_podman pod ps --format "{{.Name}}--{{.Status}}"
-    assert "$output" =~ "$pod_name--Running" "pod is running"
+    assert "$output" =~ "$pod_name--running" "pod is running"
 
     service_cleanup $QUADLET_SERVICE_NAME inactive
 }

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -598,7 +598,7 @@ EOF
     _wait_service_ready container-$ctrname.service
 
     run_podman pod inspect --format "{{.State}}" $podname
-    is "$output" "Running" "pod is in running state"
+    is "$output" "running" "pod is in running state"
     run_podman container inspect --format "{{.State.Status}}" $ctrname
     is "$output" "running" "container is in running state"
 

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -188,7 +188,7 @@ RELABEL="system_u:object_r:container_file_t:s0"
     #  2) The service container is stopped
     #  #) The service container is marked as a service container
     run_podman stop $PODCTRNAME
-    _ensure_pod_state $PODNAME Exited
+    _ensure_pod_state $PODNAME exited
     _ensure_container_running $service_container false
     run_podman container inspect $service_container --format "{{.IsService}}"
     is "$output" "true"

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -311,7 +311,7 @@ failed    | exited     | 17
 
     run_podman pod ps
     is "$output" ".*mypod.*" "podman pod ps shows name"
-    is "$output" ".*Running.*" "podman pod ps shows running state"
+    is "$output" ".*running.*" "podman pod ps shows running state"
 
     run_podman pod stop mypod
     is "$output" "mypod" "podman pod stop"


### PR DESCRIPTION
Fixes: https://github.com/podman-container-tools/podman/issues/19097
### Description

This PR updates the pod state string definitions in `libpod/define/podstate.go` to use lowercase formats (e.g., `" running"` instead of `" Running"`, `" created "` instead of `" Created "`). This ensures that the state output for Pods is consistent with the formatting used for Containers. 

The End-to-End (e2e) tests in have been updated to assert against these new lowercase state strings and also the .BATS files are updated too in correspondence to PodState.

Fixes: #19097

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)


#### Does this PR introduce a user-facing change?

```release-note
Pod states are now reported in lowercase (e.g., `running`, `created`) to maintain formatting consistency with container states.