### PR TITLE
pkg/domain/infra/tunnel: error when signing a remote push

### DIFF
--- a/pkg/domain/infra/tunnel/artifact.go
+++ b/pkg/domain/infra/tunnel/artifact.go
@@ -69,6 +69,13 @@ func (ir *ImageEngine) ArtifactRm(_ context.Context, opts entities.ArtifactRemov
 }
 
 func (ir *ImageEngine) ArtifactPush(_ context.Context, name string, opts entities.ArtifactPushOptions) (*entities.ArtifactPushReport, error) {
+	if opts.Signers != nil {
+		return nil, fmt.Errorf("forwarding Signers is not supported for remote clients")
+	}
+	if opts.SignBy != "" || opts.SignBySigstorePrivateKeyFile != "" {
+		return nil, fmt.Errorf("signing is not supported for remote clients")
+	}
+
 	options := artifacts.PushOptions{
 		Username:   &opts.Username,
 		Password:   &opts.Password,

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -274,6 +274,9 @@ func (ir *ImageEngine) Push(_ context.Context, source string, destination string
 	if opts.Signers != nil {
 		return nil, fmt.Errorf("forwarding Signers is not supported for remote clients")
 	}
+	if opts.SignBy != "" || opts.SignBySigstorePrivateKeyFile != "" {
+		return nil, fmt.Errorf("signing is not supported for remote clients")
+	}
 	if opts.OciEncryptConfig != nil {
 		return nil, fmt.Errorf("encryption is not supported for remote clients")
 	}

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -187,6 +187,9 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 	if opts.Signers != nil {
 		return "", fmt.Errorf("forwarding Signers is not supported for remote clients")
 	}
+	if opts.SignBy != "" || opts.SignBySigstorePrivateKeyFile != "" {
+		return "", fmt.Errorf("signing is not supported for remote clients")
+	}
 
 	options := new(images.PushOptions)
 	options.WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithRemoveSignatures(opts.RemoveSignatures).WithAll(opts.All).WithFormat(opts.Format).WithCompressionFormat(opts.CompressionFormat).WithQuiet(opts.Quiet).WithProgressWriter(opts.Writer).WithAddCompression(opts.AddCompression).WithForceCompressionFormat(opts.ForceCompressionFormat)

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -27,6 +27,15 @@ var _ = Describe("Podman push", func() {
 		podmanTest.AddImageToRWStore(ALPINE)
 	})
 
+	It("podman push --sign-by errors on remote", func() {
+		SkipIfNotRemote("Signing is only rejected by the remote client")
+		// Signing is not implemented for remote clients. Make sure we say so
+		// rather than pushing an unsigned image and reporting success.
+		session := podmanTest.Podman([]string{"push", "-q", "--sign-by", "foo@bar.com", ALPINE, "docker://localhost:5000/my-alpine"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, "signing is not supported for remote clients"))
+	})
+
 	It("podman push to containers/storage", func() {
 		SkipIfRemote("Remote push does not support containers-storage transport")
 		session := podmanTest.Podman([]string{"push", "-q", ALPINE, "containers-storage:busybox:test"})

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -122,6 +122,7 @@ var _ = Describe("Podman save", func() {
 	It("podman save remove signature", func() {
 		podmanTest.AddImageToRWStore(ALPINE)
 		SkipIfRootless("FIXME: Need get in rootless push sign")
+		SkipIfRemote("Signing is not supported for remote clients")
 		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}


### PR DESCRIPTION
I noticed that podman push --sign-by works fine locally but does nothing when
you run it with --remote. The remote client never sends the signing options
across, so the push finishes, tells you it worked, and you are left with an
unsigned image and no warning.

I have not tried to make remote signing work here, that is a much bigger job.
This just makes push, manifest push and artifact push fail with a clear error
instead of quietly pretending. The check goes right next to the ones that were
already there for Signers and encryption and says much the same thing. artifact
push did not have any check at all so it gets both.

There is a test in test/e2e/push_test.go that runs on remote and makes sure the
error actually shows up.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
podman --remote push, manifest push and artifact push now report an error when
--sign-by or --sign-by-sigstore-private-key is used, instead of silently pushing
an unsigned image.
```

