### PR TITLE
pkg/bindings, pkg/api: send the manifest index subject to the server

### DIFF
--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -680,14 +680,15 @@ func ManifestModify(w http.ResponseWriter, r *http.Request) {
 			// We waited until after the extraction goroutine finished to ensure
 			// that we'd pick up its changes to the ArtifactFiles list.
 			manifestAddArtifactOptions := entities.ManifestAddArtifactOptions{
-				Type:                body.ArtifactType,
-				LayerType:           body.ArtifactLayerType,
-				ConfigType:          body.ArtifactConfigType,
-				Config:              body.ArtifactConfig,
-				ExcludeTitles:       body.ArtifactExcludeTitles,
-				ArtifactAnnotations: body.ArtifactAnnotations,
-				Subject:             body.ArtifactSubject,
-				Files:               body.ArtifactFiles,
+				ManifestAnnotateOptions: body.ManifestAnnotateOptions,
+				Type:                    body.ArtifactType,
+				LayerType:               body.ArtifactLayerType,
+				ConfigType:              body.ArtifactConfigType,
+				Config:                  body.ArtifactConfig,
+				ExcludeTitles:           body.ArtifactExcludeTitles,
+				ArtifactAnnotations:     body.ArtifactAnnotations,
+				Subject:                 body.ArtifactSubject,
+				Files:                   body.ArtifactFiles,
 			}
 			id, err := imageEngine.ManifestAddArtifact(r.Context(), name, body.ArtifactFiles, manifestAddArtifactOptions)
 			if err != nil {

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -197,6 +197,8 @@ func AddArtifact(ctx context.Context, name string, options *AddArtifactOptions) 
 		ArtifactExcludeTitles: options.ExcludeTitles,
 		ArtifactSubject:       options.Subject,
 		ArtifactAnnotations:   options.Annotations,
+
+		IndexSubject: options.IndexSubject,
 	}
 	if len(options.Files) > 0 {
 		optionsv4.WithArtifactFiles(options.Files)

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -353,8 +353,7 @@ func Modify(ctx context.Context, name string, images []string, options *ModifyOp
 		// upload the files in another goroutine
 		writer := multipart.NewWriter(bodyWriter)
 		artifactContentType = writer.FormDataContentType()
-		artifactWriterGroup.Add(1)
-		go func() {
+		artifactWriterGroup.Go(func() {
 			defer bodyWriter.Close()
 			defer writer.Close()
 			// start with the body we would have uploaded if we weren't
@@ -402,7 +401,7 @@ func Modify(ctx context.Context, name string, images []string, options *ModifyOp
 					break
 				}
 			}
-		}()
+		})
 	}
 
 	header, err := auth.MakeXRegistryAuthHeader(&imageTypes.SystemContext{AuthFilePath: options.GetAuthfile()}, options.GetUsername(), options.GetPassword())

--- a/pkg/bindings/manifests/types.go
+++ b/pkg/bindings/manifests/types.go
@@ -67,6 +67,7 @@ type AddArtifactOptions struct {
 	LayerType     *string           `json:"artifact_layer_type,omitempty"`
 	ExcludeTitles *bool             `json:"artifact_exclude_titles,omitempty"`
 	Subject       *string           `json:"artifact_subject,omitempty"`
+	IndexSubject  *string           `json:"subject,omitempty"` // IndexSubject is a subject value to set in the manifest list itself
 	Annotations   map[string]string `json:"artifact_annotations,omitempty"`
 	Files         []string          `json:"artifact_files,omitempty"`
 }
@@ -87,6 +88,7 @@ type ModifyOptions struct {
 
 	Annotations      map[string]string // Annotations to add to the entries for Images in the manifest list
 	IndexAnnotations map[string]string `json:"index_annotations" schema:"index_annotations"` // Annotations to add to the manifest list as a whole
+	IndexSubject     *string           `json:"subject" schema:"subject"`                     // IndexSubject is a subject value to set in the manifest list itself
 	Arch             *string           // Arch overrides the architecture for the image
 	Features         []string          // Feature list for the image
 	OS               *string           // OS overrides the operating system for the image

--- a/pkg/bindings/manifests/types_addartifact_options.go
+++ b/pkg/bindings/manifests/types_addartifact_options.go
@@ -212,6 +212,21 @@ func (o *AddArtifactOptions) GetSubject() string {
 	return *o.Subject
 }
 
+// WithIndexSubject set indexSubject is a subject value to set in the manifest list itself
+func (o *AddArtifactOptions) WithIndexSubject(value string) *AddArtifactOptions {
+	o.IndexSubject = &value
+	return o
+}
+
+// GetIndexSubject returns value of indexSubject is a subject value to set in the manifest list itself
+func (o *AddArtifactOptions) GetIndexSubject() string {
+	if o.IndexSubject == nil {
+		var z string
+		return z
+	}
+	return *o.IndexSubject
+}
+
 // WithAnnotations set field Annotations to given value
 func (o *AddArtifactOptions) WithAnnotations(value map[string]string) *AddArtifactOptions {
 	o.Annotations = value

--- a/pkg/bindings/manifests/types_modify_options.go
+++ b/pkg/bindings/manifests/types_modify_options.go
@@ -78,6 +78,21 @@ func (o *ModifyOptions) GetIndexAnnotations() map[string]string {
 	return o.IndexAnnotations
 }
 
+// WithIndexSubject set indexSubject is a subject value to set in the manifest list itself
+func (o *ModifyOptions) WithIndexSubject(value string) *ModifyOptions {
+	o.IndexSubject = &value
+	return o
+}
+
+// GetIndexSubject returns value of indexSubject is a subject value to set in the manifest list itself
+func (o *ModifyOptions) GetIndexSubject() string {
+	if o.IndexSubject == nil {
+		var z string
+		return z
+	}
+	return *o.IndexSubject
+}
+
 // WithArch set arch overrides the architecture for the image
 func (o *ModifyOptions) WithArch(value string) *ModifyOptions {
 	o.Arch = &value

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -117,6 +117,9 @@ func (ir *ImageEngine) ManifestAddArtifact(_ context.Context, name string, files
 	options.WithType(opts.Type).WithConfigType(opts.ConfigType).WithLayerType(opts.LayerType)
 	options.WithConfig(opts.Config)
 	options.WithExcludeTitles(opts.ExcludeTitles).WithSubject(opts.Subject)
+	if opts.IndexSubject != "" {
+		options.WithIndexSubject(opts.IndexSubject)
+	}
 	options.WithAnnotations(opts.ArtifactAnnotations)
 	options.WithFiles(files)
 	id, err := manifests.AddArtifact(ir.ClientCtx, name, options)
@@ -130,6 +133,9 @@ func (ir *ImageEngine) ManifestAddArtifact(_ context.Context, name string, files
 func (ir *ImageEngine) ManifestAnnotate(_ context.Context, name, images string, opts entities.ManifestAnnotateOptions) (string, error) {
 	options := new(manifests.ModifyOptions).WithArch(opts.Arch).WithVariant(opts.Variant)
 	options.WithFeatures(opts.Features).WithOS(opts.OS).WithOSVersion(opts.OSVersion)
+	if opts.IndexSubject != "" {
+		options.WithIndexSubject(opts.IndexSubject)
+	}
 
 	annotations, err := mergeAnnotations(opts.Annotations, opts.Annotation)
 	if err != nil {

--- a/test/system/012-manifest.bats
+++ b/test/system/012-manifest.bats
@@ -82,6 +82,41 @@ function validate_instance_compression {
     run_podman rmi $mname
 }
 
+@test "podman manifest annotate --subject" {
+    local mname="m-$(safename):1.0"
+
+    run_podman manifest create $mname
+
+    run_podman manifest inspect $mname
+    assert "$(jq -r '.subject' <<<"$output")" == "null" \
+           "index has no subject before it is annotated"
+
+    # The subject belongs to the index itself, hence --index
+    run_podman manifest annotate --index --subject containers-storage:$IMAGE $mname
+
+    run_podman manifest inspect $mname
+    assert "$(jq -r '.subject.digest' <<<"$output")" =~ '^sha256:[0-9a-f]{64}$' \
+           "index subject is set after it is annotated"
+
+    run_podman manifest rm $mname
+}
+
+@test "podman manifest add --artifact-subject" {
+    local mname="m-$(safename):1.0"
+    echo oh yeah > $PODMAN_TMPDIR/listed.txt
+
+    run_podman manifest create $mname
+    run_podman manifest add --artifact \
+               --artifact-subject=containers-storage:$IMAGE \
+               $mname $PODMAN_TMPDIR/listed.txt
+
+    run_podman manifest inspect $mname
+    assert "$(jq -r '.subject.digest' <<<"$output")" =~ '^sha256:[0-9a-f]{64}$' \
+           "index subject is set by --artifact-subject"
+
+    run_podman manifest rm $mname
+}
+
 @test "podman manifest --tls-verify and --authfile" {
     skip_if_remote "running a local registry doesn't work with podman-remote"
 


### PR DESCRIPTION
podman manifest annotate --index --subject and podman manifest add --artifact-subject both work locally but do nothing when you run them with --remote. The flags are there and the commands exit fine, the subject just never gets set.

The value never leaves the client. The bindings copy everything into ModifyOptions and AddArtifactOptions before sending the request and neither struct had a field for the subject, so it was dropped. The server had a problem of its own too… ManifestModify rebuilds ManifestAddArtifactOptions by hand and left out the embedded ManifestAnnotateOptions, so --os, --arch and --annotation were getting dropped there as well.

This adds the field to both structs with the json name the server expects, regenerates the setters with go generate, forwards the value from the tunnel, and passes the annotate options along in the handler. I dropped the bindings unit test and added two system tests in test/system/012-manifest.bats instead, one per flag, and neither is skipped on remote.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed podman --remote manifest annotate --subject and podman --remote manifest add --artifact-subject not applying the subject.
Fixed podman --remote manifest add --artifact hanging instead of returning.
```
