### PR TITLE
api: avoid reinitializing exited containers on logs-only attach

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -419,17 +419,21 @@ func (c *Container) HTTPAttach(r *http.Request, w http.ResponseWriter, streams *
 			return err
 		}
 	}
-	// For Docker compatibility, we need to re-initialize containers in these states.
-	if c.ensureState(define.ContainerStateConfigured, define.ContainerStateExited, define.ContainerStateStopped) {
-		if err := c.initUnlocked(r.Context(), c.config.Pod != ""); err != nil {
-			return fmt.Errorf("preparing container %s for attach: %w", c.ID(), err)
-		}
-	} else if !c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning) {
-		return fmt.Errorf("can only attach to created or running containers - currently in state %s: %w", c.state.State.String(), define.ErrCtrStateInvalid)
-	}
-
 	if !streamAttach && !streamLogs {
 		return fmt.Errorf("must specify at least one of stream or logs: %w", define.ErrInvalidArg)
+	}
+
+	// A streaming attach requires conmon's attach socket. Initialize configured
+	// containers so clients can attach before starting them. Logs-only requests
+	// must not alter the container state.
+	if streamAttach {
+		if c.ensureState(define.ContainerStateConfigured, define.ContainerStateExited, define.ContainerStateStopped) {
+			if err := c.initUnlocked(r.Context(), c.config.Pod != ""); err != nil {
+				return fmt.Errorf("preparing container %s for attach: %w", c.ID(), err)
+			}
+		} else if !c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning) {
+			return fmt.Errorf("can only attach to created or running containers - currently in state %s: %w", c.state.State.String(), define.ErrCtrStateInvalid)
+		}
 	}
 
 	// We are NOT holding the lock for the duration of the function.

--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -39,6 +39,37 @@ t POST "containers/${CTR}/wait?condition=next-exit" 200 \
   .Error=null
 wait "${child_pid}"
 
+# Regression test for #29664: a logs-only attach to an exited container must
+# not reinitialize it or discard its exit code.
+t POST "containers/${CTR}/attach?stream=false&logs=true&stdout=true&stderr=true" 200
+t GET "containers/${CTR}/json" 200 \
+  .State.Status="exited" \
+  .State.ExitCode=3
+t POST "containers/${CTR}/wait" 200 \
+  .StatusCode=3 \
+  .Error=null
+
+# Wait for streaming attach to initialize the exited container before restarting it.
+(
+  for _ in {1..100}; do
+    state=$($PODMAN_BIN --root "$WORKDIR/server_root" inspect --format '{{.State.Status}}' "${CTR}" 2>/dev/null) || true
+    if [[ "$state" == "initialized" ]]; then
+      podman start "${CTR}"
+      exit
+    fi
+    sleep 0.1
+  done
+  echo "Timed out waiting for ${CTR}: last state was '$state'" >&2
+  podman start "${CTR}" || true
+  exit 1
+) &
+child_pid=$!
+t POST "containers/${CTR}/attach?stream=true&logs=true&stdout=true&stderr=true" 200
+wait "${child_pid}"
+t GET "containers/${CTR}/json" 200 \
+  .State.Status="exited" \
+  .State.ExitCode=3
+
 # Test that headers are sent before body. (We should actually never get a body)
 APIV2_TEST_EXPECT_TIMEOUT=2 t POST "containers/${CTR}/wait?condition=next-exit" 999
 like "$(<$WORKDIR/curl.headers.out)" ".*HTTP.* 200 OK.*" \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes) 
 
#### Does this PR introduce a user-facing change? 
Yes. 
<!-- 
Write `None` if there are no user-facing changes, otherwise enter your release note below. 
Include "action required" if users need to take action when upgrading. 
--> 
 
```release-note 
This fixes externally observable container state and exit-code behavior for logs-only attach requests on exited containers. 
``` 
#### PR Description: 
- Problem: A logs-only attach on an already exited container triggered the reinitialization logic, changing the container state from exited to created and losing the original exit code. 
- Fix: Restrict container initialization to streamAttach requests. For logs-only requests, leave the container state unchanged. 
- Tests: Add a regression test that runs a container which exits with a non-zero exit code, performs a logs-only attach, verifies that the state remains exited and the exit code is preserved, and then confirms the exit code again through the wait API.