### PR TITLE
use systemd unit name for healthcheck units

### DIFF
--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -180,10 +180,12 @@ func (c *Container) disableHealthCheckSystemd(isStartup bool) bool {
 // Bare indicates that a random suffix should not be applied to the name. This
 // was default behavior previously, and is used for backwards compatibility.
 func (c *Container) hcUnitName(isStartup, bare bool) string {
-	unitName := c.ID()
+	unitName := "libpod-healthcheck-" + c.ID()
+
 	if isStartup {
 		unitName += "-startup"
 	}
+
 	if !bare {
 		// Ensure that unit names are unique from run to run by appending
 		// a random suffix.

--- a/libpod/healthcheck_linux_test.go
+++ b/libpod/healthcheck_linux_test.go
@@ -1,0 +1,53 @@
+//go:build !remote && systemd
+
+package libpod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHCUnitName(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		isStartup bool
+		bare      bool
+		expected  string
+	}{
+		{
+			name:      "uses libpod-healthcheck prefix",
+			id:        "a1b2c3d4e5f67890123456789abcdef0123456789abcdef0123456789abcdef",
+			isStartup: false,
+			bare:      false,
+			expected:  `^libpod-healthcheck-a1b2c3d4e5f67890123456789abcdef0123456789abcdef0123456789abcdef-[0-9a-f]+$`,
+		},
+		{
+			name:      "adds startup suffix",
+			id:        "a1b2c3d4e5f67890123456789abcdef0123456789abcdef0123456789abcdef",
+			isStartup: true,
+			bare:      false,
+			expected:  `^libpod-healthcheck-a1b2c3d4e5f67890123456789abcdef0123456789abcdef0123456789abcdef-startup-[0-9a-f]+$`,
+		},
+		{
+			name:      "omits random suffix when bare is true",
+			id:        "a1b2c3d4e5f67890123456789abcdef0123456789abcdef0123456789abcdef",
+			isStartup: false,
+			bare:      true,
+			expected:  `^libpod-healthcheck-a1b2c3d4e5f67890123456789abcdef0123456789abcdef0123456789abcdef$`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctr := &Container{
+				config: &ContainerConfig{},
+			}
+
+			ctr.config.ID = tt.id
+
+			assert.Regexp(t, tt.expected, ctr.hcUnitName(tt.isStartup, tt.bare))
+		})
+	}
+}

--- a/test/system/080-pause.bats
+++ b/test/system/080-pause.bats
@@ -111,13 +111,13 @@ load helpers.systemd
     # Since the status check can be executed when HealthCheck was exited, this caused a termination error code 3
     # for systemctl status. Because service was in dead state because HealthCheck exited.
     # https://github.com/containers/podman/issues/25204
-    run -0 systemctl status $cid-*.timer
+    run -0 systemctl status libpod-healthcheck-$cid-*.timer
     assert "$output" =~ "active" "service should be running"
 
     run_podman --noout pause $ctrname
     assert "$output" == "" "output should be empty"
 
-    run -0 systemctl status $cid-*.{service,timer}
+    run -0 systemctl status libpod-healthcheck-$cid-*.{service,timer}
     assert "$output" == "" "service should not be running"
 
     run_podman --noout unpause $ctrname
@@ -126,7 +126,7 @@ load helpers.systemd
     run_podman healthcheck run $ctrname
     is "$output" "" "output from 'podman healthcheck run'"
 
-    run -0 systemctl status $cid-*.timer
+    run -0 systemctl status libpod-healthcheck-$cid-*.timer
     assert "$output" =~ "active" "service should be running"
 
     run_podman rm -t 0 -f $ctrname

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -96,18 +96,18 @@ Log[-1].ExitCode | 1
 Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\\\n\"
 " "$current_time" "healthy"
 
-    # Check that we now we do have valid podman units with this
+    # Check that we now have valid podman units with this
     # name so that the leak check below does not turn into a NOP without noticing.
     run -0 systemctl list-units
     cidmatch=$(grep "$cid" <<<"$output")
     echo "$cidmatch"
-    assert "$cidmatch" =~ " $cid-[0-9a-f]+\.timer  *.*/podman .* healthcheck run --ignore-result $cid" \
-           "Healthcheck systemd unit exists"
+    assert "$cidmatch" =~ " libpod-healthcheck-$cid-[0-9a-f]+\.timer  *.*/podman .* healthcheck run --ignore-result $cid" \
+       "Healthcheck systemd unit uses the expected name"
 
     # Check that the right service option is applied so we don't hit the systemd restart limit.
     # Even though the code sets StartLimitIntervalSec the systemd command prints StartLimitInterval*U*Sec
     # Use show --all otherwise the glob might not match the already inactive transient unit.
-    run -0 systemctl show --all "$cid-*.service"
+    run -0 systemctl show --all "libpod-healthcheck-$cid-*.service"
     assert "$output" =~ "StartLimitIntervalUSec=0" "The hc service has the right interval set"
 
     # After three successive failures, container should no longer be healthy.


### PR DESCRIPTION
# Description

Fixes: #29373 

The issue asks for healthcheck units to use a consistent name instead of using the container ID with a random suffix.

This change uses the libpod-healthcheck- prefix with the container ID to create the healthcheck unit name.

For example:

`libpod-healthcheck-<container-id>-<rand-hex>.service`
`libpod-healthcheck-<container-id>-<rand-hex>.timer`

The container ID and random suffix are kept to make the healthcheck unit names unique.

## Testing

Added unit tests to verify the healthcheck unit name, startup healthcheck name, and bare behavior.
Added a system test to verify that the healthcheck systemd unit uses the expected name.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Healthcheck units now use a consistent libpod-healthcheck- prefix with the container ID.
```