### PR TITLE
Fix list markup in Markdown

### DIFF
--- a/docs/source/markdown/podman-quadlet-install.1.md.in
+++ b/docs/source/markdown/podman-quadlet-install.1.md.in
@@ -12,11 +12,11 @@ Install a Quadlet file or an application (which may include multiple Quadlet fil
 
 This command allows you to:
 
-    * Install a single Quadlet file, optionally followed by additional non-Quadlet files.
+* Install a single Quadlet file, optionally followed by additional non-Quadlet files.
 
-    * Specify a directory containing multiple Quadlet files and other non-Quadlet files for installation (for example a config file for a quadlet container).
+* Specify a directory containing multiple Quadlet files and other non-Quadlet files for installation (for example a config file for a quadlet container).
 
-    * Install multiple Quadlets from a single file with the `.quadlets` extension, where each Quadlet is separated by a `---` delimiter. When using multiple quadlets in a single `.quadlets` file, each quadlet section must include a `# FileName=<name>` comment to specify the name for that quadlet.
+* Install multiple Quadlets from a single file with the `.quadlets` extension, where each Quadlet is separated by a `---` delimiter. When using multiple quadlets in a single `.quadlets` file, each quadlet section must include a `# FileName=<name>` comment to specify the name for that quadlet.
 
 Note: An application is a collection of files, quadlet and non-quadlets, that
 need to live together. As such, removing a quadlet that is part of an


### PR DESCRIPTION
The documentation of `podman quadlet install` in https://docs.podman.io/en/latest/markdown/podman-quadlet-install.1.html shows a list as code block.

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/64754638-0cc9-432f-84a0-c334f263dfab" />

This pull request removes the code block part.

The intention is that the page will look like

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/3e66702e-35b9-4b2f-a8f3-fafc70054372" />

I have little knowledge of the pipeline used to convert the Markdown file into something that `groff` can process to create a manual page.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
