### PR TITLE
hack/ci: fix apiv2 test count warning

### DIFF
--- a/hack/ci/logformatter
+++ b/hack/ci/logformatter
@@ -317,6 +317,10 @@ END_HTML
         # BATS handling. This will recognize num_tests both at start and end
         if ($line =~ /^1\.\.(\d+)$/) {
             $looks_like_bats = 1;
+            # -1 is the "count unknown, expect it at the end" sentinel set
+            # below. It has to be replaced, not added to.
+            $bats_count{expected_total} = 0
+                if ($bats_count{expected_total} // 0) < 0;
             $bats_count{expected_total} += $1;
             undef $looks_like_python;
         }

--- a/hack/ci/logformatter.t
+++ b/hack/ci/logformatter.t
@@ -483,3 +483,17 @@ ok 4 blah
 <span class="timestamp">         </span><span class='bats-failed'>FAILED (failures=1, skipped=1)</span>
 <span class="timestamp">         </span>make: *** [Makefile:616: localapiv2] Error 1
 <hr/><span class='bats-summary'>Summary: <span class='bats-passed'>28 Passed</span>, <span class='bats-failed'>1 Failed</span>, <span class='bats-skipped'>1 Skipped</span>. Total tests: 30 <span class='bats-failed'>(WARNING: expected 33)</span></span>
+
+== bats plan line at end of run
+
+<<<
+env PODMAN=./bin/podman stdbuf -o0 -e0 ./test/apiv2/test-apiv2
+ok 1 [00-TEMPLATE] check
+not ok 2 [10-images] GET /images/json
+1..2
+>>>
+env PODMAN=./bin/podman stdbuf -o0 -e0 ./test/apiv2/test-apiv2
+<span class='bats-passed'><a name='t--00001'>ok 1 [00-TEMPLATE] check</a></span>
+<span class='bats-failed'><a name='t--00002'>not ok 2 [10-images] GET /images/json</a></span>
+1..2
+<hr/><span class='bats-summary'>Summary: <span class='bats-passed'>1 Passed</span>, <span class='bats-failed'>1 Failed</span>. Total tests: 2</span>


### PR DESCRIPTION
#### What this PR does / why we need it:

I was reading logformatter after the aarch64 timeout on #29569, where a run stopped part way through and I wanted to know how the "expected N" warning decides. It turns out apiv2 trips it on every run.

`/test-apiv2` in the command line sets `expected_total = -1` as a "we do not know the count yet" marker, and the plan line then does `+=` on it, so the sentinel is added instead of replaced. test-apiv2 prints `1..${test_count}` at the very end, so it always lands one short:

```
Summary: 3 Passed. Total tests: 3 (WARNING: expected 2)
```

That run was complete. With the fix:

```
Summary: 3 Passed. Total tests: 3
```

and a run that really did stop early still warns:

```
Total tests: 2 (WARNING: expected 815)
```

#### How to verify it

Added a case to `logformatter.t`, it fails on current main:

```
not ok 5 - bats plan line at end of run
#     $got->[4] = '... Total tests: 2 <span class='bats-failed'>(WARNING: expected 1)</span>...'
#     $expected->[4] = '... Total tests: 2</span>'
```

#### One thing I noticed but did not touch

The mismatch warning is only written into the HTML, and the tail summary you added in 66c6da6 does not mention it. So a run that stops early looks clean in the GitHub log, which is the case I hit on #29569. 
cc @Luap99 
