### PR TITLE
hack/ci: list ginkgo failures in the summary

### DIFF
--- a/hack/ci/logformatter
+++ b/hack/ci/logformatter
@@ -225,6 +225,7 @@ END_HTML
     my $looks_like_bats;          # binary flag: for detecting BATS results
     my $looks_like_python;        #   " "   "  : for colorizing python tests
     my %bats_count;               # For summary line: count of pass/fail/skip
+    my @ginkgo_fails;             # For the tail summary: names of failed specs
 
     # When running in github, we have the commit SHA
     $git_commit = $ENV{GITHUB_SHA};
@@ -678,6 +679,8 @@ END_HTML
             $desc =~ s/^TOP-LEVEL\s*//;
             my $id = make_id("$desc $testname", 'link');
 
+            push @ginkgo_fails, $desc ? "$desc $testname" : $testname;
+
             $line = "<span class=\"log-error\">$lhs<a href='#t--$id'>$testname</a></span>";
         }
 
@@ -738,10 +741,13 @@ END_HTML
     # Grumble. Github only shows the last N lines of the log... which is
     # anti-helpful when you want a quick synopsis of what failed. Write a
     # summary at the tail, to make it easier for humans to see what went wrong.
-    if (my $fails = $bats_count{__fail_list}) {
+    my @fails;
+    push @fails, sprintf("%d %s", @$_) for @{ $bats_count{__fail_list} || [] };
+    push @fails, @ginkgo_fails;
+    if (@fails) {
         print  "\n";
-        printf "Failed tests (%d):\n", scalar(@$fails);
-        printf " - %d %s\n", @$_ for @$fails;
+        printf "Failed tests (%d):\n", scalar(@fails);
+        printf " - %s\n", $_ for @fails;
     }
 }
 

--- a/hack/ci/logformatter.t
+++ b/hack/ci/logformatter.t
@@ -33,6 +33,11 @@ while (my $line = <DATA>) {
     elsif ($line =~ /^>>>/) {
         $context = 'expect';
     }
+    elsif ($line =~ /^%%%/) {
+        # Optional: what logformatter should write to stdout, not the html
+        $context = 'stdout';
+        $tests[-1]{stdout} = [];
+    }
     elsif (@tests && $line) {
         # Handles trailing spaces in log, because we can't have actual ones.
         $line =~ s/\&TRAILINGSPACE;/ /g;
@@ -40,7 +45,7 @@ while (my $line = <DATA>) {
     }
 }
 
-plan tests => scalar(@tests);
+plan tests => scalar(@tests) + grep { $_->{stdout} } @tests;
 
 my $tempdir = tempdir("logformatter-test.XXXXXX", TMPDIR => 1, CLEANUP => !$ENV{DEBUG});
 
@@ -57,7 +62,7 @@ for my $t (@tests) {
     close $fh_out
         or die "$ME: Error writing $tempdir/$fname.txt: $!\n";
 
-    system("$FindBin::Bin/logformatter $fname <$fname.txt >/dev/null");
+    system("$FindBin::Bin/logformatter $fname <$fname.txt >$fname.stdout");
     open my $fh_in, '<', "$fname.log.html"
         or die "$ME: Fatal: $fname: logformatter did not create .log.html\n";
     my @actual;
@@ -78,6 +83,21 @@ for my $t (@tests) {
     }
 
     is_deeply \@actual, $t->{expect}, $name;
+
+    # The tail summary goes to stdout, not into the html
+    if (my $want = $t->{stdout}) {
+        open my $fh_stdout, '<', "$fname.stdout"
+            or die "$ME: Fatal: $fname: cannot read stdout: $!\n";
+        # logformatter echoes the whole log; we only care about the
+        # summary it appends at the very end.
+        my @got;
+        while (my $line = <$fh_stdout>) {
+            chomp $line;
+            push @got, $line if @got || $line =~ /^Failed tests \(/;
+        }
+        close $fh_stdout;
+        is_deeply \@got, $want, "$name (stdout)";
+    }
 }
 
 chdir '/';

--- a/hack/ci/logformatter.t
+++ b/hack/ci/logformatter.t
@@ -360,6 +360,11 @@ ok 4 blah
 <span class="timestamp">         </span>Ran 1889 of 2014 Specs in 1607.919 seconds
 <span class="timestamp">         </span><span class="ginkgo-final-fail">FAIL!</span> -- <span class="bats-passed"><b>1881</b> Passed</span> | <span class="bats-failed"><b>1</b> Failed</span> | 0 Pending | <span class="bats-skipped"><b>125</b> Skipped</span>
 
+%%%
+Failed tests (1):
+ - Podman pod create podman pod correctly sets up PIDNS
+
+
 == simple python
 
 <<<


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow-up to the thing I mentioned in #29682. The tail summary you added in 66c6da6 only ever lists bats failures - `__fail_list` is pushed to inside the bats branch and nowhere else - so for the e2e suites the part of the log github actually shows says nothing about what broke.

Before, on the ginkgo sample that is already in `logformatter.t`:

```
Ran 1889 of 2014 Specs in 1607.919 seconds
FAIL! -- 1881 Passed | 1 Failed | 0 Pending | 125 Skipped
```

after:

```
Ran 1889 of 2014 Specs in 1607.919 seconds
FAIL! -- 1881 Passed | 1 Failed | 0 Pending | 125 Skipped

Failed tests (1):
 - Podman pod create podman pod correctly sets up PIDNS
```

It hooks the `[FAIL] ... [It] ...` line that is already parsed for the anchor link, so the name is the same one the html links to. bats output is unchanged, and a run with no failures still prints nothing.

#### How to verify it

First commit is on its own because the harness sent stdout to `/dev/null`, so nothing covered the tail summary at all, not even the existing bats one. It adds a `%%%` section for expected stdout. The second commit's test fails without the change:

```
not ok 4 - simple ginkgo (stdout)
#     $got->[0] = Does not exist
#     $expected->[0] = 'Failed tests (1):'
```

#### One thing I got wrong on the way

My first attempt pushed onto `$bats_count`, which made `keys %bats_count` true for ginkgo runs and printed an empty `Summary:. Total tests: 0` line into the html. The existing test caught it, hence the separate list.
