### PR TITLE
libpod: fix :O overlay volumes in a userns

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -339,7 +339,14 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		if overlayFlag {
 			var overlayMount spec.Mount
 			var overlayOpts *overlay.Options
-			contentDir, err := overlay.TempDir(c.config.StaticDir, c.RootUID(), c.RootGID())
+			// For idmapped volumes the backing dirs must be owned by real
+			// root (0) so the runtime's identity shift surfaces them as the
+			// container root.
+			backingUID, backingGID := c.RootUID(), c.RootGID()
+			if hasIdmapOption(namedVol.Options) {
+				backingUID, backingGID = 0, 0
+			}
+			contentDir, err := overlay.TempDir(c.config.StaticDir, backingUID, backingGID)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -354,8 +361,8 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 			}
 
 			overlayOpts = &overlay.Options{
-				RootUID:                c.RootUID(),
-				RootGID:                c.RootGID(),
+				RootUID:                backingUID,
+				RootGID:                backingGID,
 				UpperDirOptionFragment: upperDir,
 				WorkDirOptionFragment:  workDir,
 				GraphOpts:              c.runtime.store.GraphOptions(),
@@ -379,6 +386,12 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 					}
 
 					if err := c.ChangeHostPathOwnership(contentDir, true, int(hostUID), int(hostGID)); err != nil {
+						return nil, nil, err
+					}
+				}
+				if isIdmapOption(o) {
+					overlayMount.UIDMappings, overlayMount.GIDMappings, err = parseIDMapMountOption(c.config.IDMappings, o)
+					if err != nil {
 						return nil, nil, err
 					}
 				}
@@ -489,7 +502,14 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		if err != nil {
 			return nil, nil, err
 		}
-		contentDir, err := overlay.TempDir(c.config.StaticDir, c.RootUID(), c.RootGID())
+		// For idmapped volumes the backing dirs must be owned by real root
+		// (0) so the runtime's identity shift surfaces them as the container
+		// root.
+		backingUID, backingGID := c.RootUID(), c.RootGID()
+		if hasIdmapOption(overlayVol.Options) {
+			backingUID, backingGID = 0, 0
+		}
+		contentDir, err := overlay.TempDir(c.config.StaticDir, backingUID, backingGID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -498,8 +518,8 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 			workDir = filepath.Join(contentDir, "work")
 		}
 		overlayOpts := &overlay.Options{
-			RootUID:                c.RootUID(),
-			RootGID:                c.RootGID(),
+			RootUID:                backingUID,
+			RootGID:                backingGID,
 			UpperDirOptionFragment: upperDir,
 			WorkDirOptionFragment:  workDir,
 			GraphOpts:              c.runtime.store.GraphOptions(),
@@ -524,6 +544,12 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 				}
 
 				if err := c.ChangeHostPathOwnership(contentDir, true, int(hostUID), int(hostGID)); err != nil {
+					return nil, nil, err
+				}
+			}
+			if isIdmapOption(o) {
+				overlayMount.UIDMappings, overlayMount.GIDMappings, err = parseIDMapMountOption(c.config.IDMappings, o)
+				if err != nil {
 					return nil, nil, err
 				}
 			}

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -298,6 +298,10 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		return nil, nil, err
 	}
 
+	// If the storage owner is not mapped into the user namespace, the runtime
+	// cannot mount overlay volumes from inside it.
+	forceOverlayMount := !hasCurrentUserMapped(c)
+
 	// Add named volumes
 	for _, namedVol := range c.config.NamedVolumes {
 		volume, err := c.runtime.GetVolume(namedVol.Name)
@@ -340,12 +344,27 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 				return nil, nil, err
 			}
 
+			if forceOverlayMount {
+				if upperDir == "" {
+					upperDir = filepath.Join(contentDir, "upper")
+				}
+				if workDir == "" {
+					workDir = filepath.Join(contentDir, "work")
+				}
+			}
+
 			overlayOpts = &overlay.Options{
 				RootUID:                c.RootUID(),
 				RootGID:                c.RootGID(),
 				UpperDirOptionFragment: upperDir,
 				WorkDirOptionFragment:  workDir,
 				GraphOpts:              c.runtime.store.GraphOptions(),
+				ForceMount:             forceOverlayMount,
+			}
+			if forceOverlayMount {
+				// podman mounts the overlay itself, so it must apply the
+				// container mount label; otherwise the runtime would.
+				overlayOpts.MountLabel = c.MountLabel()
 			}
 
 			overlayMount, err = overlay.MountWithOptions(contentDir, mountPoint, namedVol.Dest, overlayOpts)
@@ -394,7 +413,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 				m.Source = safeMount.mountPoint
 				continue
 			}
-			if o == "idmap" || strings.HasPrefix(o, "idmap=") {
+			if isIdmapOption(o) {
 				var err error
 				m.UIDMappings, m.GIDMappings, err = parseIDMapMountOption(c.config.IDMappings, o)
 				if err != nil {
@@ -474,12 +493,22 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		if err != nil {
 			return nil, nil, err
 		}
+		if forceOverlayMount && upperDir == "" && workDir == "" {
+			upperDir = filepath.Join(contentDir, "upper")
+			workDir = filepath.Join(contentDir, "work")
+		}
 		overlayOpts := &overlay.Options{
 			RootUID:                c.RootUID(),
 			RootGID:                c.RootGID(),
 			UpperDirOptionFragment: upperDir,
 			WorkDirOptionFragment:  workDir,
 			GraphOpts:              c.runtime.store.GraphOptions(),
+			ForceMount:             forceOverlayMount,
+		}
+		if forceOverlayMount {
+			// podman mounts the overlay itself, so it must apply the
+			// container mount label; otherwise the runtime would.
+			overlayOpts.MountLabel = c.MountLabel()
 		}
 
 		overlayMount, err := overlay.MountWithOptions(contentDir, overlayVol.Source, overlayVol.Dest, overlayOpts)
@@ -533,11 +562,23 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		}
 
 		var overlayMount spec.Mount
-		if volume.ReadWrite {
-			overlayMount, err = overlay.Mount(contentDir, imagePath, volume.Dest, c.RootUID(), c.RootGID(), c.runtime.store.GraphOptions())
-		} else {
-			overlayMount, err = overlay.MountReadOnly(contentDir, imagePath, volume.Dest, c.RootUID(), c.RootGID(), c.runtime.store.GraphOptions())
+		overlayOpts := &overlay.Options{
+			RootUID:    c.RootUID(),
+			RootGID:    c.RootGID(),
+			GraphOpts:  c.runtime.store.GraphOptions(),
+			ReadOnly:   !volume.ReadWrite,
+			ForceMount: forceOverlayMount,
 		}
+		if forceOverlayMount {
+			// podman mounts the overlay itself, so it must apply the
+			// container mount label; otherwise the runtime would.
+			overlayOpts.MountLabel = c.MountLabel()
+		}
+		if forceOverlayMount && volume.ReadWrite {
+			overlayOpts.UpperDirOptionFragment = filepath.Join(contentDir, "upper")
+			overlayOpts.WorkDirOptionFragment = filepath.Join(contentDir, "work")
+		}
+		overlayMount, err = overlay.MountWithOptions(contentDir, imagePath, volume.Dest, overlayOpts)
 		if err != nil {
 			return nil, nil, fmt.Errorf("creating overlay mount for image %q failed: %w", volume.Source, err)
 		}
@@ -3004,13 +3045,14 @@ func (c *Container) createSecretMountDir(runPath string) error {
 	return err
 }
 
+// isIdmapOption reports whether a single volume option requests idmapping
+// (the "idmap" or "idmap=..." option).
+func isIdmapOption(o string) bool {
+	return o == "idmap" || strings.HasPrefix(o, "idmap=")
+}
+
 func hasIdmapOption(options []string) bool {
-	for _, o := range options {
-		if o == "idmap" || strings.HasPrefix(o, "idmap=") {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(options, isIdmapOption)
 }
 
 // Fix ownership and permissions of the specified volume if necessary.

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -145,28 +145,31 @@ func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*Na
 		if strings.HasPrefix(src, "/") || strings.HasPrefix(src, ".") || IsHostWinPath(src) {
 			// This is not a named volume
 			overlayFlag := false
-			chownFlag := false
 			upperDirFlag := false
 			workDirFlag := false
 			for _, o := range options {
-				if o == "O" {
+				switch {
+				case o == "O":
 					overlayFlag = true
-
-					joinedOpts := strings.Join(options, "")
-					if strings.Contains(joinedOpts, "U") {
-						chownFlag = true
-					}
-					if strings.Contains(joinedOpts, "upperdir") {
-						upperDirFlag = true
-					}
-					if strings.Contains(joinedOpts, "workdir") {
-						workDirFlag = true
-					}
-					if (workDirFlag && !upperDirFlag) || (!workDirFlag && upperDirFlag) {
-						return nil, nil, nil, errors.New("must set both `upperdir` and `workdir`")
-					}
-					if len(options) > 2 && (len(options) != 3 || !upperDirFlag || !workDirFlag) || (len(options) == 2 && !chownFlag) {
-						return nil, nil, nil, errors.New("can't use 'O' with other options")
+				case strings.HasPrefix(o, "upperdir"):
+					upperDirFlag = true
+				case strings.HasPrefix(o, "workdir"):
+					workDirFlag = true
+				}
+			}
+			if overlayFlag {
+				if (workDirFlag && !upperDirFlag) || (!workDirFlag && upperDirFlag) {
+					return nil, nil, nil, errors.New("must set both `upperdir` and `workdir`")
+				}
+				// Only 'U', 'upperdir', 'workdir' and 'idmap' may be combined with 'O'.
+				for _, o := range options {
+					switch {
+					case o == "O", o == "U",
+						strings.HasPrefix(o, "upperdir"),
+						strings.HasPrefix(o, "workdir"),
+						strings.HasPrefix(o, "idmap"):
+					default:
+						return nil, nil, nil, errors.New("can't use 'O' with options other than 'U', 'upperdir', 'workdir' and 'idmap'")
 					}
 				}
 			}

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -204,3 +204,28 @@ EOF
 
     run_podman rm -f $cname
 }
+
+# CANNOT BE PARALLELIZED: userns=auto, rootless, => not enough unused IDs in user namespace
+@test "podman :O overlay volume in a userns that does not map the storage owner" {
+    # An overlay volume (:O) must be read-write inside a userns that does not
+    # map the storage owner.  See containers/crun#2212.
+    skip_if_rootless "storage is not owned by an unmapped user when rootless"
+    grep -E -q "^containers:" /etc/subuid || skip "no IDs allocated for user 'containers'"
+
+    local volname="myvol_$(random_string)"
+    run_podman volume create $volname
+
+    run_podman run --rm -v $volname:/vol $IMAGE sh -c "echo lower > /vol/lower.txt"
+
+    # The lower content must be readable and writes (to the upper dir) must work.
+    run_podman run --rm --userns=auto -v $volname:/mnt:O $IMAGE sh -c \
+        "cat /mnt/lower.txt; echo upper > /mnt/new.txt && cat /mnt/new.txt"
+    assert "$output" =~ "lower" "overlay lower is readable under userns"
+    assert "$output" =~ "upper" "overlay upper is writable under userns"
+
+    # Writes are ephemeral: the named volume itself is untouched.
+    run_podman run --rm -v $volname:/vol $IMAGE ls /vol
+    assert "$output" = "lower.txt" "writes to a :O overlay do not leak into the volume"
+
+    run_podman volume rm $volname
+}


### PR DESCRIPTION
When the user owning the storage is not mapped into the container user namespace (e.g. root with --userns=auto), the runtime cannot mount an overlay volume from inside the user namespace.

Mount the overlay in podman instead and pass the runtime a bind mount.

Closes: https://github.com/podman-container-tools/podman/issues/28758

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [ ] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
