### PR TITLE
test/system: Update test to handle new error message from runc 1.5.0

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -258,7 +258,11 @@ function check_label() {
         # runc 1.3.3 (temporarily?) changed the error message because of the fix to CVE-2025-52881, see
         # https://github.com/opencontainers/runc/commit/2c5356e73f15b246729d03198bfb2c6c33454099
         #   to   write fsmount:fscontext:proc/self/attr/keycreate: invalid argument
-        runc) expect=".*: \(failed\|write\).*proc/self/attr/keycreate.*" ;;
+        # runc 1.5.0 changed the error message again because of the switch to a
+        # safe procfs API (reopened handles no longer carry a /proc/self path), see
+        # https://github.com/opencontainers/runc/commit/ed6b1693b8b3ae7eb0250a7e76fc888cdacf98c1
+        #   to   write /1/attr/keycreate: invalid argument
+        runc) expect=".*: \(failed\|write\).*attr/keycreate.*" ;;
         *)    skip "Unknown runtime '$runtime'";;
     esac
 


### PR DESCRIPTION
runc 1.5.0 switched to a safe procfs API for setting SELinux labels, so reopened handles no longer carry a /proc/self path in error messages, e.g. "write /1/attr/keycreate: invalid argument" instead of "write /proc/self/attr/keycreate: invalid argument". Relax the regex to match on "attr/keycreate" without requiring the proc/self prefix.

Otherwise tests fail like this:

https://openqa-assets.opensuse.org/tests/6196731/file/podman-bats-root-local.tap.txt

```
not ok 599 [410] podman with nonexistent labels # in 486 ms
# tags: ci:parallel
# (from function `bail-now' in file test/system/helpers.bash, line 230,
#  from function `is' in file test/system/helpers.bash, line 1133,
#  in test file test/system/410-selinux.bats, line 268)
#   `is "$output" "Error.*: $expect" "podman emits useful diagnostic on failure"' failed
# 
# [22:38:55.550377403] # /usr/bin/podman  run --rm --security-opt label=type:foo.bar quay.io/libpod/testimage:20241011 true
# [22:38:55.787563884] Error: OCI runtime error: runc: runc create failed: unable to start container process: error during container init: write /1/attr/keycreate: invalid argument
# [22:38:55.791079211] [ rc=126 (expected) ]
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: podman emits useful diagnostic on failure
# #| expected: 'Error.*: .*: \(failed\|write\).*proc/self/attr/keycreate.*' (using expr)
# #|   actual: 'Error: OCI runtime error: runc: runc create failed: unable to start container process: error during container init: write /1/attr/keycreate: invalid argument'
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# # [teardown]
```

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
