### PR TITLE
Revert "test/system: skip one new pasta flake"

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -852,10 +852,9 @@ nameserver 8.8.8.8" "nameserver order is correct"
 
     local -a netmodes=("bridge")
     # pasta only works rootless
-    # FIXME: skip pasta because this is super flaky, https://bugs.passt.top/show_bug.cgi?id=202
-    #if is_rootless; then
-    #    netmodes+=("pasta")
-    #fi
+    if is_rootless; then
+        netmodes+=("pasta")
+    fi
 
     for netmode in "${netmodes[@]}"; do
         local range=$(random_free_port_range 3)


### PR DESCRIPTION
This reverts commit 0dbe00d2724620fc202233a90c239b97a78c5f75.

The linked bug[1] has been fixed for a while now, remove the skip to test the port forwarding range properly again with pasta. The CI images all have a new enough pasta.

[1] https://bugs.passt.top/show_bug.cgi?id=202



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
