### PR TITLE
completion: also claim the .exe name in generated scripts

### DIFF
--- a/cmd/podman/completion/completion.go
+++ b/cmd/podman/completion/completion.go
@@ -15,6 +15,25 @@ const (
 	completionDescription = `Generate shell autocompletions.
   Valid arguments are bash, zsh, fish, and powershell.
   Please refer to the man page to see how you can load these completions.`
+
+	// cobra registers the completion only for the command name itself, i.e.
+	// "podman". On Windows the binary is called podman.exe and shells such as
+	// git bash complete the command to that name before the argument
+	// completion runs, so the generated script never matches. Claim the .exe
+	// name as well, mirroring the condition cobra uses for the plain name.
+	windowsBashCompletion = `
+if [[ $(type -t compopt) = "builtin" ]]; then
+    complete -o default -F __start_%[1]s %[1]s.exe
+else
+    complete -o default -o nospace -F __start_%[1]s %[1]s.exe
+fi
+`
+
+	// Same problem as above for powershell, where podman.exe is the common
+	// way to call the binary.
+	windowsPwshCompletion = `
+Register-ArgumentCompleter -CommandName '%[1]s.exe' -ScriptBlock ${__%[2]sCompleterBlock}
+`
 )
 
 var (
@@ -65,7 +84,10 @@ func completion(cmd *cobra.Command, args []string) error {
 	var err error
 	switch args[0] {
 	case "bash":
-		err = cmd.Root().GenBashCompletionV2(w, !noDesc)
+		if err = cmd.Root().GenBashCompletionV2(w, !noDesc); err != nil {
+			return err
+		}
+		_, err = io.WriteString(w, fmt.Sprintf(windowsBashCompletion, cmd.Root().Name()))
 	case "zsh":
 		if noDesc {
 			err = cmd.Root().GenZshCompletionNoDesc(w)
@@ -80,6 +102,13 @@ func completion(cmd *cobra.Command, args []string) error {
 		} else {
 			err = cmd.Root().GenPowerShellCompletionWithDesc(w)
 		}
+		if err != nil {
+			return err
+		}
+		// cobra sanitizes the name for the powershell variable it declares.
+		name := cmd.Root().Name()
+		nameForVar := strings.NewReplacer("-", "_", ":", "_").Replace(name)
+		_, err = io.WriteString(w, fmt.Sprintf(windowsPwshCompletion, name, nameForVar))
 	}
 
 	if err != nil {

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -425,4 +425,10 @@ fi
 
 # ex: ts=4 sw=4 et filetype=sh
 
+if [[ $(type -t compopt) = "builtin" ]]; then
+    complete -o default -F __start_podman podman.exe
+else
+    complete -o default -o nospace -F __start_podman podman.exe
+fi
+
 # This file is generated with "podman completion"; see: podman-completion(1)

--- a/completions/bash/podman-remote
+++ b/completions/bash/podman-remote
@@ -425,4 +425,10 @@ fi
 
 # ex: ts=4 sw=4 et filetype=sh
 
+if [[ $(type -t compopt) = "builtin" ]]; then
+    complete -o default -F __start_podman-remote podman-remote.exe
+else
+    complete -o default -o nospace -F __start_podman-remote podman-remote.exe
+fi
+
 # This file is generated with "podman-remote completion"; see: podman-completion(1)

--- a/completions/powershell/podman-remote.ps1
+++ b/completions/powershell/podman-remote.ps1
@@ -269,4 +269,6 @@ filter __podman-remote_escapeStringWithSpecialChars {
 
 Register-ArgumentCompleter -CommandName 'podman-remote' -ScriptBlock ${__podman_remoteCompleterBlock}
 
+Register-ArgumentCompleter -CommandName 'podman-remote.exe' -ScriptBlock ${__podman_remoteCompleterBlock}
+
 # This file is generated with "podman-remote completion"; see: podman-completion(1)

--- a/completions/powershell/podman.ps1
+++ b/completions/powershell/podman.ps1
@@ -269,4 +269,6 @@ filter __podman_escapeStringWithSpecialChars {
 
 Register-ArgumentCompleter -CommandName 'podman' -ScriptBlock ${__podmanCompleterBlock}
 
+Register-ArgumentCompleter -CommandName 'podman.exe' -ScriptBlock ${__podmanCompleterBlock}
+
 # This file is generated with "podman completion"; see: podman-completion(1)

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -433,3 +433,21 @@ function _check_no_suggestions() {
 
     _check_completion_end NoFileComp
 }
+
+@test "podman completion - scripts claim the .exe name" {
+    # On Windows the binary is called podman.exe and shells such as git bash
+    # complete the command to that name before the argument completion runs,
+    # so the generated scripts must claim it in addition to the plain name.
+    local -a podman_as_array=($PODMAN)
+    local name
+    name=$(basename "${podman_as_array[0]}")
+    name=${name%.exe}
+
+    run_podman completion bash
+    assert "$output" =~ "-F __start_$name $name\.exe" \
+      "bash completion script must also complete $name.exe"
+
+    run_podman completion powershell
+    assert "$output" =~ "-CommandName '$name\.exe'" \
+      "powershell completion script must also complete $name.exe"
+}


### PR DESCRIPTION
## Summary

On Windows the binary is `podman.exe`, so in Git Bash typing `podman` and
pressing TAB completes the *command word* to `podman.exe` before argument
completion runs. Bash looks up completion specs by the exact command word,
and the script from `podman completion bash` registers only one name:

    complete -o default -F __start_podman podman

There is no spec for `podman.exe`, so bash falls back to file name
completion. The completion logic is fine — it is never reached, because the
name it is registered under is not the name being typed. The work-around in
the issue, `sed 's/podman$/podman podman.exe/'`, is exactly the missing
registration.

## Related Issue

Fixes: #29685

## Changes

**bash:** cobra emits the `complete` line from `c.Name()` and only ever emits
one. `completion()` already appends to cobra's output — the trailing
`# This file is generated with "podman completion"` comment is ours — so the
second registration goes through the same `io.WriteString`. It points at
`__start_podman`, the function cobra already generated, so no logic is
duplicated, only a second name bound to it. The `compopt` check mirrors
cobra's own, keeping the `-o nospace` fallback for bash 3.

The name comes from `cmd.Root().Name()` rather than a literal, so
`podman-remote` gets `podman-remote.exe` from the same code path. `root.go`
already builds it as `strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")`,
so `podman.exe completion bash` cannot produce `podman.exe.exe`.

**powershell:** a second `Register-ArgumentCompleter` reusing the same
completer block, with cobra's `-` to `_` sanitization for the variable name —
otherwise the podman-remote script would reference
`${__podman-remoteCompleterBlock}`, which is never declared.

Plus the regenerated `completions/` files.

## Steps to Test

The test fails without the fix:

    PODMAN=$(pwd)/bin/podman bats -f "claim the .exe" test/system/600-completion.bats

It asserts both generated scripts register the `.exe` name, deriving the
expected name from `$PODMAN` so it covers `podman-remote` too.

That the committed files match the generator:

    make completions && git diff --exit-code completions/

Directly: `source <(./bin/podman completion bash)`, then `complete -p
podman.exe` — no completion specification before, `-F __start_podman
podman.exe` after. On Windows, in Git Bash, `podman` TAB (completing to
`podman.exe`) then TAB again now gives subcommands instead of file names.

## Notes for the Reviewer

@Luap99 you noted these scripts come from cobra, not from us, and that is
right — the template cannot be fixed here. This changes only what podman
appends after cobra is done, which `completion()` already does.

I think there is a case for podman carrying it rather than waiting on
upstream: we ship a Windows binary, it is called `podman.exe`, and
podman-completion(1) already tells Windows users to invoke it that way. The
cobra fix helps every cobra CLI and is worth doing, but needs a release and a
vendor bump before a Windows user sees anything. Happy to open that PR
instead, or as well — say which you prefer.

zsh and fish are untouched, since neither is the shell this happens in.

#### Checklist

- [ ] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [ ] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Shell completion now also works when podman is invoked as `podman.exe`, for example in Git Bash on Windows.
```
