### PR TITLE
Prevent unwanted registry prompts in multi-stage builds

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -1444,4 +1444,40 @@ COPY --from=img2 /etc/alpine-release /prefix-test/container-prefix.txt`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitWithError(125, `missing required key "type"`))
 	})
+
+	It("podman multi-stage build local base image pull policy bug #29633", func() {
+		// Stage 1: Build the base image with a short name
+		dockerfileBase := `
+FROM scratch
+COPY app/main /main
+ENTRYPOINT ["/main"]
+`
+		dockerfileBasePath := filepath.Join(podmanTest.TempDir, "Dockerfile.base")
+		err := os.WriteFile(dockerfileBasePath, []byte(dockerfileBase), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a dummy /main to satisfy COPY
+		err = os.MkdirAll(filepath.Join(podmanTest.TempDir, "app"), 0o755)
+		Expect(err).ToNot(HaveOccurred())
+		err = os.WriteFile(filepath.Join(podmanTest.TempDir, "app", "main"), []byte("test"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		sessionBase := podmanTest.Podman([]string{"build", "-t", "container-hierarchy/base:latest", "-f", dockerfileBasePath, podmanTest.TempDir})
+		sessionBase.WaitWithDefaultTimeout()
+		Expect(sessionBase).Should(ExitCleanly())
+
+		// Stage 2: Reference it as an ARG (which triggers len(stages)>1 logic in buildah under the hood)
+		dockerfileApp := `
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+`
+		dockerfileAppPath := filepath.Join(podmanTest.TempDir, "Dockerfile.app")
+		err = os.WriteFile(dockerfileAppPath, []byte(dockerfileApp), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		// This build should succeed cleanly without hanging or trying to pull and failing
+		sessionApp := podmanTest.Podman([]string{"build", "--build-arg", "BASE_IMAGE=container-hierarchy/base:latest", "-t", "container-hierarchy/app:latest", "-f", dockerfileAppPath, podmanTest.TempDir})
+		sessionApp.WaitWithDefaultTimeout()
+		Expect(sessionApp).Should(ExitCleanly())
+	})
 })

--- a/vendor/go.podman.io/buildah/imagebuildah/stage_executor.go
+++ b/vendor/go.podman.io/buildah/imagebuildah/stage_executor.go
@@ -1089,18 +1089,19 @@ func (s *stageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 	// In a multi-stage build where `FROM --platform=<>` was used then we must
 	// reset context for new stages so that new stages don't inherit unexpected
 	// `--platform` from prior stages.
-	if stage.Builder.Platform != "" || (len(s.stages) > 1 && (s.systemContext.ArchitectureChoice == "" && s.systemContext.VariantChoice == "" && s.systemContext.OSChoice == "")) {
+	if stage.Builder.Platform != "" {
 		imageOS, imageArch, imageVariant, err := parse.Platform(stage.Builder.Platform)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse platform %q: %w", stage.Builder.Platform, err)
 		}
-		if imageArch != "" || imageVariant != "" {
-			s.systemContext.ArchitectureChoice = imageArch
-			s.systemContext.VariantChoice = imageVariant
-		}
-		if imageOS != "" {
-			s.systemContext.OSChoice = imageOS
-		}
+		s.systemContext.ArchitectureChoice = imageArch
+		s.systemContext.VariantChoice = imageVariant
+		s.systemContext.OSChoice = imageOS
+	} else if len(s.stages) > 1 {
+		// Reset to the global build context platform instead of the host architecture
+		s.systemContext.ArchitectureChoice = s.executor.architecture
+		s.systemContext.VariantChoice = ""
+		s.systemContext.OSChoice = s.executor.os
 	}
 
 	builderOptions := buildah.BuilderOptions{


### PR DESCRIPTION

Fixes: #29633

<!-- Thanks for sending a pull request! -->

Root cause : So the current logic, does not work becuase the architecture of the host get's updated incorrectly in the if-else block and it does not reset when `s.stages` > 1 becuase the architecture of the host is not null.
Subsequent builds assumes that we are running the image on different architecture which shouldn't be the case. 

So the solution should be simply decoupling the (if-else) a bit such that when we are on multi-satge builds it sepcifically distinguishes if we are using the `--platform` flag or not, if not then `s.stages` logic should always reset to the global build architecture that is null.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
            prompt when trying multi-stage builds
```
