### PR TITLE
Update to Go 1.26

### DIFF
--- a/cmd/podman-testing/main.go
+++ b/cmd/podman-testing/main.go
@@ -101,8 +101,7 @@ func main() {
 		} else {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			if w, ok := ee.Sys().(syscall.WaitStatus); ok {
 				exitCode = w.ExitStatus()
 			}

--- a/cmd/podman/compose.go
+++ b/cmd/podman/compose.go
@@ -219,8 +219,7 @@ func composeProviderExec(args []string, stdout io.Writer, stderr io.Writer, warn
 
 	if err := cmd.Run(); err != nil {
 		// Make sure podman returns with the same exit code as the compose provider.
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			registry.SetExitCode(exitErr.ExitCode())
 		}
 		// Format the error to make it explicit that error did not come

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -213,13 +213,12 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if machine already exists
-	var errNotExists *define.ErrVMDoesNotExist
 	_, _, err := shim.VMExists(initOpts.Name)
 	// if nil, means we found a vm and need to reject it by name
 	if err == nil {
 		return &define.ErrVMAlreadyExists{Name: initOpts.Name}
 	}
-	if !errors.As(err, &errNotExists) {
+	if _, ok := errors.AsType[*define.ErrVMDoesNotExist](err); !ok {
 		return err
 	}
 

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -60,8 +60,7 @@ func ssh(_ *cobra.Command, args []string) error {
 		// it implies podman cannot read its machine files, which is bad
 		mc, vmProvider, err = shim.VMExists(args[0])
 		if err != nil {
-			var vmNotExistsErr *define.ErrVMDoesNotExist
-			if !errors.As(err, &vmNotExistsErr) {
+			if _, ok := errors.AsType[*define.ErrVMDoesNotExist](err); !ok {
 				return err
 			}
 			sshOpts.Args = append(sshOpts.Args, args[0])

--- a/cmd/podman/networks/create_test.go
+++ b/cmd/podman/networks/create_test.go
@@ -34,7 +34,7 @@ func TestParseRoute(t *testing.T) {
 			want: &types.Route{
 				Destination: mustParseCIDR(t, "10.21.0.0/24"),
 				Gateway:     net.ParseIP("10.19.12.250"),
-				Metric:      uint32Ptr(100),
+				Metric:      new(uint32(100)),
 				RouteType:   types.RouteTypeUnicast,
 			},
 		},
@@ -53,7 +53,7 @@ func TestParseRoute(t *testing.T) {
 			routeStr: "10.21.0.0/24,blackhole,200",
 			want: &types.Route{
 				Destination: mustParseCIDR(t, "10.21.0.0/24"),
-				Metric:      uint32Ptr(200),
+				Metric:      new(uint32(200)),
 				RouteType:   types.RouteTypeBlackhole,
 			},
 		},
@@ -71,7 +71,7 @@ func TestParseRoute(t *testing.T) {
 			routeStr: "192.168.100.0/24,unreachable,150",
 			want: &types.Route{
 				Destination: mustParseCIDR(t, "192.168.100.0/24"),
-				Metric:      uint32Ptr(150),
+				Metric:      new(uint32(150)),
 				RouteType:   types.RouteTypeUnreachable,
 			},
 		},
@@ -89,7 +89,7 @@ func TestParseRoute(t *testing.T) {
 			routeStr: "172.16.0.0/16,prohibit,50",
 			want: &types.Route{
 				Destination: mustParseCIDR(t, "172.16.0.0/16"),
-				Metric:      uint32Ptr(50),
+				Metric:      new(uint32(50)),
 				RouteType:   types.RouteTypeProhibit,
 			},
 		},
@@ -215,8 +215,4 @@ func mustParseCIDR(t *testing.T, cidr string) types.IPNet {
 	ipnet, err := types.ParseCIDR(cidr)
 	require.NoError(t, err)
 	return ipnet
-}
-
-func uint32Ptr(v uint32) *uint32 {
-	return &v
 }

--- a/cmd/podman/utils/error.go
+++ b/cmd/podman/utils/error.go
@@ -60,8 +60,7 @@ func HandleOSExecError(err error) error {
 	if err == nil {
 		return nil
 	}
-	var exitError *exec.ExitError
-	if errors.As(err, &exitError) {
+	if exitError, ok := errors.AsType[*exec.ExitError](err); ok {
 		// the user command inside the unshare/ssh env has failed
 		// we set the exit code, do not return the error to the user
 		// otherwise "exit status X" will be printed

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module go.podman.io/podman/v6
 // Warning: if there is a "toolchain" directive anywhere in this file (and most of the
 // time there shouldn't be), its version must be an exact match to the "go" directive.
 
-go 1.25.9
+go 1.26.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -672,8 +672,7 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 // isRetryable returns whether the error was caused by a blocked syscall or the
 // specified operation on a non blocking file descriptor wasn't ready for completion.
 func isRetryable(err error) bool {
-	var errno syscall.Errno
-	if errors.As(err, &errno) {
+	if errno, ok := errors.AsType[syscall.Errno](err); ok {
 		return errno == syscall.EINTR || errno == syscall.EAGAIN
 	}
 	return false

--- a/pkg/api/handlers/compat/auth.go
+++ b/pkg/api/handlers/compat/auth.go
@@ -49,8 +49,7 @@ func Auth(w http.ResponseWriter, r *http.Request) {
 	} else {
 		var msg string
 
-		var unauthErr DockerClient.ErrUnauthorizedForCredentials
-		if errors.As(err, &unauthErr) {
+		if _, ok := errors.AsType[DockerClient.ErrUnauthorizedForCredentials](err); ok {
 			msg = "401 Unauthorized"
 		} else {
 			msg = err.Error()

--- a/pkg/api/handlers/decoder.go
+++ b/pkg/api/handlers/decoder.go
@@ -129,8 +129,7 @@ func convertTimeString(query string) reflect.Value {
 			return reflect.ValueOf(t)
 		}
 
-		var parseErr *time.ParseError
-		if errors.As(err, &parseErr) {
+		if _, ok := errors.AsType[*time.ParseError](err); ok {
 			// Try next format
 			continue
 		} else {

--- a/pkg/api/handlers/libpod/artifacts.go
+++ b/pkg/api/handlers/libpod/artifacts.go
@@ -390,8 +390,7 @@ func PushArtifact(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		var notFoundErr layout.ImageNotFoundError
-		if errors.As(err, &notFoundErr) {
+		if notFoundErr, ok := errors.AsType[layout.ImageNotFoundError](err); ok {
 			utils.ArtifactNotFound(w, name, notFoundErr)
 			return
 		}

--- a/pkg/api/handlers/utils/errors.go
+++ b/pkg/api/handlers/utils/errors.go
@@ -133,8 +133,7 @@ func GetInternalServerError(err error) *BuildError {
 }
 
 func ProcessBuildError(w http.ResponseWriter, err error) {
-	var buildErr *BuildError
-	if errors.As(err, &buildErr) {
+	if buildErr, ok := errors.AsType[*BuildError](err); ok {
 		Error(w, buildErr.code, buildErr.err)
 		return
 	}

--- a/pkg/bindings/errors.go
+++ b/pkg/bindings/errors.go
@@ -55,12 +55,10 @@ func (h *APIResponse) ProcessWithError(unmarshalInto any, unmarshalErrorInto any
 }
 
 func CheckResponseCode(inError error) (int, error) {
-	var errModel *errorhandling.ErrorModel
-	if errors.As(inError, &errModel) {
+	if errModel, ok := errors.AsType[*errorhandling.ErrorModel](inError); ok {
 		return errModel.Code(), nil
 	}
-	var podConflictModel *errorhandling.PodConflictErrorModel
-	if errors.As(inError, &podConflictModel) {
+	if podConflictModel, ok := errors.AsType[*errorhandling.PodConflictErrorModel](inError); ok {
 		return podConflictModel.Code(), nil
 	}
 	return -1, errors.New("is not type ErrorModel")

--- a/pkg/bindings/internal/util/util.go
+++ b/pkg/bindings/internal/util/util.go
@@ -12,7 +12,7 @@ import (
 )
 
 func IsSimpleType(f reflect.Value) bool {
-	if _, ok := f.Interface().(fmt.Stringer); ok {
+	if _, ok := reflect.TypeAssert[fmt.Stringer](f); ok {
 		return true
 	}
 
@@ -25,7 +25,7 @@ func IsSimpleType(f reflect.Value) bool {
 }
 
 func SimpleTypeToParam(f reflect.Value) string {
-	if s, ok := f.Interface().(fmt.Stringer); ok {
+	if s, ok := reflect.TypeAssert[fmt.Stringer](f); ok {
 		return s.String()
 	}
 

--- a/pkg/bindings/internal/util/util_test.go
+++ b/pkg/bindings/internal/util/util_test.go
@@ -11,10 +11,6 @@ import (
 	"go.podman.io/podman/v6/pkg/bindings/internal/util"
 )
 
-func strp(s string) *string { return &s }
-func intp(i int) *int       { return &i }
-func boolp(b bool) *bool    { return &b }
-
 type changedOptions struct {
 	Set   *string
 	Unset *string
@@ -107,9 +103,9 @@ func TestToParamsUnsetFieldsAreSkipped(t *testing.T) {
 
 func TestToParamsSimpleFields(t *testing.T) {
 	params, err := util.ToParams(&toParamsOptions{
-		Name:    strp("foo"),
-		Count:   intp(5),
-		Enabled: boolp(true),
+		Name:    new("foo"),
+		Count:   new(5),
+		Enabled: new(true),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "foo", params.Get("name"))
@@ -146,8 +142,8 @@ func TestToParamsEmptyMap(t *testing.T) {
 
 func TestToParamsSchemaTag(t *testing.T) {
 	params, err := util.ToParams(&toParamsOptions{
-		Renamed: strp("here"),
-		Skipped: strp("gone"),
+		Renamed: new("here"),
+		Skipped: new("gone"),
 	})
 	require.NoError(t, err)
 	// "custom_name" (the schema rename) must be the only key: the field name

--- a/pkg/criu/criu_linux.go
+++ b/pkg/criu/criu_linux.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/checkpoint-restore/go-criu/v8"
 	"github.com/checkpoint-restore/go-criu/v8/rpc"
-
-	"google.golang.org/protobuf/proto"
 )
 
 // CheckForCriu uses CRIU's go bindings to check if the CRIU
@@ -29,7 +27,7 @@ func CheckForCriu(version int) error {
 func MemTrack() bool {
 	features, err := criu.MakeCriu().FeatureCheck(
 		&rpc.CriuFeatures{
-			MemTrack: proto.Bool(true),
+			MemTrack: new(true),
 		},
 	)
 	if err != nil {

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -57,7 +57,7 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 		for _, exitCode := range filterValues {
 			ec, err := strconv.ParseInt(exitCode, 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("exited code out of range %q: %w", ec, err)
+				return nil, fmt.Errorf("exited code invalid: %w", err)
 			}
 			exitCodes = append(exitCodes, int32(ec))
 		}
@@ -480,7 +480,7 @@ func GenerateExternalContainerFilterFuncs(filter string, filterValues []string, 
 		for _, exitCode := range filterValues {
 			ec, err := strconv.ParseInt(exitCode, 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("exited code out of range %q: %w", ec, err)
+				return nil, fmt.Errorf("exited code invalid: %w", err)
 			}
 			exitCodes = append(exitCodes, int32(ec))
 		}

--- a/pkg/domain/infra/tunnel/artifact.go
+++ b/pkg/domain/infra/tunnel/artifact.go
@@ -125,8 +125,7 @@ func (ir *ImageEngine) ArtifactAdd(_ context.Context, name string, artifactBlob 
 				if err == nil {
 					continue
 				}
-				var errModel *errorhandling.ErrorModel
-				if errors.As(err, &errModel) {
+				if errModel, ok := errors.AsType[*errorhandling.ErrorModel](err); ok {
 					switch errModel.ResponseCode {
 					case http.StatusNotFound, http.StatusMethodNotAllowed:
 					default:

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -225,8 +225,7 @@ func (ir *ImageEngine) Load(_ context.Context, opts entities.ImageLoadOptions) (
 		if err == nil {
 			return report, nil
 		}
-		var errModel *errorhandling.ErrorModel
-		if errors.As(err, &errModel) {
+		if errModel, ok := errors.AsType[*errorhandling.ErrorModel](err); ok {
 			switch errModel.ResponseCode {
 			case http.StatusNotFound, http.StatusMethodNotAllowed:
 			default:
@@ -424,8 +423,7 @@ func (ir *ImageEngine) Build(_ context.Context, containerFiles []string, opts en
 			}
 			logrus.Debugf("BuildLocal failed: %v", err)
 
-			var errModel *errorhandling.ErrorModel
-			if errors.As(err, &errModel) {
+			if errModel, ok := errors.AsType[*errorhandling.ErrorModel](err); ok {
 				switch errModel.ResponseCode {
 				case http.StatusNotFound, http.StatusMethodNotAllowed:
 				default:

--- a/pkg/machine/e2e/config_start_test.go
+++ b/pkg/machine/e2e/config_start_test.go
@@ -45,7 +45,3 @@ func (s *startMachine) withUpdateConnection(value *bool) *startMachine {
 	s.updateConnection = value
 	return s
 }
-
-func ptrBool(v bool) *bool {
-	return &v
-}

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -146,7 +146,7 @@ var _ = Describe("podman machine rm", func() {
 
 		barName := "bar"
 		bar := new(initMachine)
-		session, err = mb.setName(barName).setCmd(bar.withUpdateConnection(ptrBool(false)).withImage(mb.imagePath).withNow()).run()
+		session, err = mb.setName(barName).setCmd(bar.withUpdateConnection(new(false)).withImage(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/ssh_test.go
+++ b/pkg/machine/e2e/ssh_test.go
@@ -39,7 +39,7 @@ var _ = Describe("podman machine ssh", func() {
 
 		name := "podman-machine-default"
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow().withUpdateConnection(ptrBool(true))).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow().withUpdateConnection(new(true))).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -196,7 +196,7 @@ var _ = Describe("podman machine start", func() {
 			defer GinkgoRecover()
 			defer wg.Done()
 			s := &startMachine{}
-			startSession1, err = mb.setName(machine1).setCmd(s.withUpdateConnection(ptrBool(false))).setTimeout(time.Minute * 10).run()
+			startSession1, err = mb.setName(machine1).setCmd(s.withUpdateConnection(new(false))).setTimeout(time.Minute * 10).run()
 			Expect(err).ToNot(HaveOccurred())
 		}()
 		go func() {
@@ -209,7 +209,7 @@ var _ = Describe("podman machine start", func() {
 			// second run.
 			nmb, err := newMB()
 			Expect(err).ToNot(HaveOccurred())
-			startSession2, err = nmb.setName(machine2).setCmd(s.withUpdateConnection(ptrBool(false))).setTimeout(time.Minute * 10).run()
+			startSession2, err = nmb.setName(machine2).setCmd(s.withUpdateConnection(new(false))).setTimeout(time.Minute * 10).run()
 			Expect(err).ToNot(HaveOccurred())
 		}()
 		wg.Wait()
@@ -250,7 +250,7 @@ var _ = Describe("podman machine start", func() {
 
 		// Start the new machine with --update-connection=false
 		s := startMachine{}
-		startSession, err := mb.setName(machineName).setCmd(s.withUpdateConnection(ptrBool(false))).run()
+		startSession, err := mb.setName(machineName).setCmd(s.withUpdateConnection(new(false))).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(0))
 
@@ -266,7 +266,7 @@ var _ = Describe("podman machine start", func() {
 		Expect(stopSession).To(Exit(0))
 
 		// Start the new machine with --update-connection
-		startSession, err = mb.setName(machineName).setCmd(s.withUpdateConnection(ptrBool(true))).run()
+		startSession, err = mb.setName(machineName).setCmd(s.withUpdateConnection(new(true))).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(0))
 
@@ -288,7 +288,7 @@ var _ = Describe("podman machine start", func() {
 		// Create a new machine
 		i := initMachine{}
 		machineName1 := randomString()
-		initSession, err := mb.setName(machineName1).setCmd(i.withImage(mb.imagePath).withUpdateConnection(ptrBool(false)).withNow()).run()
+		initSession, err := mb.setName(machineName1).setCmd(i.withImage(mb.imagePath).withUpdateConnection(new(false)).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(initSession).To(Exit(0))
 
@@ -305,7 +305,7 @@ var _ = Describe("podman machine start", func() {
 
 		// Create another machine
 		machineName2 := randomString()
-		initSession2, err := mb.setName(machineName2).setCmd(i.withImage(mb.imagePath).withUpdateConnection(ptrBool(true)).withNow()).run()
+		initSession2, err := mb.setName(machineName2).setCmd(i.withImage(mb.imagePath).withUpdateConnection(new(true)).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(initSession2).To(Exit(0))
 

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -161,8 +161,8 @@ func (h HyperVStubber) CreateVM(_ define.CreateVMOpts, mc *vmconfigs.MachineConf
 	}
 
 	builder.WithUnit(ignition.Unit{
-		Contents: ignition.StrToPtr(netUnitFile),
-		Enabled:  ignition.BoolToPtr(true),
+		Contents: new(netUnitFile),
+		Enabled:  new(true),
 		Name:     "vsock-network.service",
 	})
 
@@ -175,7 +175,7 @@ func (h HyperVStubber) CreateVM(_ define.CreateVMOpts, mc *vmconfigs.MachineConf
 			Contents: ignition.Resource{
 				Source: ignition.EncodeDataURLPtr(hyperVVsockNMConnection),
 			},
-			Mode: ignition.IntToPtr(0o600),
+			Mode: new(0o600),
 		},
 	})
 

--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -29,21 +29,6 @@ const (
 	DefaultIgnitionUserName = "core"
 )
 
-// Convenience function to convert int to ptr
-func IntToPtr(i int) *int {
-	return &i
-}
-
-// Convenience function to convert string to ptr
-func StrToPtr(s string) *string {
-	return &s
-}
-
-// Convenience function to convert bool to ptr
-func BoolToPtr(b bool) *bool {
-	return &b
-}
-
 func GetNodeUsr(usrName string) NodeUser {
 	return NodeUser{Name: &usrName}
 }
@@ -85,7 +70,7 @@ func (ign *DynamicIgnition) getUsers() []PasswdUser {
 	if !isCoreUser {
 		coreUser := PasswdUser{
 			Name:        DefaultIgnitionUserName,
-			ShouldExist: BoolToPtr(false),
+			ShouldExist: new(false),
 		}
 		users = append(users, coreUser)
 	}
@@ -94,7 +79,7 @@ func (ign *DynamicIgnition) getUsers() []PasswdUser {
 	user := PasswdUser{
 		Name:              ign.Name,
 		SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
-		UID:               IntToPtr(ign.UID),
+		UID:               new(ign.UID),
 	}
 
 	// If we are not using the core user, we need to make the user part
@@ -162,11 +147,11 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 				Node: Node{
 					Group:     GetNodeGrp("root"),
 					Path:      "/etc/localtime",
-					Overwrite: BoolToPtr(false),
+					Overwrite: new(false),
 					User:      GetNodeUsr("root"),
 				},
 				LinkEmbedded1: LinkEmbedded1{
-					Hard: BoolToPtr(false),
+					Hard: new(false),
 					// We always want this value in unix form (../usr/share/zoneinfo) because this is being
 					// set in the machine OS (always Linux) and systemd needs the relative symlink.  However,
 					// filepath.join on windows will use a "\\" separator so use path.Join() which always
@@ -181,7 +166,7 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 	ignSystemd := Systemd{
 		Units: []Unit{
 			{
-				Enabled: BoolToPtr(true),
+				Enabled: new(true),
 				Name:    "podman.socket",
 			},
 			{
@@ -189,7 +174,7 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 				// updates given a certain configuration
 				// Disable auto-updating of fcos images
 				// https://github.com/containers/podman/issues/20122
-				Enabled: BoolToPtr(false),
+				Enabled: new(false),
 				Name:    "zincati.service",
 			},
 		},
@@ -200,7 +185,7 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 		rosettaUnit := Systemd{
 			Units: []Unit{
 				{
-					Enabled: BoolToPtr(true),
+					Enabled: new(true),
 					Name:    "rosetta-activation.service",
 				},
 			},
@@ -236,7 +221,7 @@ func getDirs(usrName string) []Directory {
 				Path:  d,
 				User:  GetNodeUsr(usrName),
 			},
-			DirectoryEmbedded1: DirectoryEmbedded1{Mode: IntToPtr(0o755)},
+			DirectoryEmbedded1: DirectoryEmbedded1{Mode: new(0o755)},
 		}
 		dirs[i] = newDir
 	}
@@ -254,13 +239,13 @@ func getFiles(usrName string, uid int, rootful bool, vmtype define.VMType, _ boo
 			Path:  "/var/lib/systemd/linger/" + usrName,
 			User:  GetNodeUsr("root"),
 			// the coreos image might already have this defined
-			Overwrite: BoolToPtr(true),
+			Overwrite: new(true),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Contents: Resource{
 				Source: EncodeDataURLPtr(""),
 			},
-			Mode: IntToPtr(0o644),
+			Mode: new(0o644),
 		},
 	})
 
@@ -295,7 +280,7 @@ pids_limit=0
 			Contents: Resource{
 				Source: EncodeDataURLPtr(containers),
 			},
-			Mode: IntToPtr(0o744),
+			Mode: new(0o744),
 		},
 	})
 
@@ -306,14 +291,14 @@ pids_limit=0
 				Group:     GetNodeGrp("root"),
 				Path:      sub,
 				User:      GetNodeUsr("root"),
-				Overwrite: BoolToPtr(true),
+				Overwrite: new(true),
 			},
 			FileEmbedded1: FileEmbedded1{
 				Append: nil,
 				Contents: Resource{
 					Source: EncodeDataURLPtr(etcSubUID),
 				},
-				Mode: IntToPtr(0o744),
+				Mode: new(0o744),
 			},
 		})
 	}
@@ -332,7 +317,7 @@ pids_limit=0
 			Contents: Resource{
 				Source: EncodeDataURLPtr(fmt.Sprintf("%s\n", vmtype.String())),
 			},
-			Mode: IntToPtr(0o644),
+			Mode: new(0o644),
 		},
 	})
 
@@ -346,7 +331,7 @@ pids_limit=0
 			Contents: Resource{
 				Source: EncodeDataURLPtr(GetPodmanDockerTmpConfig(uid, rootful, true)),
 			},
-			Mode: IntToPtr(0o644),
+			Mode: new(0o644),
 		},
 	})
 
@@ -360,7 +345,7 @@ pids_limit=0
 				Contents: Resource{
 					Source: EncodeDataURLPtr(fmt.Sprintf("[zram0]\nzram-size=%d\n", swap)),
 				},
-				Mode: IntToPtr(0o644),
+				Mode: new(0o644),
 			},
 		})
 	}
@@ -374,28 +359,28 @@ func getLinks() []Link {
 			Group:     GetNodeGrp("root"),
 			Path:      "/etc/systemd/user/sockets.target.wants/podman.socket",
 			User:      GetNodeUsr("root"),
-			Overwrite: BoolToPtr(true),
+			Overwrite: new(true),
 		},
 		LinkEmbedded1: LinkEmbedded1{
-			Hard:   BoolToPtr(false),
+			Hard:   new(false),
 			Target: "/usr/lib/systemd/user/podman.socket",
 		},
 	}, {
 		Node: Node{
 			Group:     GetNodeGrp("root"),
 			Path:      "/usr/local/bin/docker",
-			Overwrite: BoolToPtr(true),
+			Overwrite: new(true),
 			User:      GetNodeUsr("root"),
 		},
 		LinkEmbedded1: LinkEmbedded1{
-			Hard:   BoolToPtr(false),
+			Hard:   new(false),
 			Target: "/usr/bin/podman",
 		},
 	}}
 }
 
 func EncodeDataURLPtr(contents string) *string {
-	return StrToPtr(fmt.Sprintf("data:,%s", url.PathEscape(contents)))
+	return new(fmt.Sprintf("data:,%s", url.PathEscape(contents)))
 }
 
 func GetPodmanDockerTmpConfig(uid int, rootful bool, newline bool) string {
@@ -471,7 +456,7 @@ func (i *IgnitionBuilder) AddPlaybook(contents string, destPath string, username
 			Contents: Resource{
 				Source: EncodeDataURLPtr(contents),
 			},
-			Mode: IntToPtr(0o744),
+			Mode: new(0o744),
 		},
 	}
 
@@ -494,7 +479,7 @@ func (i *IgnitionBuilder) AddPlaybook(contents string, destPath string, username
 
 	// create a systemd service
 	playbookUnit := Unit{
-		Enabled:  BoolToPtr(true),
+		Enabled:  new(true),
 		Name:     "playbook.service",
 		Contents: &unitContents,
 	}

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -275,9 +275,9 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 	}
 
 	readyUnit := ignition.Unit{
-		Enabled:  ignition.BoolToPtr(true),
+		Enabled:  new(true),
 		Name:     "ready.service",
-		Contents: ignition.StrToPtr(readyUnitFile),
+		Contents: new(readyUnitFile),
 	}
 	ignBuilder.WithUnit(readyUnit)
 

--- a/pkg/machine/volume_systemd.go
+++ b/pkg/machine/volume_systemd.go
@@ -66,9 +66,9 @@ func GenerateSystemDFilesForVirtiofsMounts(mounts []VirtIoFs) ([]ignition.Unit, 
 		// On FCOS /home is a symlink to var/home; systemd rejects non-canonical paths.
 		canonicalTarget := canonicalizeFCOSMountTarget(mnt.Target)
 		virtiofsMount := ignition.Unit{
-			Enabled:  ignition.BoolToPtr(true),
+			Enabled:  new(true),
 			Name:     fmt.Sprintf("%s.mount", parser.PathEscape(canonicalTarget)),
-			Contents: ignition.StrToPtr(fmt.Sprintf(mountUnitFile, mnt.Tag, canonicalTarget)),
+			Contents: new(fmt.Sprintf(mountUnitFile, mnt.Tag, canonicalTarget)),
 		}
 
 		unitFiles = append(unitFiles, virtiofsMount)
@@ -90,9 +90,9 @@ func GenerateSystemDFilesForVirtiofsMounts(mounts []VirtIoFs) ([]ignition.Unit, 
 	}
 
 	immutableRootOffUnit := ignition.Unit{
-		Contents: ignition.StrToPtr(immutableRootOffFile),
+		Contents: new(immutableRootOffFile),
 		Name:     "immutable-root-off.service",
-		Enabled:  ignition.BoolToPtr(true),
+		Enabled:  new(true),
 	}
 	unitFiles = append(unitFiles, immutableRootOffUnit)
 
@@ -111,9 +111,9 @@ func GenerateSystemDFilesForVirtiofsMounts(mounts []VirtIoFs) ([]ignition.Unit, 
 	}
 
 	immutableRootOnUnit := ignition.Unit{
-		Contents: ignition.StrToPtr(immutableRootOnFile),
+		Contents: new(immutableRootOnFile),
 		Name:     "immutable-root-on.service",
-		Enabled:  ignition.BoolToPtr(true),
+		Enabled:  new(true),
 	}
 	unitFiles = append(unitFiles, immutableRootOnUnit)
 

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -333,8 +333,7 @@ func launchElevate(operation string) error {
 	}
 	err := winutil.RelaunchElevatedWait()
 	if err != nil {
-		var eerr *winutil.ExitCodeError
-		if errors.As(err, &eerr) {
+		if eerr, ok := errors.AsType[*winutil.ExitCodeError](err); ok {
 			if eerr.Code == ErrorSuccessRebootRequired {
 				fmt.Println("Reboot is required to continue installation, please reboot at your convenience")
 				return define.ErrRelaunchSucceeded
@@ -375,8 +374,7 @@ func isMsiError(err error) bool {
 		return false
 	}
 
-	var eerr *exec.ExitError
-	if errors.As(err, &eerr) {
+	if eerr, ok := errors.AsType[*exec.ExitError](err); ok {
 		switch eerr.ExitCode() {
 		case 0:
 			fallthrough

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -153,8 +153,7 @@ func stopUserModeNetworking(mc *vmconfigs.MachineConfig) error {
 
 	err = wslPipe(stopUserModeNet, userModeDist, "bash")
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			switch exitErr.ExitCode() {
 			case 2:
 				err = fmt.Errorf("startup state was missing")
@@ -185,8 +184,7 @@ func launchUserModeNetDist(exeFile string) error {
 	if err := wslPipe(cmdStr, userModeDist, "bash"); err != nil {
 		_ = terminateDist(userModeDist)
 
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			switch exitErr.ExitCode() {
 			case 2:
 				return fmt.Errorf("another user-mode network is running, only one can be used at a time: shut down all machines and run wsl --shutdown if this is unexpected")

--- a/pkg/machine/wsl/wutil/wutil.go
+++ b/pkg/machine/wsl/wutil/wutil.go
@@ -67,8 +67,7 @@ func parseWSLStatus() wslStatus {
 		var outputErr error
 		status, outputErr = matchOutputLine(out)
 		err = cmd.Wait()
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if _, ok := errors.AsType[*exec.ExitError](err); ok {
 			// If `wsl --status` returns an exit error
 			// we assume that WSL isn't installed and
 			// override whatever was returned by

--- a/pkg/specgen/generate/kube/kube_test.go
+++ b/pkg/specgen/generate/kube/kube_test.go
@@ -188,10 +188,6 @@ func seccompProfile(profileType v1.SeccompProfileType, localhostProfile *string)
 	return &v1.SeccompProfile{Type: profileType, LocalhostProfile: localhostProfile}
 }
 
-func stringPtr(value string) *string {
-	return &value
-}
-
 func TestSetupSecurityContextSeccompProfile(t *testing.T) {
 	profileRoot := t.TempDir()
 	defaultPath, err := libpod.DefaultSeccompPath()
@@ -216,14 +212,14 @@ func TestSetupSecurityContextSeccompProfile(t *testing.T) {
 		{
 			name: "pod profile",
 			pod: &v1.PodSecurityContext{
-				SeccompProfile: seccompProfile(v1.SeccompProfileTypeLocalhost, stringPtr("profiles/pod.json")),
+				SeccompProfile: seccompProfile(v1.SeccompProfileTypeLocalhost, new("profiles/pod.json")),
 			},
 			expected: filepath.Join(profileRoot, "profiles/pod.json"),
 		},
 		{
 			name: "container overrides pod",
 			ctr: &v1.SecurityContext{
-				SeccompProfile: seccompProfile(v1.SeccompProfileTypeLocalhost, stringPtr("profiles/container.json")),
+				SeccompProfile: seccompProfile(v1.SeccompProfileTypeLocalhost, new("profiles/container.json")),
 			},
 			pod: &v1.PodSecurityContext{
 				SeccompProfile: seccompProfile(v1.SeccompProfileTypeUnconfined, nil),
@@ -251,7 +247,7 @@ func TestSetupSecurityContextSeccompProfile(t *testing.T) {
 			pod: &v1.PodSecurityContext{
 				SeccompProfile: seccompProfile(
 					v1.SeccompProfileTypeLocalhost,
-					stringPtr("profiles/pod.json"),
+					new("profiles/pod.json"),
 				),
 			},
 			seccompAnnotationPaths: &SeccompAnnotationPaths{
@@ -283,7 +279,7 @@ func TestSetupSecurityContextSeccompProfile(t *testing.T) {
 			ctr: &v1.SecurityContext{
 				SeccompProfile: seccompProfile(
 					v1.SeccompProfileTypeLocalhost,
-					stringPtr("/etc/seccomp.json"),
+					new("/etc/seccomp.json"),
 				),
 			},
 			expectedError: "must be a relative path",
@@ -293,7 +289,7 @@ func TestSetupSecurityContextSeccompProfile(t *testing.T) {
 			ctr: &v1.SecurityContext{
 				SeccompProfile: seccompProfile(
 					v1.SeccompProfileTypeLocalhost,
-					stringPtr("profiles/../seccomp.json"),
+					new("profiles/../seccomp.json"),
 				),
 			},
 			expectedError: "must not contain '..'",

--- a/pkg/systemd/notifyproxy/notifyproxy.go
+++ b/pkg/systemd/notifyproxy/notifyproxy.go
@@ -167,7 +167,7 @@ func (p *NotifyProxy) listen() {
 					}
 					for _, fd := range fds {
 						if err := unix.Close(fd); err != nil {
-							logrus.Errorf("closing fd passed on socket %q: %v", fd, err)
+							logrus.Errorf("closing fd passed on socket %d: %v", fd, err)
 							continue
 						}
 					}

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1115,8 +1115,7 @@ func SkipIfSystemdNotRunning(reason string) {
 	cmd := exec.Command("systemctl", "list-units")
 	err := cmd.Run()
 	if err != nil {
-		var execErr *exec.Error
-		if errors.As(err, &execErr) {
+		if _, ok := errors.AsType[*exec.Error](err); ok {
 			Skip("[notSystemd]: not running " + reason)
 		}
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -21,10 +21,6 @@ func removeNetworkDevice(name string) {
 	session.WaitWithDefaultTimeout()
 }
 
-func uintPtr(u uint32) *uint32 {
-	return &u
-}
-
 var _ = Describe("Podman network create", func() {
 	It("podman network create with name and subnet", func() {
 		netName := "subnet-" + stringid.GenerateRandomID()
@@ -710,6 +706,6 @@ var _ = Describe("Podman network create", func() {
 		Entry("blackhole route", "10.19.20.0/24", "10.21.10.0/24,blackhole", "10.21.10.0/24", types.RouteTypeBlackhole, nil),
 		Entry("unreachable route", "10.19.21.0/24", "10.21.11.0/24,unreachable", "10.21.11.0/24", types.RouteTypeUnreachable, nil),
 		Entry("prohibit route", "10.19.22.0/24", "10.21.12.0/24,prohibit", "10.21.12.0/24", types.RouteTypeProhibit, nil),
-		Entry("blackhole route with metric", "10.19.23.0/24", "10.21.13.0/24,blackhole,250", "10.21.13.0/24", types.RouteTypeBlackhole, uintPtr(250)),
+		Entry("blackhole route with metric", "10.19.23.0/24", "10.21.13.0/24,blackhole,250", "10.21.13.0/24", types.RouteTypeBlackhole, new(uint32(250))),
 	)
 })


### PR DESCRIPTION
Similar to https://github.com/podman-container-tools/container-libs/pull/1136



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Podman requires now go 1.26 to compile
```
