### PR TITLE
docs: clarify container prune behavior for pods

### DIFF
--- a/docs/source/markdown/podman-container-prune.1.md
+++ b/docs/source/markdown/podman-container-prune.1.md
@@ -1,13 +1,13 @@
 % podman-container-prune 1
 
 ## NAME
-podman\-container\-prune - Remove all stopped containers from local storage
+podman\-container\-prune - Remove all stopped containers not associated with pods from local storage
 
 ## SYNOPSIS
 **podman container prune** [*options*]
 
 ## DESCRIPTION
-**podman container prune** removes all stopped containers from local storage.
+**podman container prune** removes all stopped containers that are not associated with a pod from local storage.
 
 ## OPTIONS
 #### **--filter**=*filters*
@@ -41,7 +41,7 @@ Print usage statement.\
 The default is **false**.
 
 ## EXAMPLES
-Remove all stopped containers from local storage:
+Remove all stopped containers not associated with pods from local storage:
 ```
 $ podman container prune
 WARNING! This will remove all stopped containers.
@@ -54,7 +54,7 @@ fff1c5b6c3631746055ec40598ce8ecaa4b82aef122f9e3a85b03b55c0d06c23
 602d343cd47e7cb3dfc808282a9900a3e4555747787ec6723bb68cedab8384d5
 ```
 
-Remove all stopped containers from local storage without confirmation:
+Remove all stopped containers not associated with pods from local storage without confirmation:
 ```
 $ podman container prune -f
 878392adf2e6c5c9bb1fc19b69d37d2e98c8abf9d539c0bce4b15b46bbcce471
@@ -65,7 +65,7 @@ fff1c5b6c3631746055ec40598ce8ecaa4b82aef122f9e3a85b03b55c0d06c23
 602d343cd47e7cb3dfc808282a9900a3e4555747787ec6723bb68cedab8384d5
 ```
 
-Remove all stopped containers from local storage created before the last 10 minutes:
+Remove all stopped containers not associated with pods from local storage created before the last 10 minutes:
 ```
 $ podman container prune --filter until="10m"
 WARNING! This will remove all stopped containers.

--- a/docs/source/markdown/podman-container.1.md
+++ b/docs/source/markdown/podman-container.1.md
@@ -32,7 +32,7 @@ The container command allows management of containers
 | mount      | [podman-mount(1)](podman-mount.1.md)                | Mount a working container's root filesystem.                                 |
 | pause      | [podman-pause(1)](podman-pause.1.md)                | Pause one or more containers.                                                |
 | port       | [podman-port(1)](podman-port.1.md)                  | List port mappings for the container.                                        |
-| prune      | [podman-container-prune(1)](podman-container-prune.1.md)| Remove all stopped containers from local storage.                        |
+| prune      | [podman-container-prune(1)](podman-container-prune.1.md)| Remove all stopped containers not associated with pods from local storage. |
 | ps         | [podman-ps(1)](podman-ps.1.md)                      | Print out information about containers.                                      |
 | rename     | [podman-rename(1)](podman-rename.1.md)              | Rename an existing container.                                                |
 | restart    | [podman-restart(1)](podman-restart.1.md)            | Restart one or more containers.                                              |


### PR DESCRIPTION
The container prune documentation([`podman-container-prune.1.md`](https://github.com/podman-container-tools/podman/blob/main/docs/source/markdown/podman-container-prune.1.md)) states that all stopped containers are removed, while the existing implementation excludes containers associated with pods.

Update the container prune documentation and command summary to match the current behavior.
Fixes: #29213

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
**PR Description:**
- Problem: Container prune documentation claims that podman container prune removes all stopped containers from local storage. However, stopped containers that belong to pods are not removed. This behavior was confirmed by the reporter in #29213.
- Investigation: Runtime.PruneContainers() filters out all containers that have a Pod ID before checking their status.([`libpod/runtime_ctr.go:1350-1356`](https://github.com/podman-container-tools/podman/blob/main/libpod/runtime_ctr.go#L1350-L1356)) As a result, stopped containers that belong to pods never reach the size calculation or removal logic.
- Fix: Only the container prune documentation and the container command overview were updated to align the documentation with the existing behavior. No runtime behavior was changed.


