### PR TITLE
Fix build --secret leaving plaintext next to the context

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -337,12 +337,21 @@ func processBuildContext(query url.Values, r *http.Request, buildContext *BuildC
 }
 
 // processSecrets processes build secrets for podman-remote operations.
-// Moves secrets outside build context to prevent accidental inclusion in images.
-func processSecrets(query *BuildQuery, contextDirectory string, queryValues url.Values) ([]string, error) {
+// It moves each secret out of the build context so COPY cannot pick it up,
+// into a file under the host temp directory (not the context's parent).
+// The caller must remove the returned temp files when the build finishes.
+func processSecrets(query *BuildQuery, contextDirectory string, queryValues url.Values) ([]string, []string, error) {
 	secrets := []string{}
+	relocated := []string{}
 	m := []string{}
 	if err := utils.ParseOptionalJSONField(query.Secrets, "secrets", queryValues, &m); err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	cleanupRelocated := func() {
+		for _, path := range relocated {
+			os.Remove(path)
+		}
 	}
 
 	// for podman-remote all secrets must be picked from context director
@@ -357,14 +366,13 @@ func processSecrets(query *BuildQuery, contextDirectory string, queryValues url.
 					if key == "src" {
 						/* move secret away from contextDir */
 						/* to make sure we dont accidentally commit temporary secrets to image*/
-						builderDirectory, _ := filepath.Split(contextDirectory)
-						// following path is outside build context
-						newSecretPath := filepath.Join(builderDirectory, val)
 						oldSecretPath := filepath.Join(contextDirectory, val)
-						err := os.Rename(oldSecretPath, newSecretPath)
+						newSecretPath, err := relocateSecretToTemp(oldSecretPath)
 						if err != nil {
-							return nil, err
+							cleanupRelocated()
+							return nil, nil, err
 						}
+						relocated = append(relocated, newSecretPath)
 
 						modifiedSrc := fmt.Sprintf("src=%s", newSecretPath)
 						modifiedOpt = append(modifiedOpt, modifiedSrc)
@@ -376,7 +384,33 @@ func processSecrets(query *BuildQuery, contextDirectory string, queryValues url.
 			secrets = append(secrets, strings.Join(modifiedOpt, ","))
 		}
 	}
-	return secrets, nil
+	return secrets, relocated, nil
+}
+
+// relocateSecretToTemp copies the secret to a temp file and removes the original
+// from the build context. Temp dir is used instead of the context parent so
+// local-API builds do not leave plaintext next to user files (#29687).
+func relocateSecretToTemp(oldSecretPath string) (string, error) {
+	contents, err := os.ReadFile(oldSecretPath)
+	if err != nil {
+		return "", err
+	}
+	tmp, err := os.CreateTemp(parse.GetTempDir(), "podman-build-secret-*")
+	if err != nil {
+		return "", err
+	}
+	newSecretPath := tmp.Name()
+	_, writeErr := tmp.Write(contents)
+	closeErr := tmp.Close()
+	if err := errors.Join(writeErr, closeErr); err != nil {
+		os.Remove(newSecretPath)
+		return "", err
+	}
+	if err := os.Remove(oldSecretPath); err != nil {
+		os.Remove(newSecretPath)
+		return "", err
+	}
+	return newSecretPath, nil
 }
 
 // createBuildOptions creates a buildah BuildOptions struct from query parameters and build context.
@@ -413,11 +447,6 @@ func createBuildOptions(query *BuildQuery, buildCtx *BuildContext, queryValues u
 	dnssearch, err := utils.ParseJSONOptionalSlice(query.DNSSearch, queryValues, "dnssearch")
 	if err != nil {
 		return nil, nil, utils.GetBadRequestError("dnssearch", query.DNSSearch, err)
-	}
-
-	secrets, err := processSecrets(query, buildCtx.ContextDirectory, queryValues)
-	if err != nil {
-		return nil, nil, utils.GetBadRequestError("secrets", query.Secrets, err)
 	}
 
 	addhosts, err := utils.ParseJSONOptionalSlice(query.AddHosts, queryValues, "extrahosts")
@@ -660,6 +689,12 @@ func createBuildOptions(query *BuildQuery, buildCtx *BuildContext, queryValues u
 			return "", err
 		}
 		return filename, nil
+	}
+
+	secrets, secretTemps, err := processSecrets(query, buildCtx.ContextDirectory, queryValues)
+	temporaryFiles = append(temporaryFiles, secretTemps...)
+	if err != nil {
+		return nil, cleanup, utils.GetBadRequestError("secrets", query.Secrets, err)
 	}
 
 	// Process from image

--- a/pkg/api/handlers/compat/images_build_test.go
+++ b/pkg/api/handlers/compat/images_build_test.go
@@ -1,0 +1,70 @@
+//go:build !remote && (linux || freebsd)
+
+package compat
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessSecretsDoesNotLeavePlaintextInContextParent covers the host leak in
+// https://github.com/containers/podman/issues/29687: processSecrets used to
+// os.Rename the secret into the parent of the build context and never delete it.
+// For local-API / machine builds that parent is a user directory (e.g. the folder
+// containing the context), not a scratch dir.
+func TestProcessSecretsDoesNotLeavePlaintextInContextParent(t *testing.T) {
+	parent := t.TempDir()
+	contextDir := filepath.Join(parent, "ctx")
+	require.NoError(t, os.Mkdir(contextDir, 0o755))
+
+	secretName := "podman-build-secret-test"
+	secretPath := filepath.Join(contextDir, secretName)
+	secretValue := []byte("s3cr3t-value")
+	require.NoError(t, os.WriteFile(secretPath, secretValue, 0o600))
+
+	secretsJSON := `["id=tok,src=` + secretName + `"]`
+	query := &BuildQuery{Secrets: secretsJSON}
+	queryValues := url.Values{"secrets": []string{secretsJSON}}
+
+	secrets, relocated, err := processSecrets(query, contextDir, queryValues)
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	t.Cleanup(func() {
+		for _, path := range relocated {
+			_ = os.Remove(path)
+		}
+	})
+
+	// Must leave the context so a later COPY cannot pick the secret up.
+	assert.NoFileExists(t, secretPath)
+
+	// Must not park the plaintext copy in the context's parent.
+	leftover, err := filepath.Glob(filepath.Join(parent, "podman-build-secret-*"))
+	require.NoError(t, err)
+	assert.Empty(t, leftover, "secret must not be left in the parent of the build context")
+
+	srcPath := secretSrcPath(t, secrets[0])
+	assert.FileExists(t, srcPath)
+	assert.Equal(t, []string{srcPath}, relocated)
+	got, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, secretValue, got)
+}
+
+func secretSrcPath(t *testing.T, secret string) string {
+	t.Helper()
+	for _, token := range strings.Split(secret, ",") {
+		key, val, ok := strings.Cut(token, "=")
+		if ok && key == "src" {
+			return val
+		}
+	}
+	t.Fatalf("secret %q has no src=", secret)
+	return ""
+}


### PR DESCRIPTION
## Summary

`processSecrets` renamed each build secret into the **parent of the build context** and never deleted it. For local-API / `podman machine` builds that parent is a user directory, so a successful `podman build --secret` left `podman-build-secret-*` next to the context (mode 0600 plaintext).

Secrets are still moved out of the context so `COPY` cannot pick them up, but they now go under `parse.GetTempDir()` and are removed by the existing `temporaryFiles` cleanup when the build finishes.

## Test plan

- [x] `go test -tags 'exclude_graphdriver_btrfs containers_image_openpgp' ./pkg/api/handlers/compat/ -count=1 -run TestProcessSecretsDoesNotLeavePlaintextInContextParent`
- [ ] Reproduce issue steps: build from a third directory with `--secret`, confirm no `podman-build-secret-*` remains in the context parent

Fixes #29687