### PR TITLE
compat API: accept inline seccomp profiles

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -94,6 +94,11 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Docker clients send the seccomp profile JSON inline in
+	// HostConfig.SecurityOpt, FillOutSpecGen would treat it as a path.
+	var inlineSeccompProfile string
+	inlineSeccompProfile, body.HostConfig.SecurityOpt = extractInlineSeccompProfile(body.HostConfig.SecurityOpt)
+
 	// Take body structure and convert to cliopts
 	cliOpts, args, err := cliOpts(body, rtc)
 	if err != nil {
@@ -116,6 +121,12 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	if err := specgenutil.FillOutSpecGen(sg, cliOpts, args); err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("fill out specgen: %w", err))
 		return
+	}
+
+	if inlineSeccompProfile != "" {
+		sg.SeccompProfile = inlineSeccompProfile
+		// keep SecurityOpt in inspect output matching what the client sent
+		sg.Annotations[define.InspectAnnotationSeccomp] = inlineSeccompProfile
 	}
 
 	// empty test command means inherit the image healthcheck, but we need to preserve the other health config fields if provided
@@ -162,6 +173,50 @@ func stringMaptoArray(m map[string]string) []string {
 		a = append(a, fmt.Sprintf("%s=%s", k, v))
 	}
 	return a
+}
+
+// cutSecurityOpt splits a security option into key and value.
+// Docker deprecated the ":" separator but still supports it.
+func cutSecurityOpt(opt string) (key, val string, hasVal bool) {
+	if strings.Contains(opt, "=") {
+		return strings.Cut(opt, "=")
+	}
+	return strings.Cut(opt, ":")
+}
+
+// extractInlineSeccompProfile splits an inline JSON seccomp profile out of
+// securityOpts, returning the profile (or "") and the remaining options.
+// Only values starting with "{" are treated as inline profiles so that
+// path-based values keep working. Duplicate seccomp options resolve
+// last-one-wins, like docker, and only the winner is kept in the
+// remaining options.
+func extractInlineSeccompProfile(securityOpts []string) (string, []string) {
+	lastIdx := -1
+	lastVal := ""
+	for i, opt := range securityOpts {
+		if key, val, hasVal := cutSecurityOpt(opt); hasVal && key == "seccomp" {
+			lastIdx = i
+			lastVal = val
+		}
+	}
+	if lastIdx == -1 {
+		return "", securityOpts
+	}
+	inline := strings.HasPrefix(strings.TrimSpace(lastVal), "{")
+	rest := make([]string, 0, len(securityOpts))
+	for i, opt := range securityOpts {
+		if key, _, hasVal := cutSecurityOpt(opt); hasVal && key == "seccomp" {
+			// drop all seccomp options except a path-valued winner
+			if inline || i != lastIdx {
+				continue
+			}
+		}
+		rest = append(rest, opt)
+	}
+	if !inline {
+		return "", rest
+	}
+	return lastVal, rest
 }
 
 // cliOpts converts a compat input struct to cliopts

--- a/pkg/api/handlers/compat/containers_create_test.go
+++ b/pkg/api/handlers/compat/containers_create_test.go
@@ -1,0 +1,83 @@
+//go:build !remote && (linux || freebsd)
+
+package compat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractInlineSeccompProfile(t *testing.T) {
+	inlineProfile := `{"defaultAction":"SCMP_ACT_ALLOW"}`
+
+	tests := []struct {
+		name            string
+		opts            []string
+		expectedProfile string
+		expectedRest    []string
+	}{
+		{
+			name:            "no security opts",
+			opts:            nil,
+			expectedProfile: "",
+			expectedRest:    nil,
+		},
+		{
+			name:            "path stays untouched",
+			opts:            []string{"seccomp=/some/path.json"},
+			expectedProfile: "",
+			expectedRest:    []string{"seccomp=/some/path.json"},
+		},
+		{
+			name:            "unconfined stays untouched",
+			opts:            []string{"seccomp=unconfined"},
+			expectedProfile: "",
+			expectedRest:    []string{"seccomp=unconfined"},
+		},
+		{
+			name:            "inline json is extracted",
+			opts:            []string{"seccomp=" + inlineProfile},
+			expectedProfile: inlineProfile,
+			expectedRest:    []string{},
+		},
+		{
+			name:            "inline json with leading whitespace",
+			opts:            []string{"seccomp= \n\t" + inlineProfile},
+			expectedProfile: " \n\t" + inlineProfile,
+			expectedRest:    []string{},
+		},
+		{
+			name:            "deprecated colon separator",
+			opts:            []string{"seccomp:" + inlineProfile},
+			expectedProfile: inlineProfile,
+			expectedRest:    []string{},
+		},
+		{
+			name:            "other options are preserved",
+			opts:            []string{"label=disable", "seccomp=" + inlineProfile, "no-new-privileges"},
+			expectedProfile: inlineProfile,
+			expectedRest:    []string{"label=disable", "no-new-privileges"},
+		},
+		{
+			name:            "duplicate, last inline wins",
+			opts:            []string{"seccomp=/some/path.json", "seccomp=" + inlineProfile},
+			expectedProfile: inlineProfile,
+			expectedRest:    []string{},
+		},
+		{
+			name:            "duplicate, last path wins",
+			opts:            []string{"seccomp=" + inlineProfile, "seccomp=/some/path.json"},
+			expectedProfile: "",
+			expectedRest:    []string{"seccomp=/some/path.json"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile, rest := extractInlineSeccompProfile(test.opts)
+			assert.Equal(t, test.expectedProfile, profile)
+			assert.Equal(t, test.expectedRest, rest)
+		})
+	}
+}

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -91,6 +91,9 @@ func (s *SpecGenerator) Validate() error {
 	if s.UserNS.IsPrivate() && s.IDMappings == nil {
 		return fmt.Errorf("IDMappings are required when not creating a User namespace: %w", ErrInvalidSpecConfig)
 	}
+	if len(s.SeccompProfilePath) > 0 && len(s.SeccompProfile) > 0 {
+		return exclusiveOptions("SeccompProfilePath", "SeccompProfile")
+	}
 
 	//
 	// ContainerCgroupConfig

--- a/pkg/specgen/generate/config_linux_seccomp.go
+++ b/pkg/specgen/generate/config_linux_seccomp.go
@@ -44,7 +44,13 @@ func getSeccompConfig(s *specgen.SpecGenerator, configSpec *spec.Spec, img *libi
 		return seccompConfig, nil
 	}
 
-	if s.SeccompProfilePath != "" {
+	if s.SeccompProfile != "" {
+		logrus.Debug("Loading inline seccomp profile")
+		seccompConfig, err = goSeccomp.LoadProfile(s.SeccompProfile, configSpec)
+		if err != nil {
+			return nil, fmt.Errorf("loading inline seccomp profile failed: %w", err)
+		}
+	} else if s.SeccompProfilePath != "" {
 		logrus.Debugf("Loading seccomp profile from %q", s.SeccompProfilePath)
 		seccompProfile, err := os.ReadFile(s.SeccompProfilePath)
 		if err != nil {

--- a/pkg/specgen/generate/config_linux_seccomp_test.go
+++ b/pkg/specgen/generate/config_linux_seccomp_test.go
@@ -1,0 +1,59 @@
+//go:build linux && !remote && seccomp
+
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/podman/v6/pkg/specgen"
+)
+
+const testSeccompProfile = `{
+	"defaultAction": "SCMP_ACT_ALLOW",
+	"syscalls": [
+		{
+			"names": ["link", "linkat"],
+			"action": "SCMP_ACT_ERRNO"
+		}
+	]
+}`
+
+func TestGetSeccompConfigFromFile(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "seccomp.json")
+	require.NoError(t, os.WriteFile(profilePath, []byte(testSeccompProfile), 0o600))
+
+	s := specgen.NewSpecGenerator("", false)
+	s.SeccompProfilePath = profilePath
+
+	config, err := getSeccompConfig(s, &spec.Spec{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, spec.ActAllow, config.DefaultAction)
+	require.Len(t, config.Syscalls, 1)
+	assert.Equal(t, spec.ActErrno, config.Syscalls[0].Action)
+	assert.Equal(t, []string{"link", "linkat"}, config.Syscalls[0].Names)
+}
+
+func TestGetSeccompConfigInline(t *testing.T) {
+	s := specgen.NewSpecGenerator("", false)
+	s.SeccompProfile = testSeccompProfile
+
+	config, err := getSeccompConfig(s, &spec.Spec{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, spec.ActAllow, config.DefaultAction)
+	require.Len(t, config.Syscalls, 1)
+	assert.Equal(t, spec.ActErrno, config.Syscalls[0].Action)
+	assert.Equal(t, []string{"link", "linkat"}, config.Syscalls[0].Names)
+}
+
+func TestGetSeccompConfigRejectsInvalidInlineProfile(t *testing.T) {
+	s := specgen.NewSpecGenerator("", false)
+	s.SeccompProfile = "{invalid JSON"
+
+	_, err := getSeccompConfig(s, &spec.Spec{}, nil)
+	require.ErrorContains(t, err, "loading inline seccomp profile failed")
+}

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -312,7 +312,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	maps.Copy(annotations, s.Annotations)
 	s.Annotations = annotations
 
-	if len(s.SeccompProfilePath) < 1 {
+	if len(s.SeccompProfilePath) < 1 && len(s.SeccompProfile) < 1 {
 		p, err := libpod.DefaultSeccompPath()
 		if err != nil {
 			return nil, err

--- a/pkg/specgen/generate/security_linux.go
+++ b/pkg/specgen/generate/security_linux.go
@@ -211,7 +211,7 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 
 	// Clear default Seccomp profile from Generator for unconfined containers
 	// and privileged containers which do not specify a seccomp profile.
-	if s.SeccompProfilePath == "unconfined" || (s.IsPrivileged() && (s.SeccompProfilePath == "" || s.SeccompProfilePath == config.SeccompOverridePath || s.SeccompProfilePath == config.SeccompDefaultPath)) {
+	if s.SeccompProfilePath == "unconfined" || (s.IsPrivileged() && s.SeccompProfile == "" && (s.SeccompProfilePath == "" || s.SeccompProfilePath == config.SeccompOverridePath || s.SeccompProfilePath == config.SeccompDefaultPath)) {
 		configSpec.Linux.Seccomp = nil
 	}
 

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -414,8 +414,14 @@ type ContainerSecurityConfig struct {
 	// SeccompProfilePath is the path to a JSON file containing the
 	// container's Seccomp profile.
 	// If not specified, no Seccomp profile will be used.
+	// Conflicts with SeccompProfile.
 	// Optional.
 	SeccompProfilePath string `json:"seccomp_profile_path,omitempty"`
+	// SeccompProfile is the JSON content of the container's Seccomp
+	// profile.
+	// Conflicts with SeccompProfilePath.
+	// Optional.
+	SeccompProfile string `json:"seccomp_profile,omitempty"`
 	// NoNewPrivileges is whether the container will set the no new
 	// privileges flag on create, which disables gaining additional
 	// privileges (e.g. via setuid) in the container.

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -339,6 +339,29 @@ t GET    libpod/containers/${cid}/json 200 \
 
 t DELETE containers/$cid 204
 
+# Regression test for #27710. Docker clients send the seccomp profile JSON
+# itself in HostConfig.SecurityOpt (the docker CLI reads the file client-side
+# and inlines it). Pad with enough whitespace to exceed NAME_MAX so treating
+# the value as a path cannot accidentally succeed.
+SECCOMP_TMPD=$(mktemp -d podman-apiv2-test.seccomp.XXXXXXXX)
+seccomp_profile=$(printf '\n  {"defaultAction":"SCMP_ACT_ALLOW","syscalls":[{"names":["link","linkat"],"action":"SCMP_ACT_ERRNO"}]}%300s' '')
+jq -cn --arg image "$IMAGE" --arg profile "$seccomp_profile" \
+  '{Image:$image,
+    Cmd:["sh","-c","echo test > /tmp/link-src && ln /tmp/link-src /tmp/link-not-allowed"],
+    HostConfig:{SecurityOpt:["seccomp=" + $profile]}}' \
+  >$SECCOMP_TMPD/create.json
+t POST containers/create $SECCOMP_TMPD/create.json 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+# the inline profile must round-trip through inspect like docker does
+t GET containers/$cid/json 200 \
+  .HostConfig.SecurityOpt[0]~seccomp=.*SCMP_ACT_ERRNO.*
+t POST containers/$cid/start 204
+t POST containers/$cid/wait 200 \
+  .StatusCode=1
+t DELETE containers/$cid 204
+rm -rf $SECCOMP_TMPD
+
 # test only set the entrypoint, Cmd should be []
 t POST containers/create \
   Image=$IMAGE \


### PR DESCRIPTION
Docker clients send the seccomp profile JSON itself in HostConfig.SecurityOpt (the docker CLI reads the profile file client-side and inlines it). The compat API treated the value as a path to a profile file, so container create failed with "file name too long". This breaks docker-compat tooling that passes seccomp profiles through the socket, like Nextcloud AIO and forgejo-runner.

Add a SeccompProfile field to specgen for inline profile content, next to the existing SeccompProfilePath, as requested in review of the earlier PR that tried to fix this (#28985). The compat create handler extracts inline profiles (values starting with "{") from SecurityOpt and sets the new field. Path-based values and "unconfined" keep their current meaning, and duplicate seccomp options resolve last-one-wins, like docker.

The profile loader in specgen/generate loads the inline profile directly, the two fields are validated as mutually exclusive, and inline profiles round-trip through inspect's SecurityOpt like they do with docker.

Fixes: #27710

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed the Docker-compatible API to accept inline seccomp profile JSON in HostConfig.SecurityOpt
```
