### PR TITLE
Speed up machine tests

### DIFF
--- a/pkg/machine/e2e/api_test.go
+++ b/pkg/machine/e2e/api_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -39,57 +40,26 @@ var _ = Describe("run podman API test calls", func() {
 		Expect(err).ToNot(HaveOccurred())
 		sockPath := inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()
 
+		// check with docker client
 		cli, err := client.New(client.WithHost("unix://" + sockPath))
 		Expect(err).ToNot(HaveOccurred())
 		_, err = cli.Ping(context.Background(), client.PingOptions{})
 		Expect(err).ToNot(HaveOccurred())
-	})
 
-	It("client connect to machine named pipe", func() {
-		if runtime.GOOS != "windows" {
-			Skip("test is only supported on Windows")
-		}
-		name := randomString()
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		inspectJSON := new(inspectMachine)
-		inspectSession, err := mb.setName(name).setCmd(inspectJSON).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(inspectSession).To(Exit(0))
-
-		var inspectInfo []machine.InspectInfo
-		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
-		Expect(err).ToNot(HaveOccurred())
-		pipePath := inspectInfo[0].ConnectionInfo.PodmanPipe.GetPath()
-
-		cli, err := client.New(client.WithHost(NamedPipeProto + filepath.ToSlash(pipePath)))
-		Expect(err).ToNot(HaveOccurred())
-		_, err = cli.Ping(context.Background(), client.PingOptions{})
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("curl connect to machine socket", func() {
-		name := randomString()
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		inspectJSON := new(inspectMachine)
-		inspectSession, err := mb.setName(name).setCmd(inspectJSON).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(inspectSession).To(Exit(0))
-
-		var inspectInfo []machine.InspectInfo
-		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
-		Expect(err).ToNot(HaveOccurred())
-		sockPath := inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()
-
+		// check with curl
 		cmd := exec.Command("curl", "--unix-socket", sockPath, "http://d/v5.0.0/libpod/info")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 		err = cmd.Run()
 		Expect(err).ToNot(HaveOccurred())
+
+		if runtime.GOOS == "windows" {
+			// check that the pipe connection also works on windows
+			pipePath := inspectInfo[0].ConnectionInfo.PodmanPipe.GetPath()
+			cli, err := client.New(client.WithHost(NamedPipeProto + filepath.ToSlash(pipePath)))
+			Expect(err).ToNot(HaveOccurred())
+			_, err = cli.Ping(context.Background(), client.PingOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
 	})
 })

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -173,16 +173,16 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(run.outputToString()).To(And(ContainSubstring("test1-"+name), ContainSubstring("test2-"+name)))
 	})
 
-	It("Volume should be disabled by command line", func() {
+	It("Volume should be disabled by command line and work with --import-native-ca", func() {
 		skipIfWSL("Requires standard volume handling")
-		skipIfVmtype(define.AppleHvVirt, "Skipped on Apple platform")
-		skipIfVmtype(define.LibKrun, "Skipped on Apple platform")
 
 		name := randomString()
 		i := new(initMachine).withImage(mb.imagePath).withNow()
 
 		// Empty arg forces no volumes
 		i.withVolume("")
+		// test that --import-native-ca also works without volumes
+		i.withImportNativeCA(true)
 		session, err := mb.setName(name).setCmd(i).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
@@ -198,6 +198,14 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(findmntVirtiofs).To(Exit(0))
 		Expect(findmntVirtiofs.outputToString()).To(BeEmpty())
+
+		certFilePath := "/etc/pki/ca-trust/source/anchors"
+		certFileName := "host-ca-certs.pem"
+		sshMachine := sshMachine{}
+		sshCertFile, err := mb.setName(name).setCmd(sshMachine.withSSHCommand([]string{"ls", certFilePath})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sshCertFile).To(Exit(0))
+		Expect(sshCertFile.outputToString()).To(Equal(certFileName))
 	})
 
 	It("Podman ops with port forwarding and gvproxy", func() {

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -145,6 +145,32 @@ var _ = Describe("run basic podman commands", func() {
 			Expect(findmnt).To(Exit(0))
 			Expect(findmnt.outputToString()).To(ContainSubstring("virtiofs"))
 		}
+
+		// Test build context support
+		mainContextDir := GinkgoT().TempDir()
+		cfile := filepath.Join(mainContextDir, "test1")
+		err = os.WriteFile(cfile, []byte("test1-"+name+"\n"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		additionalContextDir := GinkgoT().TempDir()
+		cfile = filepath.Join(additionalContextDir, "test2")
+		err = os.WriteFile(cfile, []byte("test2-"+name+"\n"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		cfile = filepath.Join(mainContextDir, "Containerfile")
+		err = os.WriteFile(cfile, []byte("FROM "+TESTIMAGE+"\nCOPY test1 /\nCOPY --from=test-context test2 /\n"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		bm = basicMachine{}
+		build, err = mb.setCmd(bm.withPodmanCommand([]string{"build", "-t", name, "--build-context", "test-context=" + additionalContextDir, mainContextDir})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(build).To(Exit(0))
+		Expect(build.outputToString()).To(ContainSubstring("COMMIT"))
+
+		run, err = mb.setCmd(bm.withPodmanCommand([]string{"run", name, "cat", "/test1", "/test2"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(run).To(Exit(0))
+		Expect(run.outputToString()).To(And(ContainSubstring("test1-"+name), ContainSubstring("test2-"+name)))
 	})
 
 	It("Volume should be disabled by command line", func() {
@@ -258,44 +284,6 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ls).To(Exit(0))
 		Expect(ls.outputToString()).To(ContainSubstring(testString))
-	})
-
-	It("podman build contexts", func() {
-		name := randomString()
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		mainContextDir := GinkgoT().TempDir()
-		cfile := filepath.Join(mainContextDir, "test1")
-		err = os.WriteFile(cfile, []byte(name), 0o644)
-		Expect(err).ToNot(HaveOccurred())
-
-		additionalContextDir := GinkgoT().TempDir()
-		cfile = filepath.Join(additionalContextDir, "test2")
-		err = os.WriteFile(cfile, []byte(name), 0o644)
-		Expect(err).ToNot(HaveOccurred())
-
-		cfile = filepath.Join(mainContextDir, "Containerfile")
-		err = os.WriteFile(cfile, []byte("FROM "+TESTIMAGE+"\nCOPY test1 /\nCOPY --from=test-context test2 /\n"), 0o644)
-		Expect(err).ToNot(HaveOccurred())
-
-		bm := basicMachine{}
-		build, err := mb.setCmd(bm.withPodmanCommand([]string{"build", "-t", name, "--build-context", "test-context=" + additionalContextDir, mainContextDir})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(build).To(Exit(0))
-		Expect(build.outputToString()).To(ContainSubstring("COMMIT"))
-
-		run, err := mb.setCmd(bm.withPodmanCommand([]string{"run", name, "cat", "/test1"})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(run).To(Exit(0))
-		Expect(build.outputToString()).To(ContainSubstring(name))
-
-		run, err = mb.setCmd(bm.withPodmanCommand([]string{"run", name, "cat", "/test2"})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(run).To(Exit(0))
-		Expect(build.outputToString()).To(ContainSubstring(name))
 	})
 
 	It("CVE-2025-6032 regression test - HTTP", func() {

--- a/pkg/machine/e2e/config_set_test.go
+++ b/pkg/machine/e2e/config_set_test.go
@@ -8,7 +8,7 @@ type setMachine struct {
 	cpus               *uint
 	diskSize           *uint
 	memory             *uint
-	rootful            bool
+	rootful            *bool
 	userModeNetworking bool
 	importNativeCA     bool
 
@@ -26,8 +26,12 @@ func (i *setMachine) buildCmd(m *machineTestBuilder) []string {
 	if i.memory != nil {
 		cmd = append(cmd, "--memory", strconv.Itoa(int(*i.memory)))
 	}
-	if i.rootful {
-		cmd = append(cmd, "--rootful")
+	if i.rootful != nil {
+		if *i.rootful {
+			cmd = append(cmd, "--rootful")
+		} else {
+			cmd = append(cmd, "--rootful=false")
+		}
 	}
 	if i.userModeNetworking {
 		cmd = append(cmd, "--user-mode-networking")
@@ -56,7 +60,7 @@ func (i *setMachine) withMemory(num uint) *setMachine {
 }
 
 func (i *setMachine) withRootful(r bool) *setMachine {
-	i.rootful = r
+	i.rootful = new(r)
 	return i
 }
 

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -26,7 +26,7 @@ import (
 var originalHomeDir = os.Getenv("HOME")
 
 const (
-	defaultTimeout = 10 * time.Minute
+	defaultTimeout = 3 * time.Minute
 )
 
 type machineCommand interface {
@@ -148,11 +148,6 @@ func (m *machineTestBuilder) setCmd(mc machineCommand) *machineTestBuilder {
 // setStdin sets the stdin for the next command to be run
 func (m *machineTestBuilder) setStdin(data io.Reader) *machineTestBuilder {
 	m.stdin = data
-	return m
-}
-
-func (m *machineTestBuilder) setTimeout(timeout time.Duration) *machineTestBuilder { //nolint: unparam
-	m.timeout = timeout
 	return m
 }
 

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -156,9 +156,9 @@ func (m *machineTestBuilder) setTimeout(timeout time.Duration) *machineTestBuild
 	return m
 }
 
-// toQemuInspectInfo is only for inspecting qemu machines.  Other providers will need
+// toInspectInfo is only for inspecting qemu machines.  Other providers will need
 // to make their own.
-func (m *machineTestBuilder) toQemuInspectInfo() ([]machine.InspectInfo, int, error) {
+func (m *machineTestBuilder) toInspectInfo() ([]machine.InspectInfo, int, error) {
 	args := []string{"machine", "inspect"}
 	args = append(args, m.names...)
 	session, err := runWrapper(m.podmanBinary, args, nil, defaultTimeout, true)

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -416,7 +416,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(session).To(Exit(0))
 
 		s := &startMachine{}
-		ssession, err := mb.setCmd(s).setTimeout(time.Minute * 10).run()
+		ssession, err := mb.setCmd(s).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ssession).Should(Exit(0))
 
@@ -438,7 +438,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(session).To(Exit(0))
 
 		s := &startMachine{}
-		ssession, err := mb.setCmd(s).setTimeout(time.Minute * 10).run()
+		ssession, err := mb.setCmd(s).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ssession).Should(Exit(0))
 
@@ -580,7 +580,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(session).To(Exit(0))
 
 		s := &startMachine{}
-		ssession, err := mb.setCmd(s).setTimeout(time.Minute * 10).run()
+		ssession, err := mb.setCmd(s).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ssession).Should(Exit(0))
 
@@ -631,7 +631,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(session).To(Exit(0))
 
 		s := &startMachine{}
-		ssession, err := mb.setCmd(s).setTimeout(time.Minute * 10).run()
+		ssession, err := mb.setCmd(s).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ssession).Should(Exit(0))
 

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -113,7 +113,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
-		inspectBefore, ec, err := mb.toQemuInspectInfo()
+		inspectBefore, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(BeZero())
 		Expect(inspectBefore).ToNot(BeEmpty())
@@ -204,7 +204,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
-		inspectBefore, ec, err := mb.toQemuInspectInfo()
+		inspectBefore, ec, err := mb.toInspectInfo()
 		Expect(ec).To(BeZero())
 		Expect(inspectBefore).ToNot(BeEmpty())
 		Expect(err).ToNot(HaveOccurred())
@@ -216,7 +216,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ssession).Should(Exit(0))
 
-		inspectAfter, ec, err := mb.toQemuInspectInfo()
+		inspectAfter, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(BeZero())
 		Expect(inspectBefore).ToNot(BeEmpty())
@@ -241,7 +241,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
-		inspectBefore, ec, err := mb.toQemuInspectInfo()
+		inspectBefore, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(BeZero())
 
@@ -513,7 +513,7 @@ var _ = Describe("podman machine init", func() {
 
 		// Inspecting a non-existent machine should fail
 		// which means it is gone
-		_, ec, err := mb.toQemuInspectInfo()
+		_, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(Equal(125))
 

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -198,42 +198,6 @@ var _ = Describe("podman machine init", func() {
 		Expect(sshSession.outputToString()).To(Equal(str))
 	})
 
-	It("simple init with start", func() {
-		i := initMachine{}
-		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		inspectBefore, ec, err := mb.toInspectInfo()
-		Expect(ec).To(BeZero())
-		Expect(inspectBefore).ToNot(BeEmpty())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(inspectBefore).ToNot(BeEmpty())
-		Expect(inspectBefore[0].Name).To(Equal(mb.names[0]))
-
-		s := &startMachine{}
-		ssession, err := mb.setCmd(s).setTimeout(time.Minute * 10).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ssession).Should(Exit(0))
-
-		inspectAfter, ec, err := mb.toInspectInfo()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ec).To(BeZero())
-		Expect(inspectBefore).ToNot(BeEmpty())
-		Expect(inspectAfter).ToNot(BeEmpty())
-		Expect(inspectAfter[0].State).To(Equal(define.Running))
-
-		if isWSL() { // WSL does not use FCOS
-			return
-		}
-
-		// check to see that zincati is masked
-		sshDisk := sshMachine{}
-		zincati, err := mb.setCmd(sshDisk.withSSHCommand([]string{"sudo", "systemctl", "is-enabled", "zincati"})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(zincati.outputToString()).To(ContainSubstring("disabled"))
-	})
-
 	It("simple init with username", func() {
 		i := new(initMachine)
 		remoteUsername := "remoteuser"
@@ -288,6 +252,16 @@ var _ = Describe("podman machine init", func() {
 				subid_count, count_min, file,
 			)
 		}
+
+		if isWSL() { // WSL does not use FCOS
+			return
+		}
+
+		// check to see that zincati is masked
+		sshDisk := sshMachine{}
+		zincati, err := mb.setCmd(sshDisk.withSSHCommand([]string{"sudo", "systemctl", "is-enabled", "zincati"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(zincati.outputToString()).To(ContainSubstring("disabled"))
 	})
 
 	It("machine init with cpus, disk size, memory, timezone", func() {

--- a/pkg/machine/e2e/restart_test.go
+++ b/pkg/machine/e2e/restart_test.go
@@ -20,27 +20,7 @@ var _ = Describe("podman machine restart", func() {
 		Expect(session.errorToString()).To(ContainSubstring("VM does not exist"))
 	})
 
-	It("should restart a running machine", func() {
-		name := randomString()
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow().withVolume("")).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		r := restartMachine{}
-		restartSession, err := mb.setName(name).setCmd(r).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(restartSession).To(Exit(0))
-		Expect(restartSession.outputToString()).To(ContainSubstring(fmt.Sprintf("Machine %q restarted successfully", name)))
-
-		inspect := new(inspectMachine)
-		inspectSession, err := mb.setName(name).setCmd(inspect.withFormat("{{.State}}")).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(inspectSession).To(Exit(0))
-		Expect(inspectSession.outputToString()).To(Equal(define.Running))
-	})
-
-	It("should start a stopped machine", func() {
+	It("should restart machine", func() {
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withVolume("")).run()
@@ -53,11 +33,25 @@ var _ = Describe("podman machine restart", func() {
 		Expect(inspectSession).To(Exit(0))
 		Expect(inspectSession.outputToString()).To(Equal(define.Stopped))
 
+		// Restart stopped machine
 		r := restartMachine{}
 		restartSession, err := mb.setName(name).setCmd(r).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(restartSession).To(Exit(0))
 
+		inspectSession, err = mb.setName(name).setCmd(inspect.withFormat("{{.State}}")).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+		Expect(inspectSession.outputToString()).To(Equal(define.Running))
+
+		// Now restart running machine
+		r = restartMachine{}
+		restartSession, err = mb.setName(name).setCmd(r).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(restartSession).To(Exit(0))
+		Expect(restartSession.outputToString()).To(ContainSubstring(fmt.Sprintf("Machine %q restarted successfully", name)))
+
+		inspect = new(inspectMachine)
 		inspectSession, err = mb.setName(name).setCmd(inspect.withFormat("{{.State}}")).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(inspectSession).To(Exit(0))

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -33,7 +33,7 @@ var _ = Describe("podman machine rm", func() {
 
 		// Inspecting a non-existent machine should fail
 		// which means it is gone
-		_, ec, err := mb.toQemuInspectInfo()
+		_, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(Equal(125))
 
@@ -91,7 +91,7 @@ var _ = Describe("podman machine rm", func() {
 		Expect(stopAgain).To(Exit(0))
 
 		// Inspect to be dead sure
-		_, ec, err := mb.toQemuInspectInfo()
+		_, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(Equal(125))
 	})
@@ -116,7 +116,7 @@ var _ = Describe("podman machine rm", func() {
 
 		// Inspecting a non-existent machine should fail
 		// which means it is gone
-		_, ec, err := mb.toQemuInspectInfo()
+		_, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(Equal(125))
 

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -71,31 +71,6 @@ var _ = Describe("podman machine rm", func() {
 		Expect(sysConnOutput.outputToString()).To(ContainSubstring(name2 + "-root--true"))
 	})
 
-	It("Remove running machine", func() {
-		name := randomString()
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-		rm := new(rmMachine)
-
-		// Removing a running machine should fail
-		stop, err := mb.setCmd(rm).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stop).To(Exit(125))
-		Expect(stop.errorToString()).To(ContainSubstring(fmt.Sprintf("vm \"%s\" cannot be destroyed", name)))
-
-		// Removing again with force
-		stopAgain, err := mb.setCmd(rm.withForce()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stopAgain).To(Exit(0))
-
-		// Inspect to be dead sure
-		_, ec, err := mb.toInspectInfo()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ec).To(Equal(125))
-	})
-
 	It("machine rm --save-ignition --save-image", func() {
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withFakeImage(mb)).run()

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -16,7 +16,7 @@ var _ = Describe("podman machine set", func() {
 		skipIfWSL("WSL cannot change cpus via set")
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -81,6 +80,12 @@ var _ = Describe("podman machine set", func() {
 		runner, err := mb.setName(name).setCmd(set.withCPUs(4)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runner).To(Exit(125))
+
+		set = setMachine{}
+		setSession, err = mb.setName(name).setCmd(set.withRootful(true)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(setSession).To(Exit(125))
+		Expect(setSession.errorToString()).To(ContainSubstring("Error: unable to change settings unless vm is stopped"))
 	})
 
 	It("wsl cannot change disk, memory, processor", func() {
@@ -143,7 +148,7 @@ var _ = Describe("podman machine set", func() {
 		Expect(sshSession3.outputToString()).To(ContainSubstring(fmt.Sprintf("%d GiB", defaultDiskSize)))
 	})
 
-	It("set rootful with docker sock change", func() {
+	It("set rootful/rootless with user and docker sock change", func() {
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
@@ -171,8 +176,43 @@ var _ = Describe("podman machine set", func() {
 		sshSession2, err := mb.setName(name).setCmd(ssh2.withSSHCommand([]string{"readlink /var/run/docker.sock"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sshSession2).To(Exit(0))
-		output := strings.TrimSpace(sshSession2.outputToString())
-		Expect(output).To(Equal("/run/podman/podman.sock"))
+		Expect(sshSession2.outputToString()).To(Equal("/run/podman/podman.sock"))
+
+		ssh := &sshMachine{}
+		sshSession, err := mb.setName(name).setCmd(ssh.withSSHCommand([]string{"whoami"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sshSession).To(Exit(0))
+		Expect(sshSession.outputToString()).To(Equal("root"))
+
+		stop := &stopMachine{}
+		stopSession, err := mb.setName(name).setCmd(stop).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopSession).To(Exit(0))
+
+		set = setMachine{}
+		setSession, err = mb.setName(name).setCmd(set.withRootful(false)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(setSession).To(Exit(0))
+
+		start := &startMachine{}
+		startSession, err = mb.setName(name).setCmd(start).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(startSession).To(Exit(0))
+
+		sshSession, err = mb.setName(name).setCmd(ssh.withSSHCommand([]string{"whoami"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sshSession).To(Exit(0))
+		if testProvider.VMType() == define.WSLVirt {
+			Expect(sshSession.outputToString()).To(Equal("user"))
+		} else {
+			Expect(sshSession.outputToString()).To(Equal("core"))
+		}
+
+		ssh2 = sshMachine{}
+		sshSession2, err = mb.setName(name).setCmd(ssh2.withSSHCommand([]string{"readlink /var/run/docker.sock"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sshSession2).To(Exit(0))
+		Expect(sshSession2.outputToString()).To(MatchRegexp(`/run/user/[0-9]+/podman/podman.sock`))
 	})
 
 	It("set user mode networking", func() {
@@ -199,24 +239,5 @@ var _ = Describe("podman machine set", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(inspectSession).To(Exit(0))
 		Expect(inspectSession.outputToString()).To(Equal("true"))
-	})
-
-	It("set while machine already running", func() {
-		name := randomString()
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		s := new(startMachine)
-		startSession, err := mb.setCmd(s).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(startSession).To(Exit(0))
-
-		set := setMachine{}
-		setSession, err := mb.setName(name).setCmd(set.withRootful(true)).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(setSession).To(Exit(125))
-		Expect(setSession.errorToString()).To(ContainSubstring("Error: unable to change settings unless vm is stopped"))
 	})
 })

--- a/pkg/machine/e2e/ssh_test.go
+++ b/pkg/machine/e2e/ssh_test.go
@@ -74,43 +74,4 @@ var _ = Describe("podman machine ssh", func() {
 			Expect(sshSession.errorToString()).To(Equal(""))
 		}
 	})
-
-	It("verify machine rootfulness", func() {
-		wsl := testProvider.VMType() == define.WSLVirt
-		name := randomString()
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		ssh := &sshMachine{}
-		sshSession, err := mb.setName(name).setCmd(ssh.withSSHCommand([]string{"whoami"})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(sshSession).To(Exit(0))
-		if wsl {
-			Expect(sshSession.outputToString()).To(Equal("user"))
-		} else {
-			Expect(sshSession.outputToString()).To(Equal("core"))
-		}
-
-		stop := &stopMachine{}
-		stopSession, err := mb.setName(name).setCmd(stop).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stopSession).To(Exit(0))
-
-		set := &setMachine{}
-		setSession, err := mb.setName(name).setCmd(set.withRootful(true)).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(setSession).To(Exit(0))
-
-		start := &startMachine{}
-		startSession, err := mb.setName(name).setCmd(start).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(startSession).To(Exit(0))
-
-		sshSession, err = mb.setName(name).setCmd(ssh.withSSHCommand([]string{"whoami"})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(sshSession).To(Exit(0))
-		Expect(sshSession.outputToString()).To(Equal("root"))
-	})
 })

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -126,7 +126,7 @@ var _ = Describe("podman machine start", func() {
 		Expect(connectionPorts2).To(HaveEach(inspectPort2))
 	})
 
-	It("start only starts specified machine", func() {
+	It("start only starts specified machine and remove running machine", func() {
 		j := initMachine{}
 		dontstartme := randomString()
 		session2, err := mb.setName(dontstartme).setCmd(j.withFakeImage(mb)).run()
@@ -163,6 +163,25 @@ var _ = Describe("podman machine start", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(inspectSession2).To(Exit(0))
 		Expect(inspectSession2.outputToString()).To(Not(Equal(define.Running)))
+
+		rm := new(rmMachine)
+		// Removing a running machine should fail
+		stop, err := mb.setName(startme).setCmd(rm).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stop).To(Exit(125))
+		Expect(stop.errorToString()).To(ContainSubstring(fmt.Sprintf("vm \"%s\" cannot be destroyed", startme)))
+
+		// Removing again with force should work
+		stopAgain, err := mb.setCmd(rm.withForce()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopAgain).To(Exit(0))
+
+		// Inspect to be sure it is gone
+		inspect3 := new(inspectMachine)
+		inspectSession3, err := mb.setName(startme).setCmd(inspect3).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession3).To(Exit(125))
+		Expect(inspectSession3.errorToString()).To(ContainSubstring("VM does not exist"))
 	})
 
 	It("start two machines in parallel", func() {

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -19,42 +19,6 @@ import (
 )
 
 var _ = Describe("podman machine start", func() {
-	It("start simple machine", func() {
-		i := new(initMachine)
-		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-		s := new(startMachine)
-		startSession, err := mb.setCmd(s).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(startSession).To(Exit(0))
-
-		info, ec, err := mb.toInspectInfo()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ec).To(BeZero())
-		Expect(info[0].State).To(Equal(define.Running))
-
-		stop := new(stopMachine)
-		stopSession, err := mb.setCmd(stop).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stopSession).To(Exit(0))
-
-		// suppress output
-		startSession, err = mb.setCmd(s.withNoInfo()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(startSession).To(Exit(0))
-		Expect(startSession.outputToString()).ToNot(ContainSubstring("API forwarding"))
-
-		stopSession, err = mb.setCmd(stop).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stopSession).To(Exit(0))
-
-		startSession, err = mb.setCmd(s.withQuiet()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(startSession).To(Exit(0))
-		Expect(startSession.outputToStringSlice()).To(HaveLen(1))
-	})
-
 	It("bad start name", func() {
 		i := startMachine{}
 		reallyLongName := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -73,9 +37,11 @@ var _ = Describe("podman machine start", func() {
 		Expect(session).To(Exit(0))
 
 		s := new(startMachine)
-		startSession, err := mb.setCmd(s).run()
+		// suppress output with no info and check for that.
+		startSession, err := mb.setCmd(s.withNoInfo()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(0))
+		Expect(startSession.outputToString()).ToNot(ContainSubstring("API forwarding"))
 
 		info, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
@@ -115,10 +81,12 @@ var _ = Describe("podman machine start", func() {
 		defer listener.Close()
 
 		s := new(startMachine)
-		startSession, err := mb.setCmd(s).run()
+		// Also test with quiet to ensure no extra stout is logged but the error is still logged.
+		startSession, err := mb.setCmd(s.withQuiet()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(0))
 		Expect(startSession.errorToString()).To(ContainSubstring("detected port conflict on machine ssh port"))
+		Expect(startSession.outputToString()).To(Equal(fmt.Sprintf("Machine %q started successfully", mb.name)))
 
 		inspect2 := new(inspectMachine)
 		inspectSession2, err := mb.setCmd(inspect2.withFormat("{{.SSHConfig.Port}}")).run()

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -339,27 +339,6 @@ var _ = Describe("podman machine start", func() {
 		Expect(sshCertFile).To(Exit(0))
 		Expect(sshCertFile.outputToString()).To(Equal(certFileName))
 	})
-	It("machine init --now with --import-native-ca with SCP file transfer", func() {
-		skipIfVmtype(define.WSLVirt, "WSL doesn't allow handling volumes (the machine data folder is always mounted")
-
-		// Create a new machine
-		i := initMachine{}
-		initCommand := i.withImage(mb.imagePath).withImportNativeCA(true).withNow()
-		// Don't mount any volume to force the transfer the certificates file via SCP
-		initCommand = initCommand.withVolume("")
-		m := randomString()
-		initSession, err := mb.setName(m).setCmd(initCommand).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(initSession).To(Exit(0))
-
-		certFilePath := "/etc/pki/ca-trust/source/anchors"
-		certFileName := "host-ca-certs.pem"
-		sshMachine := sshMachine{}
-		sshCertFile, err := mb.setName(m).setCmd(sshMachine.withSSHCommand([]string{"ls", certFilePath})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(sshCertFile).To(Exit(0))
-		Expect(sshCertFile.outputToString()).To(Equal(certFileName))
-	})
 	It("start interrupted by SIGTERM while waiting for VM start", func() {
 		if !isVmtype(define.AppleHvVirt) && !isVmtype(define.LibKrun) {
 			Skip("SIGTERM interruption is supported on macOS only")

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -29,7 +29,7 @@ var _ = Describe("podman machine start", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(0))
 
-		info, ec, err := mb.toQemuInspectInfo()
+		info, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(BeZero())
 		Expect(info[0].State).To(Equal(define.Running))
@@ -77,7 +77,7 @@ var _ = Describe("podman machine start", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(0))
 
-		info, ec, err := mb.toQemuInspectInfo()
+		info, ec, err := mb.toInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(BeZero())
 		Expect(info[0].State).To(Equal(define.Running))

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -28,7 +28,7 @@ var _ = Describe("podman machine start", func() {
 		Expect(session.errorToString()).To(ContainSubstring("VM does not exist"))
 	})
 
-	It("start machine already started", func() {
+	It("start machine already started and stop machine already stopped", func() {
 		name := randomString()
 		i := new(initMachine)
 		machineTestBuilderInit := mb.setName(name).setCmd(i.withImage(mb.imagePath))
@@ -36,6 +36,7 @@ var _ = Describe("podman machine start", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
+		starttime := time.Now()
 		s := new(startMachine)
 		// suppress output with no info and check for that.
 		startSession, err := mb.setCmd(s.withNoInfo()).run()
@@ -52,6 +53,26 @@ var _ = Describe("podman machine start", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(125))
 		Expect(startSession.errorToString()).To(ContainSubstring(fmt.Sprintf("Error: unable to start %q: already running", machineTestBuilderInit.name)))
+
+		stop := new(stopMachine)
+		stopSession, err := mb.setCmd(stop).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopSession).To(Exit(0))
+
+		// Stopping it again should not result in an error
+		stopAgain, err := mb.setCmd(stop).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopAgain).To(Exit(0))
+		Expect(stopAgain.outputToString()).To(ContainSubstring(fmt.Sprintf("Machine \"%s\" stopped successfully", name)))
+
+		// Stopping a machine should update the last up time
+		inspect := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspect.withFormat("{{.LastUp.Format \"2006-01-02T15:04:05Z07:00\"}}")).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+		lastupTime, err := time.Parse(time.RFC3339, inspectSession.outputToString())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lastupTime).To(BeTemporally(">", starttime))
 	})
 
 	It("start machine with conflict on SSH port", func() {

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -143,7 +143,7 @@ var _ = Describe("podman machine start", func() {
 		// Provide a buffer as stdin to simulate non-tty input (e.g., piped or redirected stdin)
 		// When stdin is not a tty, the command should not prompt for connection updates
 		stdinBuf := bytes.NewBufferString("n\n")
-		session3, err := mb.setName(startme).setCmd(s).setTimeout(time.Minute * 10).setStdin(stdinBuf).run()
+		session3, err := mb.setName(startme).setCmd(s).setStdin(stdinBuf).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session3).Should(Exit(0))
 		// Verify that the prompt message did not appear (no prompting when stdin is not a tty)
@@ -204,7 +204,7 @@ var _ = Describe("podman machine start", func() {
 			defer GinkgoRecover()
 			defer wg.Done()
 			s := &startMachine{}
-			startSession1, err = mb.setName(machine1).setCmd(s.withUpdateConnection(new(false))).setTimeout(time.Minute * 10).run()
+			startSession1, err = mb.setName(machine1).setCmd(s.withUpdateConnection(new(false))).run()
 			Expect(err).ToNot(HaveOccurred())
 		}()
 		go func() {
@@ -217,7 +217,7 @@ var _ = Describe("podman machine start", func() {
 			// second run.
 			nmb, err := newMB()
 			Expect(err).ToNot(HaveOccurred())
-			startSession2, err = nmb.setName(machine2).setCmd(s.withUpdateConnection(new(false))).setTimeout(time.Minute * 10).run()
+			startSession2, err = nmb.setName(machine2).setCmd(s.withUpdateConnection(new(false))).run()
 			Expect(err).ToNot(HaveOccurred())
 		}()
 		wg.Wait()

--- a/pkg/machine/e2e/stop_test.go
+++ b/pkg/machine/e2e/stop_test.go
@@ -1,9 +1,6 @@
 package e2e_test
 
 import (
-	"fmt"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -16,34 +13,5 @@ var _ = Describe("podman machine stop", func() {
 		session, err := mb.setName(reallyLongName).setCmd(&i).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(125))
-	})
-
-	It("Stop running machine", func() {
-		name := randomString()
-		i := new(initMachine)
-		starttime := time.Now()
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		stop := new(stopMachine)
-		stopSession, err := mb.setCmd(stop).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stopSession).To(Exit(0))
-
-		// Stopping it again should not result in an error
-		stopAgain, err := mb.setCmd(stop).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stopAgain).To(Exit(0))
-		Expect(stopAgain.outputToString()).To(ContainSubstring(fmt.Sprintf("Machine \"%s\" stopped successfully", name)))
-
-		// Stopping a machine should update the last up time
-		inspect := new(inspectMachine)
-		inspectSession, err := mb.setName(name).setCmd(inspect.withFormat("{{.LastUp.Format \"2006-01-02T15:04:05Z07:00\"}}")).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(inspectSession).To(Exit(0))
-		lastupTime, err := time.Parse(time.RFC3339, inspectSession.outputToString())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(lastupTime).To(BeTemporally(">", starttime))
 	})
 })

--- a/pkg/machine/hyperv/vsock/vsock.go
+++ b/pkg/machine/hyperv/vsock/vsock.go
@@ -24,12 +24,11 @@ var ErrVSockRegistryEntryExists = errors.New("registry entry already exists")
 // to signal readiness over the hvsock. Without it, a guest that stays alive
 // but never connects (stuck boot, corrupted image, ignition hang) hangs the
 // calling `podman machine init`/`start` command forever: sockets.
-// ListenAndWaitOnSocket, which this waits on, has no timeout of its own,
-// confirmed by testing it directly against a real, unconnected net.Listener.
-// 10 real successful `podman machine init --now` runs from Podman's own
-// Hyper-V CI clustered between 15.8s and 19.4s, so 30s is headroom over a
-// normal healthy boot without leaving a stuck wait hanging for minutes.
-const readyTimeout = 30 * time.Second
+// The timeout must be high enough to even pass on slow CI systems.
+// On our current github action runners a podman machine init commands takes
+// around 50 seconds so lets use 90 seconds as timeout for now which should
+// be enough.
+const readyTimeout = 90 * time.Second
 
 const (
 	// HvsockMachineName is the string identifier for the machine name in a registry entry


### PR DESCRIPTION
see commits

While this certainly does make them less readable we really need to cut down the machine starts in CI as they are just to slow on the linux runners with about 60 seconds for each init/start cycle.


Looking at CI timings this maybe reduces CI time by up to 25%.
Linux timing seems to be down to 46mins from 60 mins
On macos test are down to 15 mins from 20 mins.
HyperV is down to 28 mins from 52 mins.
WSL is down to 33 mins from 40 mins.

The number of course have a decent amount of variance per run but I think this still shows the overall improvement without loosing any coverage unless I made some mistake somewhere.
 
compare https://github.com/podman-container-tools/podman/actions/runs/34219507137/usage (this PR)
to https://github.com/podman-container-tools/podman/actions/runs/34115392096/usage (some PR on main)


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
