### PR TITLE
Document rootless bind-mount access through an unmapped parent

### DIFF
--- a/docs/tutorials/rootless_tutorial.md
+++ b/docs/tutorials/rootless_tutorial.md
@@ -205,6 +205,30 @@ Another consideration in regards to volumes:
 - When providing the path of a directory you'd like to bind-mount, the path needs to be provided as an absolute path
   or a relative path that starts with `.` (a dot), otherwise the string will be interpreted as the name of a named volume.
 
+#### Permission denied on a bind-mount source
+
+Inside the user namespace the process setting up the mount is `root`, but `CAP_DAC_OVERRIDE` only bypasses a file's mode when that file's user ID and group ID both have valid mappings in the namespace. That is the rule under "Operation of file-related capabilities" in **[user_namespaces(7)](https://man7.org/linux/man-pages/man7/user_namespaces.7.html)**. A directory owned by an unmapped ID is reported with the overflow ID, 65534 by default, and nothing overrides its mode.
+
+World permissions are checked first, so this only comes up when the mode alone does not let you through. In each case below the parent is owned as shown, the bind mount source is the child inside it, and `/etc/subuid` has `johndoe:100000:65536`:
+
+```
+# parent mode 755, owned by root: the mode already allows it, mapping never comes up
+host$ podman run --rm -v /tmp/open/child:/mnt alpine echo ok
+ok
+
+# parent mode 700, owned by root: root is not mapped, so nothing overrides the mode
+host$ podman run --rm -v /tmp/private/child:/mnt alpine echo ok
+Error: statfs /tmp/private/child: permission denied
+
+# parent mode 700, owned by 100999, which the range maps to UID 1000 in the namespace
+host$ podman run --rm -v /tmp/mapped/child:/mnt alpine echo ok
+ok
+```
+
+`podman unshare ls -ldn` on the parent shows which case you are in: an owner of 65534 there means the ID is not mapped. `--userns=keep-id` does not change this, it changes which UID you are inside the container rather than which host IDs the namespace maps.
+
+This is the file side of the warning above about subordinating active user ids: a range that covers UIDs real accounts use gives that user the override on their files in any namespace they create, which is why default ranges start at 100000.
+
 ## More information
 
 If you are still experiencing problems running Podman in a rootless environment, please refer to the [Shortcomings of Rootless Podman](https://github.com/containers/podman/blob/main/rootless.md) page which lists known issues and solutions to known issues in this environment.


### PR DESCRIPTION
A user asked in https://github.com/podman-container-tools/podman/discussions/29443 why rootless Podman let him bind-mount a directory under `/etc/letsencrypt`, owned by `certbot:certbot` and mode 750, when his user is not in that group. The answer is in how the user namespace maps IDs, and the tutorial never says so. I isolated the rule on three directories of my own.

All three parents are mode 700, and the child under each is mounted with `podman run --rm -v /tmp/<parent>/child:/mnt alpine echo ok`. With the parent owned by `0:0` it fails with `Error: statfs /tmp/t_root/child: permission denied`. Owned by `300000:300000`, above my range, it fails the same way. Owned by `100999:100999`, inside `jmrplens:100000:65536`, it prints `ok`. `podman unshare ls -ldn` shows why: the first two parents are owned by 65534 inside the namespace, the third by 1000. `--userns=keep-id` changes none of them. This is podman 5.4.2 on Debian, the same version as the reporter.

The rule is in user_namespaces(7), section "Unmapped user and group IDs": an unmapped user ID is converted to the overflow user ID, 65534 by default. A capability in a user namespace only permits privileged operations on resources that namespace governs, so root in the namespace holds no DAC override over a file whose owner is unmapped. The parent's mode is then enforced as it would be for any other user. A parent owned inside the subuid range is mapped, the override applies, and mode 700 is bypassed.

The "Using volumes" section covers the ID shift for files created inside the container and the `--userns=keep-id` advice, and stops there. The words "unmapped" and "overflow" appear nowhere under `docs/`. This adds one subsection at the end of that section with the two outcomes, the `podman unshare` check, and a line tying the range-overlap hazard back to the impersonation warning the `/etc/subuid` section already gives. There is no issue for this one, so the commit carries the discussion URL instead of a `Fixes:` line. Documentation only, no code and no test changes.

On `make validatepr`: it builds the binaries and lints the Go tree, which this change does not touch, so I did not run the full target. The pre-commit hooks it carries (end-of-file, trailing whitespace, mixed line endings, codespell with the repo's `.codespellrc`) pass on the file, and `hack/commit-subject-check.sh` passes on the commit.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
