### PR TITLE
libpod/sqlite: enable WAL mode and cap connection pool to fix state DB corruption

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -42,6 +42,11 @@ const (
 	sqliteOptionTXLock = "&_txlock=exclusive"
 	// Enforce case sensitivity for LIKE
 	sqliteOptionCaseSensitiveLike = "&_cslike=TRUE"
+	// Enable WAL (Write-Ahead Logging) mode to prevent freelist corruption under high concurrency
+	// and enable SQLite's broken-lock defenses (#29721).
+	// NOTE: WAL mode requires a local POSIX filesystem (ext4, xfs, btrfs) since the -shm shared
+	// memory sidecar file relies on POSIX mmap, which is not supported on network filesystems (NFS/SMB).
+	sqliteOptionJournalMode = "&_journal_mode=WAL"
 
 	// Assembled sqlite options used when opening the database.
 	sqliteOptions = "?" +
@@ -49,7 +54,8 @@ const (
 		sqliteOptionSynchronous +
 		sqliteOptionForeignKeys +
 		sqliteOptionTXLock +
-		sqliteOptionCaseSensitiveLike
+		sqliteOptionCaseSensitiveLike +
+		sqliteOptionJournalMode
 )
 
 // NewSqliteState creates a new SQLite-backed state database.
@@ -81,6 +87,12 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 	if err != nil {
 		return nil, fmt.Errorf("initializing sqlite database: %w", err)
 	}
+	// Limit maximum open connections to 1. This serializes database operations within a single
+	// process to a single SQLite connection handle, eliminating internal connection thrashing
+	// and avoiding POSIX advisory lock invalidations caused by closing connection file descriptors (#29721).
+	conn.SetMaxOpenConns(1)
+	conn.SetMaxIdleConns(1)
+
 	defer func() {
 		if defErr != nil {
 			if err := conn.Close(); err != nil {
@@ -107,6 +119,15 @@ func (s *SQLiteState) Name() string {
 
 // Close closes the state and prevents further use
 func (s *SQLiteState) Close() error {
+	if s.conn != nil && s.valid {
+		// Best-effort WAL truncate checkpoint before closing connection.
+		// If another process holds a read lock, this may return SQLITE_BUSY, which we log at debug level
+		// so that s.conn.Close() is always called cleanly.
+		if _, err := s.conn.Exec("PRAGMA wal_checkpoint(TRUNCATE);"); err != nil {
+			logrus.Debugf("SQLite WAL truncate checkpoint on DB close: %v", err)
+		}
+	}
+
 	if err := s.conn.Close(); err != nil {
 		return err
 	}

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -2444,3 +2444,17 @@ func TestRemoveVolumeNotInDB(t *testing.T) {
 		require.ErrorIs(t, err, define.ErrNoSuchVolume)
 	})
 }
+
+func TestSqliteJournalModeWAL(t *testing.T) {
+	state, _ := getEmptySqliteState(t)
+	sqliteState, ok := state.(*SQLiteState)
+	require.True(t, ok)
+
+	var journalMode string
+	err := sqliteState.conn.QueryRow("PRAGMA journal_mode;").Scan(&journalMode)
+	require.NoError(t, err)
+	assert.Equal(t, "wal", strings.ToLower(journalMode))
+
+	err = sqliteState.Close()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
### Summary
Fixes SQLite state database corruption (`"database disk image is malformed"`, freelist page count mismatch on page 1) under sustained high container churn (#29721).

### Cause
In SQLite's default rollback journal mode (`DELETE`), write transactions write directly to page 1 of `db.sql`. Under POSIX advisory locking (`fcntl`), closing any file descriptor to a file by any connection/thread drops all POSIX locks held by the process on that file. When Go's `database/sql` connection pool opens and closes multiple connection handles within the Podman daemon, active transaction locks are invalidated, leading to merged/torn freelist header writes on page 1.

### Solution
1. **Enable WAL Mode (`_journal_mode=WAL`)**:
   - Write transactions append to `-wal` sidecar files rather than modifying page 1 of `db.sql` directly.
   - Shared-memory locking (`-shm`) avoids POSIX lock-drop corruption vectors and enables SQLite's broken-lock defenses.
   - *Note*: Requires a local POSIX filesystem (ext4, xfs, btrfs); `mmap` for `-shm` is not supported over NFS/SMB.
2. **Cap Connection Pool (`SetMaxOpenConns(1)`)**:
   - Serializes database queries within the daemon process through a single SQLite connection handle, eliminating internal connection thrashing and POSIX file-descriptor closing side effects.
3. **Best-Effort WAL Checkpoint on `Close()`**:
   - Executes `PRAGMA wal_checkpoint(TRUNCATE);` during `SQLiteState.Close()` to flush and truncate `-wal` frames back into `db.sql` upon daemon shutdown.
4. **Unit Test**: Added `TestSqliteJournalModeWAL` in `libpod/state_test.go`.

### Fixes
Fixes #29721

### Checklist
- [x] Code builds clean (`make binaries`)
- [x] Unit tests pass (`go test -v -tags "sqlite ..." ./libpod`)
- [x] DCO signed commit (`git commit -s`)
