### PR TITLE
docs: fix podman-systemd.unit man page errors

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -2573,6 +2573,34 @@ Options=iam_role,endpoint=${AWS_REGION},use_xattr,listobjectsv2,del_cache,use_ca
 # `iam_role` assumes inside EC2, if not, Use `profile=` instead
 ```
 
+Starting a service defined as a `.container` file:
+
+1. Create a Quadlet file named `myservice.container` in `~/.config/containers/systemd/` for a rootless service, or in `/etc/containers/systemd/` for a system service:
+
+```ini
+[Unit]
+Description=My Service
+
+[Container]
+Image=quay.io/centos/centos:latest
+Exec=sleep 60
+
+[Install]
+WantedBy=multi-user.target default.target
+```
+
+2. Reload systemd to generate the service unit:
+
+```bash
+systemctl --user daemon-reload
+```
+
+3. Start the service:
+
+```bash
+systemctl --user start myservice.service
+```
+
 For more examples, please see the [podman-quadlet-basic-usage.7](podman-quadlet-basic-usage.7.md).
 
 ## SEE ALSO


### PR DESCRIPTION
Fixes #17514

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/containers/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/containers/podman/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None

Summary of changes:

This PR resolves issue #17514 by adding the requested step-by-step example on how to start a service defined as a .container file in the ## EXAMPLES section.

Note to reviewers: I investigated the other points raised in the original issue (the typo in the table and the keep-id/RemapUid descriptions), but noticed they were already resolved in the main branch during the deprecation and migration to UserNS= (commits 65a64da271 and f6a50311c5). Therefore, this PR focuses solely on the missing documentation example.