### PR TITLE
docs: clarify podman pull --all-tags behavior

### DIFF
--- a/docs/source/markdown/options/all-tags.md
+++ b/docs/source/markdown/options/all-tags.md
@@ -10,4 +10,6 @@
 
 All tagged images in the repository are pulled.
 
+The SOURCE must reference a repository without a tag or digest (for example `alpine`, not `alpine:latest`). If SOURCE includes a tag or digest, only that specific image is pulled and **--all-tags** has no effect.
+
 *IMPORTANT: When using the all-tags flag, Podman does not iterate over the search registries in the **[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)** but always uses docker.io for unqualified image names.*

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -223,6 +223,23 @@ Never pull the image, only use local version.
 $ podman pull --policy never alpine:latest
 ```
 
+Pull all tagged images in a repository. SOURCE must not include a tag or digest.
+```
+$ podman pull --all-tags alpine
+Trying to pull docker.io/library/alpine:latest...
+Getting image source signatures
+Copying blob 5843afab3874 done
+Copying config d4ff818577 done
+Writing manifest to image destination
+Storing signatures
+Trying to pull docker.io/library/alpine:3.19...
+Getting image source signatures
+Copying blob 91ef9543149d done
+Copying config 05455a08881 done
+Writing manifest to image destination
+Storing signatures
+```
+
 Always pull the image even if present locally.
 ```
 $ podman pull --policy always alpine:latest


### PR DESCRIPTION
## Changes

The `--all-tags` option did not explain that `SOURCE` should be a plain repository name without a tag or digest.

I added this clarification and also added an example for using `--all-tags`.

Fixes: #23625

## Release note

None
