### PR TITLE
add new container-libs vendor check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,7 @@ vendor: ## Tidy, vendor, and verify Go module dependencies
 	$(GO) mod vendor
 	$(GO) mod verify
 	$(GO) mod edit -toolchain none
+	./hack/container-libs-module-check.sh
 
 
 # We define *-in-container targets for the following make targets. This allow the targets to be run in a container.

--- a/hack/container-libs-module-check.sh
+++ b/hack/container-libs-module-check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+function die() {
+    echo "$1" >&2
+    exit 1
+}
+
+# All these modules are part of the same git monorepo, https://github.com/podman-container-tools/container-libs/
+MODULES=(go.podman.io/common go.podman.io/image/v5 go.podman.io/storage)
+VERSIONS=()
+
+for module in "${MODULES[@]}"; do
+    VERSIONS+=($(go list -m -f '{{.Version}}' $module))
+done
+
+commit=""
+is_tag=false
+is_commit=false
+for version in "${VERSIONS[@]}"; do
+    # match pseudo version format, https://go.dev/ref/mod#pseudo-versions
+    if [[ $version =~ .*[0-9]{14}-([0-9a-f]{12}) ]]; then
+        new_commit="${BASH_REMATCH[1]}"
+        if [[ "$commit" != "" && "$commit" != "$new_commit" ]]; then
+            die "go.mod contains different commits for the container-libs repo, please ensure all three modules use the same commit. commit 1: $commit, commit 2: $new_commit"
+        fi
+        commit="$new_commit"
+        is_commit=true
+    else
+        is_tag=true
+    fi
+done
+
+if [[ $is_commit = true && $is_tag = true ]]; then
+    die "go.mod contains tagged versions and commits for the container-libs repo, please either only use tagged versions or only specific commits for all three modules"
+fi


### PR DESCRIPTION
With the container-libs repos we either only supported the tagged versions or using the same vendor commit for all of the at the same time. Mixing different commits, while possible, can run into untested version combinations that cause weird errors later on.

To avoid the mismatch add a custom bash script to validate that either all modules use a proper tag or all modules use the same commit.


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
