### PR TITLE
Fix podman run with docker transport references

### DIFF
--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -56,7 +56,9 @@ is a non-standardized format, primarily useful for debugging or noninvasive cont
   **docker://**_docker-reference_ (Default)
   An image reference stored in a remote container image registry. Example: "quay.io/podman/stable:latest".
 The reference can include a path to a specific registry; if it does not, the
-registries listed in registries.conf are queried to find a matching image.
+registries listed in registries.conf are queried to find a matching image. If the
+image is already present in local storage, Podman uses that image instead of
+requiring a separate local-storage transport prefix.
 By default, credentials from `podman login` (stored at
 $XDG_RUNTIME_DIR/containers/auth.json by default) are used to authenticate;
 otherwise it falls back to using credentials in $HOME/.docker/config.json.

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -17,7 +17,9 @@ import (
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/libnetwork/types"
 	"go.podman.io/common/pkg/config"
+	"go.podman.io/image/v5/docker"
 	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/transports/alltransports"
 	"go.podman.io/podman/v6/libpod"
 	"go.podman.io/podman/v6/libpod/define"
 	ann "go.podman.io/podman/v6/pkg/annotations"
@@ -41,9 +43,18 @@ func getImageFromSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGen
 		return image, resolvedName, inspectData, nil
 	}
 
-	// Need to look up image.
+	// Need to look up image.  The docker transport identifies a registry
+	// image, but local lookups need the normalized image name.  A pull may
+	// have just stored the image under that name, so strip the transport
+	// before looking it up.
 	lookupOptions := &libimage.LookupImageOptions{ManifestList: true}
-	image, resolvedName, err := r.LibimageRuntime().LookupImage(s.Image, lookupOptions)
+	imageName := s.Image
+	if imageRef, parseErr := alltransports.ParseImageName(imageName); parseErr == nil && imageRef.Transport().Name() == docker.Transport.Name() {
+		if named := imageRef.DockerReference(); named != nil {
+			imageName = named.String()
+		}
+	}
+	image, resolvedName, err := r.LibimageRuntime().LookupImage(imageName, lookupOptions)
 	if err != nil {
 		return nil, "", nil, err
 	}

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -18,6 +18,12 @@ load helpers
     fi
 }
 
+# Regression test for using a docker transport reference with a local image.
+@test "podman run accepts docker transport references" {
+    run_podman run --pull=never --rm docker://$PODMAN_TEST_IMAGE_FQN true
+    is "$output" "" "run image referenced with docker transport"
+}
+
 # CANNOT BE PARALLELIZED: relies on exact output from podman images
 @test "podman images - custom formats" {
     tests="


### PR DESCRIPTION
## Summary

- Normalize `docker://` image references before `podman run` looks up the locally pulled image.
- Add a system regression test covering a docker transport reference with `--pull=never`.
- Clarify the behavior in the `podman run` image documentation.

## Root cause

After an image was pulled, container-spec completion passed the original `docker://` reference to libimage's local lookup. The local lookup intentionally rejects non-`containers-storage` transports, producing the misleading unsupported-transport error even though the image was available locally.

## Validation

- `git diff --check`
- Static regression-coverage assertions passed.
- Full Go/CLI execution was attempted but the environment lacks required Linux headers and the `gpgme` pkg-config dependency.

Validation observed for this change:
- `git diff --check && git status --short`
- `python3 -c 'from pathlib import Path; code=Path("pkg/specgen/generate/container.go").read_text(); test=Path("test/system/010-images.bats").read_text(); assert "alltransports.ParseImageName" in code and "imageRef.DockerReference()" in code; assert "docker://$PODMAN_TEST_IMAGE_FQN" in test; print("docker transport regression coverage is present")'`

Fixes #20775

<!-- repo-agent-case:2df5e925-1549-4bf0-90e9-ae319e6d7bc4 -->