### PR TITLE
test/{apiv2,system}: remove cgroupv2 check

### DIFF
--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -48,13 +48,8 @@ t GET    libpod/containers/create  405
 #
 # system info
 #
-# Some day perhaps it will always be runc; for now, cgroupsv2 requires crun
-#
 # FIXME: run 'podman info --format=json', and compare select fields
-runtime=runc
-if have_cgroupsv2; then
-    runtime=crun
-fi
+runtime=crun
 t GET info 200                \
   .OSType=linux               \
   .DefaultRuntime~.*$runtime  \

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -17,27 +17,16 @@ t GET libpod/containers/nonesuch/exists 404
 t GET libpod/containers/foo/exists 204
 
 # Pause and Unpause the container
-if root || have_cgroupsv2; then
-    t POST libpod/containers/foo/pause 204
+t POST libpod/containers/foo/pause 204
 
-    t GET libpod/containers/foo/json 200 \
-      .Id~[0-9a-f]\\{64\\} \
-      .State.Status=paused \
-      .ImageName=$IMAGE \
-      .Config.Cmd[0]=top \
-      .Name=foo
+t GET libpod/containers/foo/json 200 \
+  .Id~[0-9a-f]\\{64\\} \
+  .State.Status=paused \
+  .ImageName=$IMAGE \
+  .Config.Cmd[0]=top \
+  .Name=foo
 
-    t POST libpod/containers/foo/unpause 204
-else
-    # cgroupsv1 rootless : pause and unpause are not supported in cgroups v1 rootless
-    t POST libpod/containers/foo/pause 500 \
-      .cause="this container does not have a cgroup" \
-      .message~".*pause containers on rootless containers with cgroup V1"
-
-    t POST libpod/containers/foo/unpause 500 \
-      .cause="container state improper" \
-      .message~".*is not paused, can't unpause: container state improper"
-fi
+t POST libpod/containers/foo/unpause 204
 
 t GET libpod/containers/foo/json 200 \
   .Id~[0-9a-f]\\{64\\} \

--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -47,14 +47,8 @@ t POST libpod/pods/fakename/start 404 \
   .cause="no such pod" \
   .message="no pod with name or ID fakename found: no such pod"
 
-if root || have_cgroupsv2; then
-    t POST libpod/pods/foo/pause 200
-else
-    # Rootless cgroupsv1 : unsupported
-    t POST "libpod/pods/foo/pause (rootless cgroups v1)" 500 \
-      .cause="this container does not have a cgroup" \
-      .message~".*pause pods containing rootless containers with cgroup V1"
-fi
+
+t POST libpod/pods/foo/pause 200
 t POST  libpod/pods/foo/unpause 200
 t POST "libpod/pods/foo/unpause (2nd unpause in a row)" 200
 t POST "libpod/pods/fakename/unpause" 404\
@@ -108,28 +102,21 @@ t POST libpod/pods/bar/stop?t=1 200 \
 
 t POST libpod/pods/bar/start 200
 
-if root || have_cgroupsv2; then
-    t GET libpod/pods/stats?all=true 200
-    is $(jq '. | length' <<<"$output") 3 "stats?all=true: number of records found"
+t GET libpod/pods/stats?all=true 200
+is $(jq '. | length' <<<"$output") 3 "stats?all=true: number of records found"
 
-    t GET libpod/pods/stats?namesOrIDs=foo 200
-    is $(jq '. | length' <<<"$output") 1 "stats?namesOrIDs=foo: number of records found"
+t GET libpod/pods/stats?namesOrIDs=foo 200
+is $(jq '. | length' <<<"$output") 1 "stats?namesOrIDs=foo: number of records found"
 
-    t GET libpod/pods/stats?namesOrIDs=fakename 404 \
-      .cause="no such pod" \
-      .message="unable to get list of pods: no pod with name or ID fakename found: no such pod"
+t GET libpod/pods/stats?namesOrIDs=fakename 404 \
+  .cause="no such pod" \
+  .message="unable to get list of pods: no pod with name or ID fakename found: no such pod"
 
-    t GET "libpod/pods/stats?all=true&namesOrIDs=foo" 500 \
-      .cause="--all, --latest and arguments cannot be used together" \
-      .message="--all, --latest and arguments cannot be used together"
+t GET "libpod/pods/stats?all=true&namesOrIDs=foo" 500 \
+  .cause="--all, --latest and arguments cannot be used together" \
+  .message="--all, --latest and arguments cannot be used together"
 
-    t DELETE  libpod/pods/bar?force=true 200
-else
-    # Rootless cgroupsv1 : libpod/pods/stats is unsupported
-    t GET libpod/pods/stats?all=true 500 \
-      .cause="pod stats is not supported in rootless mode without cgroups v2" \
-      .message~"pod stats is not supported in rootless mode without cgroups v2"
-fi
+t DELETE  libpod/pods/bar?force=true 200
 
 # test the fake name
 t GET libpod/pods/fakename/top 404 \
@@ -161,10 +148,8 @@ t DELETE  libpod/pods/foo 200
 t DELETE "libpod/pods/foo (pod has already been deleted)" 404
 
 # Expect this to time out
-if root || have_cgroupsv2; then
-    # Rootless cgroupsv1 : libpod/pods/stats is unsupported
-    APIV2_TEST_EXPECT_TIMEOUT=5 t GET "libpod/pods/stats?stream=true&delay=1" 999
-fi
+# Rootless cgroupsv1 : libpod/pods/stats is unsupported
+APIV2_TEST_EXPECT_TIMEOUT=5 t GET "libpod/pods/stats?stream=true&delay=1" 999
 
 podman pod create --name=specgen
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -675,12 +675,6 @@ function rootless() {
     test "$ROOTLESS" = "true"
 }
 
-# True if cgroups v2 are enabled
-function have_cgroupsv2() {
-    cgroup_type=$(stat -f -c %T /sys/fs/cgroup)
-    test "$cgroup_type" = "cgroup2fs"
-}
-
 # END   infrastructure code
 ###############################################################################
 # BEGIN sanity checks

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -80,12 +80,7 @@ EOF
 # bats test_tags=ci:parallel
 @test "podman run --memory=0 runtime option" {
     run_podman run --memory=0 --rm $IMAGE echo hello
-    if is_rootless && ! is_cgroupsv2; then
-        is "${lines[0]}" "Resource limits are not supported and ignored on cgroups V1 rootless systems" "--memory is not supported"
-        is "${lines[1]}" "hello" "--memory is ignored"
-    else
-        is "$output" "hello" "failed to run when --memory is set to 0"
-    fi
+    is "$output" "hello" "failed to run when --memory is set to 0"
 }
 
 # 'run --preserve-fds' passes a number of additional file descriptors into the container
@@ -1177,17 +1172,10 @@ EOF
     local dev_maj_min=$(stat -c %Hr:%Lr /dev/nullb0)
 
     # this test is a triple check on blkio flags since they seem to sneak by the tests
-    if is_cgroupsv2; then
-        run_podman run -dt --device-read-bps=/dev/nullb0:1M $IMAGE top
-        cid=$output
-        run_podman exec -it $output cat /sys/fs/cgroup/io.max
-        is "$output" ".*$dev_maj_min rbps=1048576 wbps=max riops=max wiops=max" "throttle devices passed successfully.*"
-    else
-        run_podman run -dt --device-read-bps=/dev/nullb0:1M $IMAGE top
-        cid=$output
-        run_podman exec -it $output cat /sys/fs/cgroup/blkio/blkio.throttle.read_bps_device
-        is "$output" ".*$dev_maj_min 1048576" "throttle devices passed successfully.*"
-    fi
+    run_podman run -dt --device-read-bps=/dev/nullb0:1M $IMAGE top
+    cid=$output
+    run_podman exec -it $output cat /sys/fs/cgroup/io.max
+    is "$output" ".*$dev_maj_min rbps=1048576 wbps=max riops=max wiops=max" "throttle devices passed successfully.*"
     run_podman container rm -f -t0 $cid
 }
 

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -157,10 +157,6 @@ load helpers
 }
 
 @test "podman cp file from/to host while --pid=host" {
-    if is_rootless && ! is_cgroupsv2; then
-        skip "'podman cp --pid=host' (rootless) only works with cgroups v2"
-    fi
-
     srcdir=$PODMAN_TMPDIR/cp-pid-equals-host
     mkdir -p $srcdir
     touch $srcdir/hostfile

--- a/test/system/080-pause.bats
+++ b/test/system/080-pause.bats
@@ -10,10 +10,6 @@ load helpers.systemd
 # as this command takes locks of all containers and parallel containers may
 # block for a while.
 @test "podman pause/unpause" {
-    if is_rootless && ! is_cgroupsv2; then
-        skip "'podman pause' (rootless) only works with cgroups v2"
-    fi
-
     cname="c-$(safename)"
     run_podman run -d --name $cname $IMAGE \
                sh -c 'while :;do date +%s;sleep 1;done'
@@ -68,10 +64,6 @@ load helpers.systemd
 
 # CANNOT BE PARALLELIZED! (because of unpause --all)
 @test "podman unpause --all" {
-    if is_rootless && ! is_cgroupsv2; then
-        skip "'podman pause' (rootless) only works with cgroups v2"
-    fi
-
     cname="c-$(safename)"
     cname_notrunning="c-notrunning-$(safename)"
 
@@ -91,10 +83,6 @@ load helpers.systemd
 
 # bats test_tags=ci:parallel
 @test "podman pause/unpause with HealthCheck interval" {
-    if is_rootless && ! is_cgroupsv2; then
-        skip "'podman pause' (rootless) only works with cgroups v2"
-    fi
-
     local ctrname="c-$(safename)"
     local msg="healthmsg-$(random_string)"
 

--- a/test/system/180-blkio.bats
+++ b/test/system/180-blkio.bats
@@ -47,23 +47,10 @@ function teardown() {
     echo bfq > /sys/block/$(basename ${lodevice})/queue/scheduler
 
     # run podman
-    if is_cgroupsv2; then
-        if [ ! -f /sys/fs/cgroup/system.slice/io.bfq.weight ]; then
-            skip "Kernel does not support BFQ IO scheduler"
-        fi
-        run_podman run --device ${lodevice}:${lodevice} --blkio-weight-device ${lodevice}:123 --rm $IMAGE \
-            /bin/sh -c "cat /sys/fs/cgroup/\$(sed -e 's/0:://' < /proc/self/cgroup)/io.bfq.weight"
-        is "${lines[1]}" "${lomajmin}\s\+123"
-    else
-        if [ ! -f /sys/fs/cgroup/blkio/system.slice/blkio.bfq.weight_device ]; then
-            skip "Kernel does not support BFQ IO scheduler"
-        fi
-        if [ $(podman_runtime) = "crun" ]; then
-            # As of crun 1.2, crun doesn't support blkio.bfq.weight_device
-            skip "crun doesn't support blkio.bfq.weight_device"
-        fi
-        run_podman run --device ${lodevice}:${lodevice} --blkio-weight-device ${lodevice}:123 --rm $IMAGE \
-            /bin/sh -c "cat /sys/fs/cgroup/blkio/blkio.bfq.weight_device"
-        is "${lines[1]}" "${lomajmin}\s\+123"
+    if [ ! -f /sys/fs/cgroup/system.slice/io.bfq.weight ]; then
+        skip "Kernel does not support BFQ IO scheduler"
     fi
+    run_podman run --device ${lodevice}:${lodevice} --blkio-weight-device ${lodevice}:123 --rm $IMAGE \
+        /bin/sh -c "cat /sys/fs/cgroup/\$(sed -e 's/0:://' < /proc/self/cgroup)/io.bfq.weight"
+    is "${lines[1]}" "${lomajmin}\s\+123"
 }

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -771,12 +771,7 @@ function thingy_with_unique_id() {
         result="$output"
         assert "$result" =~ "/" ".CgroupPath is a valid path"
 
-        if is_cgroupsv2; then
-           cgroup_path=/sys/fs/cgroup/$result
-        else
-           cgroup_path=/sys/fs/cgroup/memory/$result
-        fi
-
+        cgroup_path=/sys/fs/cgroup/$result
         if test ! -e $cgroup_path; then
             die "the cgroup $cgroup_path does not exist"
         fi
@@ -793,11 +788,7 @@ function thingy_with_unique_id() {
 
         # validate that cgroup limits are in place after a restart
         # issue #19175
-        if is_cgroupsv2; then
-           memory_limit_file=$cgroup_path/memory.max
-        else
-           memory_limit_file=$cgroup_path/memory.limit_in_bytes
-        fi
+        memory_limit_file=$cgroup_path/memory.max
         assert "$(< $memory_limit_file)" = "268435456" "Contents of $memory_limit_file"
 
         run_podman pod rm -t 0 -f $podid

--- a/test/system/280-update.bats
+++ b/test/system/280-update.bats
@@ -17,55 +17,41 @@ function teardown() {
 
 
 @test "podman update - test all options" {
-    local cgv=1
-    if is_cgroupsv2; then
-        cgv=2;
-    fi
-
     # Need a block device for blkio-weight-device testing
     local pass_loop_device=
     if ! is_rootless; then
-        if is_cgroupsv2; then
-            lofile=${PODMAN_TMPDIR}/disk.img
-            fallocate -l 1k  ${lofile}
-            LOOPDEVICE=$(losetup --show -f $lofile)
-            pass_loop_device="--device $LOOPDEVICE"
+        lofile=${PODMAN_TMPDIR}/disk.img
+        fallocate -l 1k  ${lofile}
+        LOOPDEVICE=$(losetup --show -f $lofile)
+        pass_loop_device="--device $LOOPDEVICE"
 
-            # Get maj:min (tr needed because losetup seems to use %2d)
-            lomajmin=$(losetup -l --noheadings --output MAJ:MIN $LOOPDEVICE | tr -d ' ')
-        fi
+        # Get maj:min (tr needed because losetup seems to use %2d)
+        lomajmin=$(losetup -l --noheadings --output MAJ:MIN $LOOPDEVICE | tr -d ' ')
     fi
 
     # Shortcuts to make the table narrower
     local -a gig=(0 1073741824 2147483648 3221225472)
     local devicemax="1:5 rbps=10485760 wbps=31457280 riops=2000 wiops=4000"
-    local mm=memory/memory
 
     # Format:
-    #   --<option> = <value>  | rootless? | check: cgroups v1            | check: cgroups v2
-    #
-    # Requires very wide window to read. Sorry.
-    #
-    # FIXMEs:
-    #  cpu-rt-period  (cgv1 only, on cpu/cpu.rt_period_us) works on RHEL8 but not on Ubuntu
-    #  cpu-rt-runtime (cgv1 only, on cpu/cpu.rt_runtime_us) fails: error setting cgroup config for procHooks ...
+    #   --<option> = <value>  | rootless (true/false) | check: cgroups v2
     tests="
-cpu-shares          =            512 | - | cpu/cpu.shares       = 512              | cpu.weight      = 20
-cpus                =              5 | - | cpu/cpu.cfs_quota_us = 500000           | cpu.max         = 500000 100000
-cpuset-cpus         =              0 | - | cpuset/cpuset.cpus   = 0                | cpuset.cpus     = 0
-cpuset-mems         =              0 | - | cpuset/cpuset.mems   = 0                | cpuset.mems     = 0
+cpu-shares          =            512 | true | cpu.weight      = 20
+cpus                =              5 | true | cpu.max         = 500000 100000
+cpuset-cpus         =              0 | true | cpuset.cpus     = 0
+cpuset-mems         =              0 | true | cpuset.mems     = 0
 
-memory              =             1G | 2 | $mm.limit_in_bytes       = ${gig[1]}    | memory.max      = ${gig[1]}
-memory-swap         =             3G | 2 | $mm.memsw.limit_in_bytes = ${gig[3]}    | memory.swap.max = ${gig[2]}
-memory-reservation  =           400M | 2 | $mm.soft_limit_in_bytes  = 419430400    | memory.low      = 419430400
+memory              =             1G | true | memory.max      = ${gig[1]}
+memory-swap         =             3G | true | memory.swap.max = ${gig[2]}
+memory-reservation  =           400M | true | memory.low      = 419430400
 
-blkio-weight        =            321 | - | -                                       | io.bfq.weight   = default 321 $lomajmin 98
-blkio-weight-device = $LOOPDEVICE:98 | - | -                                       | io.bfq.weight   = default 321 $lomajmin 98
+blkio-weight        =            321 | false | io.bfq.weight   = default 321 $lomajmin 98
+blkio-weight-device = $LOOPDEVICE:98 | false | io.bfq.weight   = default 321 $lomajmin 98
 
-device-read-bps     = $LOOPDEVICE:10mb | - | -                                       | io.max          = $devicemax
-device-read-iops    = $LOOPDEVICE:2000 | - | -                                       | io.max          = $devicemax
-device-write-bps    = $LOOPDEVICE:30mb | - | -                                       | io.max          = $devicemax
-device-write-iops   = $LOOPDEVICE:4000 | - | -                                       | io.max          = $devicemax
+device-read-bps     = $LOOPDEVICE:10mb | false | io.max          = $devicemax
+device-read-iops    = $LOOPDEVICE:2000 | false | io.max          = $devicemax
+device-write-bps    = $LOOPDEVICE:30mb | false | io.max          = $devicemax
+device-write-iops   = $LOOPDEVICE:4000 | false | io.max          = $devicemax
 "
 
     # Run a container
@@ -76,28 +62,17 @@ device-write-iops   = $LOOPDEVICE:4000 | - | -                                  
     # to this test environment (root/rootless, cgroups v1/v2)
     local -a opts
     local -A check
-    while read opt works_rootless cgv1 cgv2; do
+    while read opt works_rootless cgv2; do
         if is_rootless; then
             local skipping="skipping --$opt : does not work rootless"
-            if [[ $works_rootless = '-' ]]; then
+            if [[ $works_rootless = false ]]; then
                 echo "[ $skipping ]"
-                continue
-            fi
-            if [[ ! $works_rootless =~ $cgv ]]; then
-                echo "[ $skipping on cgroups v$cgv ]"
                 continue
             fi
         fi
 
         # Determine the "path = newvalue" string for this cgroup
-        tuple=$cgv1
-        if is_cgroupsv2; then
-            tuple=$cgv2
-        fi
-        if [[ $tuple = '-' ]]; then
-            echo "[ skipping --$opt : N/A on cgroups v$cgv ]"
-            continue
-        fi
+        tuple=$cgv2
 
         # Sigh. bfq doesn't exist on Debian (2024-03)
         read path op expect <<<"$tuple"

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -18,17 +18,6 @@ function setup() {
     basic_setup
 }
 
-# Returns true if we are able to podman-pause
-function _can_pause() {
-    # Even though we're just trying completion, not an actual unpause,
-    # podman barfs with:
-    #    Error: unpause is not supported for cgroupv1 rootless containers
-    if is_rootless && is_cgroupsv1; then
-        return 1
-    fi
-    return 0
-}
-
 function check_shell_completion() {
     local count=0
 
@@ -98,11 +87,6 @@ function check_shell_completion() {
                     ;;
 
                 *CONTAINER*)
-                    # podman unpause fails early on rootless cgroupsv1
-                    if [[ $cmd = "unpause" ]] && ! _can_pause; then
-                        continue 2
-                    fi
-
                     name=$random_container_name
                     # special case podman cp suggest containers names with a colon
                     if [[ $cmd = "cp" ]]; then
@@ -284,9 +268,7 @@ function _check_no_suggestions() {
     run_podman create --name created-$random_container_name $IMAGE
     run_podman run --name running-$random_container_name -d $IMAGE top
     run_podman run --name pause-$random_container_name -d $IMAGE top
-    if _can_pause; then
-        run_podman pause pause-$random_container_name
-    fi
+    run_podman pause pause-$random_container_name
     run_podman run --name exited-$random_container_name -d $IMAGE echo exited
 
     # create pods for each state

--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -20,9 +20,6 @@ function teardown() {
 # podman machine is finicky. Assume we can't run it, but see below for more.
 can_run_podman_machine=
 
-# podman stats, too
-can_run_stats=
-
 # Main test loop. Recursively runs 'podman [subcommand] help', looks for:
 #    > '[command]', which indicates, recurse; or
 #    > '--format', in which case we
@@ -38,9 +35,6 @@ function check_subcommand() {
         # Human-readable podman command string, with multiple spaces collapsed
         # Special case: 'podman machine' can only be run under ideal conditions
         if [[ "$cmd" = "machine" ]] && [[ -z "$can_run_podman_machine" ]]; then
-            continue
-        fi
-        if [[ "$cmd" = "stats" ]] && [[ -z "$can_run_stats" ]]; then
             continue
         fi
 
@@ -164,6 +158,10 @@ pod inspect       | $podname
 
 events            | --stream=false --events-backend=file
 system events     | --stream=false --events-backend=file
+
+container stats   | --no-stream
+pod stats         | --no-stream
+stats             | --no-stream
 "
 
 
@@ -177,16 +175,6 @@ system events     | --stream=false --events-backend=file
         can_run_podman_machine=true
         extra_args_table+="
 machine inspect   | $machinename
-"
-    fi
-
-    # Similarly, 'stats' cannot run rootless under cgroups v1
-    if ! is_rootless || is_cgroupsv2; then
-        can_run_stats=true
-        extra_args_table+="
-container stats   | --no-stream
-pod stats         | --no-stream
-stats             | --no-stream
 "
     fi
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -751,17 +751,6 @@ function is_remote() {
     [[ "$PODMAN" =~ -remote ]]
 }
 
-function is_cgroupsv1() {
-    # WARNING: This will break if there's ever a cgroups v3
-    ! is_cgroupsv2
-}
-
-# True if cgroups v2 are enabled
-function is_cgroupsv2() {
-    cgroup_type=$(stat -f -c %T /sys/fs/cgroup)
-    test "$cgroup_type" = "cgroup2fs"
-}
-
 # True if podman is using netavark
 function is_netavark() {
     run_podman info --format '{{.Host.NetworkBackend}}'


### PR DESCRIPTION
Since podman 6 we only support cgroupv2 systems. Therefore we no longer
need this check in the tests and we can simplify them.

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
