### PR TITLE
Kube play: preserve memory-backed emptyDir data after init containers exit

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -140,6 +140,13 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | stdinOnce                                           | no      |
 | tty                                                 | no      |
 
+## EmptyDir Fields
+
+| Field     | Support |
+|-----------|---------|
+| medium    | ✅      |
+| sizeLimit | ✅      |
+
 ## PersistentVolumeClaim Fields
 
 | Field               | Support |

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -32,8 +32,8 @@ Only five volume types are supported by kube play, the *hostPath*, *emptyDir*, *
 
 - When using the *hostPath* volume type, only the  *default (empty)*, *DirectoryOrCreate*, *Directory*, *FileOrCreate*, *File*, *Socket*, *CharDevice* and *BlockDevice* subtypes are supported. Podman interprets the value of *hostPath* *path* as a file path when it contains at least one forward slash, otherwise Podman treats the value as the name of a named volume.
 - When using a *persistentVolumeClaim*, the value for *claimName* is the name for the Podman named volume.
-- When using an *emptyDir* volume, Podman creates an anonymous volume that is attached the containers running inside the pod and is deleted once the pod is removed.
-- When using an *configMap* volume, Podman creates an anonymous volume that is attached the containers running inside the pod and is deleted once the pod is removed.
+- When using an *emptyDir* volume, Podman creates an anonymous volume that is shared by the containers that mount it and is deleted once the pod is removed. If *medium* is set to *Memory*, the volume is backed by tmpfs, and *sizeLimit* sets its size limit.
+- When using a *configMap* volume, Podman creates an anonymous volume populated with the ConfigMap data and mounts it into the containers that reference it. The volume is deleted once the pod is removed.
 - When using an *image* volume, Podman creates a read-only image volume with an empty subpath (the whole image is mounted). The image must already exist locally. It is supported in rootful mode only.
 
 Note: The default restart policy for containers is `always`.  You can change the default by setting the `restartPolicy` field in the spec.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -245,6 +245,9 @@ type ContainerNamedVolume struct {
 	// IsAnonymous sets the named volume as anonymous even if it has a name
 	// This is used for emptyDir volumes from a kube yaml
 	IsAnonymous bool `json:"setAnonymous,omitempty"`
+	// NoInherit prevents containers joining the pod from inheriting this
+	// volume from the infra container.
+	NoInherit bool `json:"noInherit,omitempty"`
 	// SubPath determines which part of the Source will be mounted in the container
 	SubPath string `json:",omitempty"`
 	// NoCreate indicates that the volume must already exist and should not

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1352,6 +1352,7 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 				Dest:        vol.Dest,
 				Options:     mountOpts,
 				IsAnonymous: vol.IsAnonymous,
+				NoInherit:   vol.NoInherit,
 				SubPath:     vol.SubPath,
 				NoCreate:    noCreate,
 			})

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -948,6 +948,22 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if err != nil {
 			return nil, nil, err
 		}
+
+		// A memory-backed emptyDir belongs to the pod, not to an individual
+		// container. Keep the tmpfs mounted through the infra container so it
+		// survives the gap between one-shot init and regular containers.
+		for _, volume := range volumes {
+			if volume.Type != kube.KubeVolumeTypeEmptyDirTmpfs {
+				continue
+			}
+			podSpec.PodSpecGen.InfraContainerSpec.Volumes = append(podSpec.PodSpecGen.InfraContainerSpec.Volumes, &specgen.NamedVolume{
+				Name:        volume.Source,
+				Dest:        "/run/podman/emptydir/" + volume.Source,
+				Options:     kube.MemoryEmptyDirOptions(volume.SizeLimit),
+				IsAnonymous: true,
+				NoInherit:   true,
+			})
+		}
 	}
 
 	// Add the original container names from the kube yaml as aliases for it. This will allow network to work with

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -534,9 +534,10 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 	if len(conf.NamedVolumes) != 0 {
 		for _, v := range conf.NamedVolumes {
 			named = append(named, &specgen.NamedVolume{
-				Name:    v.Name,
-				Dest:    v.Dest,
-				Options: v.Options,
+				Name:      v.Name,
+				Dest:      v.Dest,
+				Options:   v.Options,
+				NoInherit: v.NoInherit,
 			})
 		}
 	}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -496,6 +496,7 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 				Dest:        v.Dest,
 				Options:     v.Options,
 				IsAnonymous: v.IsAnonymous,
+				NoInherit:   v.NoInherit,
 				SubPath:     v.SubPath,
 			})
 		}
@@ -754,7 +755,7 @@ func Inherit(infra *libpod.Container, s *specgen.SpecGenerator, rt *libpod.Runti
 	compatibleOptions.Mounts = append(compatibleOptions.Mounts, s.Mounts...)
 	compatibleOptions.OverlayVolumes = append(compatibleOptions.OverlayVolumes, s.OverlayVolumes...)
 	compatibleOptions.SelinuxOpts = append(compatibleOptions.SelinuxOpts, s.SelinuxOpts...)
-	compatibleOptions.Volumes = append(compatibleOptions.Volumes, s.Volumes...)
+	compatibleOptions.Volumes = inheritNamedVolumes(compatibleOptions.Volumes, s.Volumes)
 
 	if err := applyInfraInherit(compatibleOptions, s); err != nil {
 		return nil, nil, nil, err
@@ -770,6 +771,16 @@ func Inherit(infra *libpod.Container, s *specgen.SpecGenerator, rt *libpod.Runti
 		s.ShmSize = nil
 	}
 	return options, infraSpec, compatibleOptions, nil
+}
+
+func inheritNamedVolumes(infraVolumes, containerVolumes []*specgen.NamedVolume) []*specgen.NamedVolume {
+	inheritedVolumes := make([]*specgen.NamedVolume, 0, len(infraVolumes)+len(containerVolumes))
+	for _, volume := range infraVolumes {
+		if !volume.NoInherit {
+			inheritedVolumes = append(inheritedVolumes, volume)
+		}
+	}
+	return append(inheritedVolumes, containerVolumes...)
 }
 
 // applyInfraInherit copies the InfraInherit fields into the SpecGenerator.

--- a/pkg/specgen/generate/container_create_test.go
+++ b/pkg/specgen/generate/container_create_test.go
@@ -12,6 +12,29 @@ import (
 	"go.podman.io/podman/v6/pkg/specgen"
 )
 
+func TestInheritNamedVolumesExcludesNoInherit(t *testing.T) {
+	regularInfraVolume := &specgen.NamedVolume{
+		Name: "shared",
+		Dest: "/shared",
+	}
+	internalInfraVolume := &specgen.NamedVolume{
+		Name:      "holder",
+		Dest:      "/run/podman/emptydir/holder",
+		NoInherit: true,
+	}
+	containerVolume := &specgen.NamedVolume{
+		Name: "container",
+		Dest: "/container",
+	}
+
+	volumes := inheritNamedVolumes(
+		[]*specgen.NamedVolume{regularInfraVolume, internalInfraVolume},
+		[]*specgen.NamedVolume{containerVolume},
+	)
+
+	assert.Equal(t, []*specgen.NamedVolume{regularInfraVolume, containerVolume}, volumes)
+}
+
 // TestApplyInfraInheritMountOptionsDoNotLeak verifies that mount options from
 // one mount do not leak into another when calling applyInfraInherit.
 func TestApplyInfraInheritMountOptionsDoNotLeak(t *testing.T) {

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -610,10 +610,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 			s.Volumes = append(s.Volumes, &emptyDirVolume)
 		case KubeVolumeTypeEmptyDirTmpfs:
 			// A named volume, so the tmpfs is shared by every container in the pod.
-			tmpfsOptions := append(slices.Clone(options), "volume-opt=type="+define.TypeTmpfs)
-			if volumeSource.SizeLimit > 0 {
-				tmpfsOptions = append(tmpfsOptions, fmt.Sprintf("volume-opt=o=size=%d", volumeSource.SizeLimit))
-			}
+			tmpfsOptions := append(slices.Clone(options), MemoryEmptyDirOptions(volumeSource.SizeLimit)...)
 			memVolume := specgen.NamedVolume{
 				Dest:        volume.MountPath,
 				Name:        volumeSource.Source,

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -12,6 +12,7 @@ import (
 	"go.podman.io/common/pkg/parse"
 	"go.podman.io/common/pkg/secrets"
 	"go.podman.io/podman/v6/libpod"
+	"go.podman.io/podman/v6/libpod/define"
 	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
 	"go.podman.io/storage/pkg/fileutils"
 
@@ -60,6 +61,17 @@ type KubeVolume struct {
 	ImagePullPolicy v1.PullPolicy
 	// Size limit in bytes, 0 when unset. Only used for EmptyDirTmpfs.
 	SizeLimit int64
+}
+
+// MemoryEmptyDirOptions returns the volume options for a memory-backed
+// emptyDir. These options must be used by every container that can create the
+// underlying named volume.
+func MemoryEmptyDirOptions(sizeLimit int64) []string {
+	options := []string{"volume-opt=type=" + define.TypeTmpfs}
+	if sizeLimit > 0 {
+		options = append(options, fmt.Sprintf("volume-opt=o=size=%d", sizeLimit))
+	}
+	return options
 }
 
 // Create a KubeVolume from an HostPathVolumeSource

--- a/pkg/specgen/generate/kube/volume_test.go
+++ b/pkg/specgen/generate/kube/volume_test.go
@@ -34,3 +34,8 @@ func TestVolumeFromEmptyDir(t *testing.T) {
 	assert.Equal(t, sizedEmptyDirVol.Type, KubeVolumeTypeEmptyDirTmpfs)
 	assert.Equal(t, int64(64*1024*1024), sizedEmptyDirVol.SizeLimit)
 }
+
+func TestMemoryEmptyDirOptions(t *testing.T) {
+	assert.Equal(t, []string{"volume-opt=type=tmpfs"}, MemoryEmptyDirOptions(0))
+	assert.Equal(t, []string{"volume-opt=type=tmpfs", "volume-opt=o=size=67108864"}, MemoryEmptyDirOptions(64*1024*1024))
+}

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -27,6 +27,9 @@ type NamedVolume struct {
 	// IsAnonymous sets the named volume as anonymous even if it has a name
 	// This is used for emptyDir volumes from a kube yaml
 	IsAnonymous bool
+	// NoInherit prevents containers joining the pod from inheriting this
+	// volume from the infra container.
+	NoInherit bool
 	// SubPath stores the sub directory of the named volume to be mounted in the container
 	SubPath string
 }

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -675,6 +675,13 @@ spec:
     {{ end }}
     image: {{ .Image }}
     name: {{ .Name }}
+    {{ if .VolumeMount }}
+    volumeMounts:
+    - name: {{ .VolumeName }}
+      mountPath: {{ .VolumeMountPath }}
+      subPath: {{ .VolumeSubPath }}
+      readOnly: {{ .VolumeReadOnly }}
+    {{ end }}
   {{ end }}
 {{ end }}
 {{ if .SecurityContext }}
@@ -4500,6 +4507,32 @@ spec:
 		podmanTest.PodmanExitCleanly("exec", podName+"-"+ctrName1, "sh", "-c", "echo shared-data > /test-emptydir/file")
 		data := podmanTest.PodmanExitCleanly("exec", podName+"-"+ctrName2, "cat", "/test-emptydir/file")
 		Expect(data.OutputToString()).To(Equal("shared-data"))
+
+		podmanTest.PodmanExitCleanly("pod", "rm", "-f", podName)
+		volList := podmanTest.PodmanExitCleanly("volume", "ls", "-q")
+		Expect(volList.OutputToString()).To(Equal(""))
+	})
+
+	It("with memory backed emptyDir volume shared from init container", func() {
+		podName := "test-pod"
+		initCtrName := "vol-test-init"
+		ctrName := "vol-test-ctr"
+		initCtr := getCtr(withVolumeMount("/test-emptydir", "", false), withImage(CITEST_IMAGE), withName(initCtrName), withCmd([]string{"sh", "-c", "echo shared-data > /test-emptydir/file"}), withInitCtr())
+		ctr := getCtr(withVolumeMount("/test-emptydir", "", false), withImage(CITEST_IMAGE), withName(ctrName))
+		pod := getPod(withPodName(podName), withVolume(getMemoryEmptyDirVolume()), withPodInitCtr(initCtr), withCtr(ctr))
+		err = generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		podmanTest.PodmanExitCleanly("kube", "play", kubeYaml)
+
+		fsType := podmanTest.PodmanExitCleanly("exec", podName+"-"+ctrName, "stat", "-f", "-c", "%T", "/test-emptydir")
+		Expect(fsType.OutputToString()).To(Equal("tmpfs"))
+
+		data := podmanTest.PodmanExitCleanly("exec", podName+"-"+ctrName, "cat", "/test-emptydir/file")
+		Expect(data.OutputToString()).To(Equal("shared-data"))
+
+		mounts := podmanTest.PodmanExitCleanly("inspect", podName+"-"+ctrName, "--format", "{{range .Mounts}}{{println .Destination}}{{end}}")
+		Expect(strings.Fields(mounts.OutputToString())).To(ConsistOf("/test-emptydir"))
 
 		podmanTest.PodmanExitCleanly("pod", "rm", "-f", podName)
 		volList := podmanTest.PodmanExitCleanly("volume", "ls", "-q")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
I intentionally kept the commits as three commits for easier review. I can later squash with a commit message mentioning the issue as mentioned in the guidelines.

## Problem

[#29555](https://github.com/podman-container-tools/podman/issues/29555) reported an
issue with memory-backed `emptyDir` volumes used by `podman kube play`.
[#29565](https://github.com/podman-container-tools/podman/pull/29565) addressed
sharing the tmpfs between regular containers that are running concurrently.
[#29670](https://github.com/podman-container-tools/podman/issues/29670) shows the
remaining case: data written by a one-shot init container is unavailable to a
regular container that starts afterward.

<!-- Check that the description of #29565 matches the final merged behavior. -->

## Root cause

A memory-backed `emptyDir` is represented by an anonymous named volume. Podman
mounts a tmpfs at the volume's host-side mountpoint and bind-mounts that path
into the init container.

When a one-shot init container is removed, its volume mounts are released. If
this reduces the volume mount reference count to zero, Podman unmounts the
host-side tmpfs and its contents are lost.

## Approach

The change adds an internal mount of every memory-backed `emptyDir` volume to
the pod's infra container. 

Infra-container mounts are normally inherited by containers subsequently added
to the pod. That behavior supports pod-wide mounts such as:

```console
podman pod create --name mypod --volume myvolume:/data
podman run --pod mypod alpine ls /data
```

I used an additional `NoInherit` option to both `specgen.NamedVolume` and `libpod.ContainerNamedVolume` work around this.


Fixes: #29670
Related: #29555

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a bug in podman kube play that caused data written by an init container to a memory-backed emptyDir volume to be lost when the init container exited. 
Regular containers in the pod can now access that data as expected. 
See [podman-kube-play(1)](https://docs.podman.io/en/latest/markdown/podman-kube-play.1.html).
```
