### PR TITLE
fix: set correct content-type for generate kube

### DIFF
--- a/pkg/api/handlers/libpod/generate.go
+++ b/pkg/api/handlers/libpod/generate.go
@@ -138,7 +138,5 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// FIXME: Content-Type is being set as application/x-tar NOT text/vnd.yaml
-	// https://mailarchive.ietf.org/arch/msg/media-types/e9ZNC0hDXKXeFlAVRWxLCCaG9GI/
-	utils.WriteResponse(w, http.StatusOK, report.Reader)
+	utils.WriteResponseWithContentType(w, http.StatusOK, report.Reader, "text/vnd.yaml")
 }

--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -293,3 +293,21 @@ func (b *ResponseSender) SendBuildError(message string) {
 func (b *ResponseSender) SendBuildAux(aux []byte) {
 	b.Send(images.BuildResponse{Aux: aux})
 }
+
+// WriteResponseWithContentType encodes the given value and renders it for http client
+func WriteResponseWithContentType(w http.ResponseWriter, code int, value io.Reader, contentType string) {
+	// RFC2616 explicitly states that the following status codes "MUST NOT
+	// include a message-body":
+	switch code {
+	case http.StatusNoContent, http.StatusNotModified: // 204, 304
+		w.WriteHeader(code)
+		return
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(code)
+
+	if _, err := io.Copy(w, value); err != nil {
+		logrus.Errorf("Unable to copy to response: %q", err)
+	}
+}

--- a/pkg/api/handlers/utils/handler_test.go
+++ b/pkg/api/handlers/utils/handler_test.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
@@ -414,4 +415,16 @@ func (t *testResponseWriter) Flush() {
 	if t.onFlush != nil {
 		t.onFlush()
 	}
+}
+
+func TestWriteResponseWithContentType(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	content := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: test-pod\n"
+	value := strings.NewReader(content)
+
+	WriteResponseWithContentType(recorder, http.StatusOK, value, "text/vnd.yaml")
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "text/vnd.yaml", recorder.Header().Get("Content-Type"))
+	assert.Equal(t, content, recorder.Body.String())
 }

--- a/test/apiv2/80-kube.at
+++ b/test/apiv2/80-kube.at
@@ -21,6 +21,7 @@ like "$output" ".*apiVersion:.*" "Check generated kube yaml - apiVersion"
 like "$output" ".*kind:\\sPod.*" "Check generated kube yaml - kind: Pod"
 like "$output" ".*metadata:.*" "Check generated kube yaml - metadata"
 like "$output" ".*spec:.*" "Check generated kube yaml - spec"
+is "$response_content_type" "text/vnd.yaml" "Check response Content-Type is text/vnd.yaml"
 
 t GET "libpod/generate/kube?service=true&names=$cid" 200
 like "$output" ".*apiVersion:.*" "Check generated kube yaml(service=true) - apiVersion"

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -385,6 +385,7 @@ function t() {
     fi
 
     IFS='^' read actual_code content_type time_total <<<"$response"
+    response_content_type="$content_type"
     printf "X-Response-Time: ${time_total}s\n\n" >>$LOG
 
     # Log results, if text. If JSON, filter through jq for readability.


### PR DESCRIPTION
Fixes: #29674

### Description

Fix the content-type for the generate kube api response.
It now returns text/vnd.yaml instead of application/x-tar.

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed incorrect content-type for generate kube.
```
