### PR TITLE
compat: Omit empty Created field from GET /images/{id}/json

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -389,12 +389,22 @@ func imageDataToImageInspect(ctx context.Context, l *libimage.Image, r *http.Req
 	cc.Hostname = info.ID[0:11] // short ID is the hostname
 	cc.Volumes = info.Config.Volumes
 
+	// Since Docker Engine API v1.44 the Created field is omitted when it is
+	// missing from the image config.
+	// Older API versions still return the zero value.
+	var created string
+	if info.Created != nil {
+		created = info.Created.Format(time.RFC3339Nano)
+	} else if _, err := apiutil.SupportedVersion(r, "<1.44.0"); err == nil {
+		created = time.Time{}.Format(time.RFC3339Nano)
+	}
+
 	dockerImageInspect := dockerImage.InspectResponse{
 		Architecture: info.Architecture,
 		Author:       info.Author,
 		Comment:      info.Comment,
 		Config:       &config,
-		Created:      l.Created().Format(time.RFC3339Nano),
+		Created:      created,
 		GraphDriver:  &graphDriver,
 		ID:           "sha256:" + l.ID(),
 		Metadata:     dockerImage.Metadata{},

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -74,6 +74,28 @@ t GET /v1.44/images/$iid/json 200 \
 t GET /v1.45/images/$iid/json 200 \
   .ContainerConfig=null
 
+# Create a modified image with the Created field removed.
+NOCREATED=$(mktemp -d podman-apiv2-test.nocreated.XXXXXXXX)
+podman save --format docker-archive -o $NOCREATED/img.tar $IMAGE
+tar -C $NOCREATED -xf $NOCREATED/img.tar manifest.json
+config=$(jq -r '.[0].Config' $NOCREATED/manifest.json)
+layers=$(jq -r '.[0].Layers[]' $NOCREATED/manifest.json)
+tar -C $NOCREATED -xf $NOCREATED/img.tar $config $layers
+jq 'del(.created)' $NOCREATED/$config > $NOCREATED/c && mv $NOCREATED/c $NOCREATED/$config
+jq '.[0].RepoTags=["localhost/nocreated:latest"]' $NOCREATED/manifest.json > $NOCREATED/m && mv $NOCREATED/m $NOCREATED/manifest.json
+tar -C $NOCREATED -cf $NOCREATED/img.tar manifest.json $config $layers
+podman load -i $NOCREATED/img.tar
+
+# Test that the Created field is omitted when empty for the compat API v1.44+.
+t GET /v1.44/images/localhost/nocreated:latest/json 200 .Created=null
+
+# Test that the Created field has the zero value when empty for the compat API before v1.44.
+t GET /v1.43/images/localhost/nocreated:latest/json 200 .Created="0001-01-01T00:00:00Z"
+
+# Cleanup the image after the Created tests.
+podman rmi -f localhost/nocreated:latest
+rm -rf $NOCREATED
+
 t POST "images/create?fromImage=alpine" 200 .error~null .status~".*Download complete.*"
 t POST "libpod/images/pull?reference=alpine&compatMode=true" 200 .error~null .status~".*Download complete.*"
 


### PR DESCRIPTION
Docker API [v1.44](https://docs.docker.com/reference/api/engine/version-history/#v144-api-changes) omits the `Created` field (previously, it was the zero value of `0001-01-01T00:00:00Z`) if
the Created field is missing from the image config.

- Omit it when zero from the compat API GET /images/{id}/json (using `info.Created` instead of the previous `l.Created()` that is set to `Now()` in storage/images.go when empty).
- Add a test creating an image with the `Created` field missing.

Fixes: https://redhat.atlassian.net/browse/RUN-3317

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Compat API v1.44+ omits the Created field for GET /images/{id}/json when the field is missing.
```
